### PR TITLE
Responseクラスにof()ファクトリメソッドを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,7 +260,9 @@ PostgreSQLの2つのスキーマ：
 - Lombokアノテーションでボイラープレートを削減（`@Builder`、`@Getter`、`@Setter`を優先）
 - Entityクラスには `@Data` と `@Builder` のみを使用する（`@NoArgsConstructor` や `@AllArgsConstructor` は使用しない）
 - サービスとリポジトリはインターフェースベース設計
-- Responseクラスには `static from()` ファクトリメソッドを定義し、Model/Entity→Responseの変換ロジックをResponseクラス側に集約する。Controllerでは `from()` を呼び出すだけにする
+- Responseクラスにはファクトリメソッドを定義し、レスポンス生成ロジックをResponseクラス側に集約する。Controllerではファクトリメソッドを呼び出すだけにする
+  - `static from(Model)`: Model/Entity→Responseの変換に使用する
+  - `static of(...)`: 固定値や少数のパラメータから直接生成する場合に使用する
 - 明示的なリンティング・フォーマットツールは未設定。既存のコードスタイルに従うこと
 
 ### 新機能追加の手順

--- a/backend/src/main/java/com/web/gallary/controller/AccountRestController.java
+++ b/backend/src/main/java/com/web/gallary/controller/AccountRestController.java
@@ -120,11 +120,7 @@ public class AccountRestController {
 				.build();
 		
 		Boolean isSuccess = accountServiceImpl.registAccount(accountModel);
-		return ResponseEntity.ok(AccountRegistResponse.builder()
-					.httpStatus(HttpStatus.OK.value())
-					.isSuccess(isSuccess)
-					.message(Consts.STRING_EMPTY)
-					.build());
+		return ResponseEntity.ok(AccountRegistResponse.of(isSuccess, Consts.STRING_EMPTY));
 	}
 	
 	/**
@@ -175,13 +171,11 @@ public class AccountRestController {
 		
 		Boolean isDuplicateAccountId = accountServiceImpl.updateAccount(accountModel);
 		
-		return ResponseEntity.ok(AccountUpdateResponse.builder()
-					.httpStatus(HttpStatus.OK.value())
-					.isDuplicateAccountId(isDuplicateAccountId)
-					.isAccountIdChanged(!accountUpdateRequest.getAccountId().equals(sessionHelper.getAccountId()))
-					.isPasswordChanged(!accountUpdateRequest.getNewPassword().isEmpty())
-					.message(Consts.STRING_EMPTY)
-					.build());
+		return ResponseEntity.ok(AccountUpdateResponse.of(
+					isDuplicateAccountId,
+					!accountUpdateRequest.getAccountId().equals(sessionHelper.getAccountId()),
+					!accountUpdateRequest.getNewPassword().isEmpty(),
+					Consts.STRING_EMPTY));
 	}
 	
 	/**

--- a/backend/src/main/java/com/web/gallary/controller/CommonRestControllerAdvice.java
+++ b/backend/src/main/java/com/web/gallary/controller/CommonRestControllerAdvice.java
@@ -39,13 +39,7 @@ public class CommonRestControllerAdvice {
 	 */
 	@ExceptionHandler(BadRequestException.class)
 	public ResponseEntity<BadRequestResponse> handleBadRequestException(BadRequestException exception) {
-		BadRequestResponse response = BadRequestResponse.builder()
-				.httpStatus(HttpStatus.BAD_REQUEST.value())
-				.isSuccess(false)
-				.message(exception.getMessage())
-				.build();
-
-		return new ResponseEntity<BadRequestResponse>(response, HttpStatus.BAD_REQUEST);
+		return new ResponseEntity<BadRequestResponse>(BadRequestResponse.of(exception), HttpStatus.BAD_REQUEST);
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallary/controller/PhotoFavoriteController.java
+++ b/backend/src/main/java/com/web/gallary/controller/PhotoFavoriteController.java
@@ -1,6 +1,5 @@
 package com.web.gallary.controller;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
@@ -66,13 +65,9 @@ public class PhotoFavoriteController {
 				.build();
 		photoFavoriteService.addFavorite(photoFavoriteModel);
 		
-		return ResponseEntity.ok(PhotoFavoriteResponse.builder()
-				.httpStatus(HttpStatus.OK.value())
-				.isSuccess(true)
-				.message(MessageConst.REGIST_FAVORITE)
-				.build());
+		return ResponseEntity.ok(PhotoFavoriteResponse.of(MessageConst.REGIST_FAVORITE));
 	}
-	
+
 	/**
 	 * お気に入り解除
 	 * 
@@ -100,10 +95,6 @@ public class PhotoFavoriteController {
 				.build();
 		photoFavoriteService.deleteFavorite(photoFavoriteModel);
 		
-		return ResponseEntity.ok(PhotoFavoriteResponse.builder()
-				.httpStatus(HttpStatus.OK.value())
-				.isSuccess(true)
-				.message(MessageConst.CANCEL_FAVORITE)
-				.build());
+		return ResponseEntity.ok(PhotoFavoriteResponse.of(MessageConst.CANCEL_FAVORITE));
 	}
 }

--- a/backend/src/main/java/com/web/gallary/controller/PhotoRestController.java
+++ b/backend/src/main/java/com/web/gallary/controller/PhotoRestController.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -113,9 +112,7 @@ public class PhotoRestController {
 		if (photoAccountId.equals(sessionHelper.getAccountId())) {
 			isReachedUpperLimit = photoService.isReachedUpperLimit(sessionHelper.getAccountNo());
 		}
-		return ResponseEntity.ok(PhotoUpperLimitResponse.builder()
-				.isReachedUpperLimit(isReachedUpperLimit)
-				.build());
+		return ResponseEntity.ok(PhotoUpperLimitResponse.of(isReachedUpperLimit));
 	}
 
 	/**
@@ -238,13 +235,7 @@ public class PhotoRestController {
 			savedImageFilePath = Optional.ofNullable(photoSaveRequest.getImageFilePath()).orElse("");
 		}
 
-		return ResponseEntity.ok(PhotoEditResponse.builder()
-				.httpStatus(HttpStatus.OK.value())
-				.isSuccess(true)
-				.message(MessageConst.REGIST_PHOTO)
-				.photoNo(savedPhotoNo)
-				.imageFilePath(savedImageFilePath)
-				.build());
+		return ResponseEntity.ok(PhotoEditResponse.of(MessageConst.REGIST_PHOTO, savedPhotoNo, savedImageFilePath));
 	}
 	
 	/**
@@ -285,11 +276,7 @@ public class PhotoRestController {
 		
 		photoService.deletePhotos(photoAccountId, photoDeleteModelList);
 		
-		return ResponseEntity.ok(PhotoEditResponse.builder()
-				.httpStatus(HttpStatus.OK.value())
-				.isSuccess(true)
-				.message(MessageConst.DELETE_PHOTO)
-				.build());
+		return ResponseEntity.ok(PhotoEditResponse.of(MessageConst.DELETE_PHOTO, null, null));
 	}
 	
 }

--- a/backend/src/main/java/com/web/gallary/controller/response/AccountRegistResponse.java
+++ b/backend/src/main/java/com/web/gallary/controller/response/AccountRegistResponse.java
@@ -1,5 +1,7 @@
 package com.web.gallary.controller.response;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.Builder;
 import lombok.Data;
 
@@ -14,7 +16,22 @@ public class AccountRegistResponse {
 
 	/** 登録成功 */
 	private Boolean isSuccess;
-	
+
 	/** メッセージ */
 	private String message;
+
+	/**
+	 * 成功レスポンスを生成する
+	 *
+	 * @param	isSuccess	登録成功
+	 * @param	message		メッセージ
+	 * @return				{@link AccountRegistResponse}
+	 */
+	public static AccountRegistResponse of(Boolean isSuccess, String message) {
+		return AccountRegistResponse.builder()
+				.httpStatus(HttpStatus.OK.value())
+				.isSuccess(isSuccess)
+				.message(message)
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/controller/response/AccountUpdateResponse.java
+++ b/backend/src/main/java/com/web/gallary/controller/response/AccountUpdateResponse.java
@@ -1,5 +1,7 @@
 package com.web.gallary.controller.response;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.Builder;
 import lombok.Data;
 
@@ -17,10 +19,29 @@ public class AccountUpdateResponse {
 
 	/** アカウントIDが更新されたか */
 	private Boolean isAccountIdChanged;
-	
+
 	/** パスワードが更新されたか */
 	private Boolean isPasswordChanged;
-	
+
 	/** メッセージ */
 	private String message;
+
+	/**
+	 * 成功レスポンスを生成する
+	 *
+	 * @param	isDuplicateAccountId	アカウントIDが重複しているか
+	 * @param	isAccountIdChanged		アカウントIDが更新されたか
+	 * @param	isPasswordChanged		パスワードが更新されたか
+	 * @param	message					メッセージ
+	 * @return							{@link AccountUpdateResponse}
+	 */
+	public static AccountUpdateResponse of(Boolean isDuplicateAccountId, Boolean isAccountIdChanged, Boolean isPasswordChanged, String message) {
+		return AccountUpdateResponse.builder()
+				.httpStatus(HttpStatus.OK.value())
+				.isDuplicateAccountId(isDuplicateAccountId)
+				.isAccountIdChanged(isAccountIdChanged)
+				.isPasswordChanged(isPasswordChanged)
+				.message(message)
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/controller/response/BadRequestResponse.java
+++ b/backend/src/main/java/com/web/gallary/controller/response/BadRequestResponse.java
@@ -1,5 +1,9 @@
 package com.web.gallary.controller.response;
 
+import org.springframework.http.HttpStatus;
+
+import com.web.gallary.exception.BadRequestException;
+
 import lombok.Builder;
 import lombok.Data;
 
@@ -11,10 +15,24 @@ import lombok.Data;
 public class BadRequestResponse {
 	/** HTTPステータス */
 	private Integer httpStatus;
-	
+
 	/** 登録成功 */
 	private Boolean isSuccess;
 
 	/** メッセージ */
 	private String message;
+
+	/**
+	 * BadRequestExceptionからエラーレスポンスを生成する
+	 *
+	 * @param	exception	{@link BadRequestException}
+	 * @return				{@link BadRequestResponse}
+	 */
+	public static BadRequestResponse of(BadRequestException exception) {
+		return BadRequestResponse.builder()
+				.httpStatus(HttpStatus.BAD_REQUEST.value())
+				.isSuccess(false)
+				.message(exception.getMessage())
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/controller/response/PhotoEditResponse.java
+++ b/backend/src/main/java/com/web/gallary/controller/response/PhotoEditResponse.java
@@ -1,5 +1,7 @@
 package com.web.gallary.controller.response;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.Builder;
 import lombok.Data;
 
@@ -23,4 +25,22 @@ public class PhotoEditResponse {
 
 	/** 画像ファイルパス */
 	private String imageFilePath;
+
+	/**
+	 * 成功レスポンスを生成する
+	 *
+	 * @param	message			メッセージ
+	 * @param	photoNo			写真番号
+	 * @param	imageFilePath	画像ファイルパス
+	 * @return					{@link PhotoEditResponse}
+	 */
+	public static PhotoEditResponse of(String message, Integer photoNo, String imageFilePath) {
+		return PhotoEditResponse.builder()
+				.httpStatus(HttpStatus.OK.value())
+				.isSuccess(true)
+				.message(message)
+				.photoNo(photoNo)
+				.imageFilePath(imageFilePath)
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/controller/response/PhotoFavoriteResponse.java
+++ b/backend/src/main/java/com/web/gallary/controller/response/PhotoFavoriteResponse.java
@@ -1,5 +1,7 @@
 package com.web.gallary.controller.response;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.Builder;
 import lombok.Data;
 
@@ -14,7 +16,21 @@ public class PhotoFavoriteResponse {
 
 	/** 登録成功 */
 	private Boolean isSuccess;
-	
+
 	/** メッセージ */
 	private String message;
+
+	/**
+	 * 成功レスポンスを生成する
+	 *
+	 * @param	message	メッセージ
+	 * @return			{@link PhotoFavoriteResponse}
+	 */
+	public static PhotoFavoriteResponse of(String message) {
+		return PhotoFavoriteResponse.builder()
+				.httpStatus(HttpStatus.OK.value())
+				.isSuccess(true)
+				.message(message)
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/controller/response/PhotoUpperLimitResponse.java
+++ b/backend/src/main/java/com/web/gallary/controller/response/PhotoUpperLimitResponse.java
@@ -11,4 +11,16 @@ import lombok.Data;
 public class PhotoUpperLimitResponse {
 	/** 写真の登録枚数が上限に達しているか */
 	private Boolean isReachedUpperLimit;
+
+	/**
+	 * レスポンスを生成する
+	 *
+	 * @param	isReachedUpperLimit	写真の登録枚数が上限に達しているか
+	 * @return						{@link PhotoUpperLimitResponse}
+	 */
+	public static PhotoUpperLimitResponse of(Boolean isReachedUpperLimit) {
+		return PhotoUpperLimitResponse.builder()
+				.isReachedUpperLimit(isReachedUpperLimit)
+				.build();
+	}
 }


### PR DESCRIPTION
## Summary
- Responseクラスに`static of()`ファクトリメソッドを追加し、固定値（httpStatus, isSuccess等）の組み立てをResponseクラス側に集約
- Controllerから直接`builder()`を呼び出していた箇所を`of()`呼び出しに置き換え
- 対象: `PhotoFavoriteResponse`, `PhotoEditResponse`, `PhotoUpperLimitResponse`, `AccountRegistResponse`, `AccountUpdateResponse`, `BadRequestResponse`

## Test plan
- [x] `./backend/gradlew -p backend build` でビルド・全テスト成功を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)