### PR TITLE
ServiceクラスからEntityクラスの依存を除去

### DIFF
--- a/backend/src/main/java/com/web/gallary/AccountPrincipal.java
+++ b/backend/src/main/java/com/web/gallary/AccountPrincipal.java
@@ -7,7 +7,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import com.web.gallary.entity.Account;
+import com.web.gallary.model.AccountModel;
 
 /**
  * Spring SecurityのUserDetailsクラスの実装クラス
@@ -17,11 +17,11 @@ public class AccountPrincipal implements UserDetails {
 	private static final String ROLE_ADMIN = "ROLE_ADMIN";
 	private static final String ROLE_USER = "ROLE_USER";
 
-	private final Account account;
+	private final AccountModel accountModel;
 	private final int maxFailCount;
 
-	public AccountPrincipal(Account account, int failCount) {
-		this.account = account;
+	public AccountPrincipal(AccountModel accountModel, int failCount) {
+		this.accountModel = accountModel;
 		this.maxFailCount = failCount;
 	}
 
@@ -30,55 +30,55 @@ public class AccountPrincipal implements UserDetails {
 	 */
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
-		switch(account.getAuthorityKbn()) {
+		switch(accountModel.getAuthorityKbn()) {
 			case ADMINISTRATOR:
 				return Collections.singleton(new SimpleGrantedAuthority(ROLE_ADMIN));
 			default:
 				return Collections.singleton(new SimpleGrantedAuthority(ROLE_USER));
 		}
 	}
-	
+
 	/**
 	 * アカウント番号を取得する
-	 * 
+	 *
 	 * @return	アカウント番号
 	 */
 	public Integer getAccountNo() {
-		return account.getAccountNo();
+		return accountModel.getAccountNo();
 	}
-	
+
 	/**
 	 * アカウント名を取得する
-	 * 
+	 *
 	 * @return	アカウント名
 	 */
 	public String getAccountName() {
-		return account.getAccountName();
+		return accountModel.getAccountName();
 	}
-	
+
 	/**
 	 * パスワードを取得する
-	 * 
+	 *
 	 * @return	パスワード
 	 */
 	@Override
 	public String getPassword() {
-		return account.getPassword();
+		return accountModel.getPassword();
 	}
-	
+
 	/**
 	 * アカウントIDを取得する
-	 * 
+	 *
 	 * @return	アカウントID
 	 */
 	@Override
 	public String getUsername() {
-		return account.getAccountId();
+		return accountModel.getAccountId();
 	}
 
 	/***
 	 * アカウントが有効期限切れかどうかを返す
-	 * 
+	 *
 	 * @return 有効期限は設定しないため、常にtrueを返す
 	 */
 	@Override
@@ -88,17 +88,17 @@ public class AccountPrincipal implements UserDetails {
 
 	/***
 	 * アカウントがロックされていないかどうかを返す
-	 * 
+	 *
 	 * @return ログイン失敗回数が一定数を超えていなければtrueを返す
 	 */
 	@Override
 	public boolean isAccountNonLocked() {
-		return account.getLoginFailureCount() < maxFailCount;
+		return accountModel.getLoginFailureCount() < maxFailCount;
 	}
 
 	/***
 	 * 資格情報（ここではパスワード）が有効期限切れかどうかを返す
-	 * 
+	 *
 	 * @return 有効期限は設定しないため、常にtrueを返す
 	 */
 	@Override
@@ -108,11 +108,11 @@ public class AccountPrincipal implements UserDetails {
 
 	/***
 	 * アカウントの有効／無効を返す
-	 * 
+	 *
 	 * @return 有効な場合、trueを返す
 	 */
 	@Override
 	public boolean isEnabled() {
-		return !account.getIsDeleted();
+		return !accountModel.getIsDeleted();
 	}
 }

--- a/backend/src/main/java/com/web/gallary/model/AccountModel.java
+++ b/backend/src/main/java/com/web/gallary/model/AccountModel.java
@@ -61,6 +61,9 @@ public class AccountModel {
 	/** ログイン失敗回数 */
 	private Integer loginFailureCount;
 
+	/** 削除フラグ */
+	private Boolean isDeleted;
+
 	/**
 	 * アカウント登録リクエストからAccountModelを生成する
 	 *

--- a/backend/src/main/java/com/web/gallary/model/RefreshTokenModel.java
+++ b/backend/src/main/java/com/web/gallary/model/RefreshTokenModel.java
@@ -1,0 +1,28 @@
+package com.web.gallary.model;
+
+import java.time.OffsetDateTime;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * リフレッシュトークン情報を受け渡すためのModelクラス
+ * @author	Kento Kodama
+ * @version	1.0.0
+ * @since	1.0.0
+ */
+@Value
+@Builder
+public class RefreshTokenModel {
+	/** アカウント番号 */
+	private Integer accountNo;
+
+	/** トークンハッシュ */
+	private String tokenHash;
+
+	/** 有効期限 */
+	private OffsetDateTime expiresAt;
+
+	/** 無効化フラグ */
+	private Boolean isRevoked;
+}

--- a/backend/src/main/java/com/web/gallary/repository/AccountRepository.java
+++ b/backend/src/main/java/com/web/gallary/repository/AccountRepository.java
@@ -2,7 +2,6 @@ package com.web.gallary.repository;
 
 import java.util.List;
 
-import com.web.gallary.entity.Account;
 import com.web.gallary.exception.RegistFailureException;
 import com.web.gallary.exception.UpdateFailureException;
 import com.web.gallary.model.AccountModel;
@@ -13,58 +12,58 @@ import com.web.gallary.model.AccountModel;
 public interface AccountRepository {
 	/**
 	 * Accountテーブルで該当するレコードを取得する
-	 * 
-	 * @param	accountNo	アカウント番号
-	 * @return	Account		{@link Account}<p>
-	 * 						取得できない場合はnullを返す
+	 *
+	 * @param	accountNo		アカウント番号
+	 * @return	AccountModel	{@link AccountModel}<p>
+	 * 							取得できない場合はnullを返す
 	 */
-	Account getByAccountNo(Integer accountNo);
-	
+	AccountModel getByAccountNo(Integer accountNo);
+
 	/**
 	 * Accountテーブルで該当するレコードを取得する
-	 * 
-	 * @param	accountId	アカウントId
-	 * @return	Account		{@link Account}<p>
-	 * 						取得できない場合はnullを返す
+	 *
+	 * @param	accountId		アカウントId
+	 * @return	AccountModel	{@link AccountModel}<p>
+	 * 							取得できない場合はnullを返す
 	 */
-	Account getByAccountId(String accountId);
-	
+	AccountModel getByAccountId(String accountId);
+
 	/**
 	 * Accountテーブルへ登録する
-	 * 
+	 *
 	 * @param	accountModel			{@link AccountModel}
 	 * @throws	RegistFailureException	登録に失敗した場合
 	 */
 	void regist(AccountModel accountModel) throws RegistFailureException;
-	
+
 	/**
 	 * Accountテーブルで該当するレコードを更新する
-	 * 
+	 *
 	 * @param	accountModel			{@link AccountModel}
-	 * @throws	UpdateFailureException	更新に失敗した場合 
+	 * @throws	UpdateFailureException	更新に失敗した場合
 	 */
 	void update(AccountModel accountModel) throws UpdateFailureException;
-	
+
 	/**
 	 * Accountテーブルのログイン失敗回数を更新する
-	 * 
+	 *
 	 * @param	accountModel			{@link AccountModel}
 	 * @throws	UpdateFailureException	更新に失敗した場合
 	 */
 	void updateLoginFailureCount(AccountModel accountModel) throws UpdateFailureException;
-	
+
 	/**
 	 * アカウントIDに該当するアカウントの存在有無をチェックする
-	 * 
+	 *
 	 * @param	accountNo	検索対象外のアカウント番号
 	 * @param	accountId	アカウントID
 	 * @return				true：存在する
 	 */
 	Boolean isExistAccount(Integer accountNo, String accountId);
-	
+
 	/**
 	 * アカウントの一覧を取得する
-	 * 
+	 *
 	 * @return	{@link AccountModel}
 	 */
 	List<AccountModel> getAccountList();

--- a/backend/src/main/java/com/web/gallary/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/web/gallary/repository/RefreshTokenRepository.java
@@ -1,6 +1,6 @@
 package com.web.gallary.repository;
 
-import com.web.gallary.entity.RefreshToken;
+import com.web.gallary.model.RefreshTokenModel;
 
 /**
  * リフレッシュトークンデータを永続化するRepositoryクラス
@@ -12,17 +12,17 @@ public interface RefreshTokenRepository {
 	/**
 	 * リフレッシュトークンを保存する
 	 *
-	 * @param	refreshToken	{@link RefreshToken}
+	 * @param	refreshTokenModel	{@link RefreshTokenModel}
 	 */
-	void save(RefreshToken refreshToken);
+	void save(RefreshTokenModel refreshTokenModel);
 
 	/**
 	 * トークンハッシュに該当するリフレッシュトークンを取得する
 	 *
 	 * @param	tokenHash	トークンハッシュ
-	 * @return				{@link RefreshToken}、取得できない場合はnull
+	 * @return				{@link RefreshTokenModel}、取得できない場合はnull
 	 */
-	RefreshToken findByTokenHash(String tokenHash);
+	RefreshTokenModel findByTokenHash(String tokenHash);
 
 	/**
 	 * アカウント番号に該当するリフレッシュトークンをすべて無効化する

--- a/backend/src/main/java/com/web/gallary/repository/impl/AccountRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/AccountRepositoryImpl.java
@@ -35,38 +35,38 @@ public class AccountRepositoryImpl implements AccountRepository {
 	
 	/**
 	 * Accountテーブルで該当するレコードを取得する
-	 * 
-	 * @param	accountNo	アカウント番号
-	 * @return	Account		{@link Account}<p>
-	 * 						取得できない場合はnullを返す
+	 *
+	 * @param	accountNo		アカウント番号
+	 * @return	AccountModel	{@link AccountModel}<p>
+	 * 							取得できない場合はnullを返す
 	 */
 	@Override
-	public Account getByAccountNo(Integer accountNo) {
+	public AccountModel getByAccountNo(Integer accountNo) {
 		Account account = Account.builder()
 				.accountNo(accountNo)
 				.build();
-		
+
 		List<Account> accountList = accountMapper.select(account);
-		
-		return accountList.isEmpty() ? null : accountList.getFirst();
+
+		return accountList.isEmpty() ? null : toAccountModel(accountList.getFirst());
 	}
-	
+
 	/**
 	 * Accountテーブルで該当するレコードを取得する
-	 * 
-	 * @param	accountId	アカウントId
-	 * @return	Account		{@link Account}<p>
-	 * 						取得できない場合はnullを返す
+	 *
+	 * @param	accountId		アカウントId
+	 * @return	AccountModel	{@link AccountModel}<p>
+	 * 							取得できない場合はnullを返す
 	 */
 	@Override
-	public Account getByAccountId(String accountId) {
+	public AccountModel getByAccountId(String accountId) {
 		Account account = Account.builder()
 				.accountId(accountId)
 				.build();
-		
+
 		List<Account> accountList = accountMapper.select(account);
-		
-		return accountList.isEmpty() ? null : accountList.getFirst();
+
+		return accountList.isEmpty() ? null : toAccountModel(accountList.getFirst());
 	}
 
 	/**
@@ -182,31 +182,39 @@ public class AccountRepositoryImpl implements AccountRepository {
 	
 	/**
 	 * アカウントの一覧を取得する
-	 * 
+	 *
 	 * @return	{@link AccountModel}
 	 */
 	@Override
 	public List<AccountModel> getAccountList() {
 		Account account = Account.builder().isDeleted(false).build();
-		
+
 		List<Account> accountList = accountMapper.select(account);
-		
-		List<AccountModel> accountModelList
-			= accountList.stream().map(accountData -> AccountModel.builder()
-					.accountNo(accountData.getAccountNo())
-					.accountId(accountData.getAccountId())
-					.accountName(accountData.getAccountName())
-					.password(accountData.getPassword())
-					.birthdate(accountData.getBirthdate())
-					.sexKbn(accountData.getSexKbn())
-					.birthplacePrefectureKbnCode(accountData.getBirthplacePrefectureKbnCode())
-					.residentPrefectureKbnCode(accountData.getResidentPrefectureKbnCode())
-					.freeMemo(accountData.getFreeMemo())
-					.authorityKbn(accountData.getAuthorityKbn())
-					.lastLoginDatetime(accountData.getLastLoginDatetime())
-					.loginFailureCount(accountData.getLoginFailureCount())
-					.build()).toList();
-		
-		return accountModelList;
+
+		return accountList.stream().map(this::toAccountModel).toList();
+	}
+
+	/**
+	 * AccountエンティティからAccountModelに変換する
+	 *
+	 * @param	account	{@link Account}
+	 * @return			{@link AccountModel}
+	 */
+	private AccountModel toAccountModel(Account account) {
+		return AccountModel.builder()
+				.accountNo(account.getAccountNo())
+				.accountId(account.getAccountId())
+				.accountName(account.getAccountName())
+				.password(account.getPassword())
+				.birthdate(account.getBirthdate())
+				.sexKbn(account.getSexKbn())
+				.birthplacePrefectureKbnCode(account.getBirthplacePrefectureKbnCode())
+				.residentPrefectureKbnCode(account.getResidentPrefectureKbnCode())
+				.freeMemo(account.getFreeMemo())
+				.authorityKbn(account.getAuthorityKbn())
+				.lastLoginDatetime(account.getLastLoginDatetime())
+				.loginFailureCount(account.getLoginFailureCount())
+				.isDeleted(account.getIsDeleted())
+				.build();
 	}
 }

--- a/backend/src/main/java/com/web/gallary/repository/impl/RefreshTokenRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/RefreshTokenRepositoryImpl.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Repository;
 
 import com.web.gallary.entity.RefreshToken;
 import com.web.gallary.mapper.RefreshTokenMapper;
+import com.web.gallary.model.RefreshTokenModel;
 import com.web.gallary.repository.RefreshTokenRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -20,13 +21,27 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
 	private final RefreshTokenMapper refreshTokenMapper;
 
 	@Override
-	public void save(RefreshToken refreshToken) {
+	public void save(RefreshTokenModel refreshTokenModel) {
+		RefreshToken refreshToken = RefreshToken.builder()
+				.accountNo(refreshTokenModel.getAccountNo())
+				.tokenHash(refreshTokenModel.getTokenHash())
+				.expiresAt(refreshTokenModel.getExpiresAt())
+				.build();
 		refreshTokenMapper.insert(refreshToken);
 	}
 
 	@Override
-	public RefreshToken findByTokenHash(String tokenHash) {
-		return refreshTokenMapper.selectByTokenHash(tokenHash);
+	public RefreshTokenModel findByTokenHash(String tokenHash) {
+		RefreshToken refreshToken = refreshTokenMapper.selectByTokenHash(tokenHash);
+		if (refreshToken == null) {
+			return null;
+		}
+		return RefreshTokenModel.builder()
+				.accountNo(refreshToken.getAccountNo())
+				.tokenHash(refreshToken.getTokenHash())
+				.expiresAt(refreshToken.getExpiresAt())
+				.isRevoked(refreshToken.getIsRevoked())
+				.build();
 	}
 
 	@Override

--- a/backend/src/main/java/com/web/gallary/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallary/service/impl/AccountServiceImpl.java
@@ -18,7 +18,6 @@ import com.web.gallary.AccountPrincipal;
 import com.web.gallary.config.LoginConfig;
 import com.web.gallary.constant.Consts;
 import com.web.gallary.constant.MessageConst;
-import com.web.gallary.entity.Account;
 import com.web.gallary.exception.RegistFailureException;
 import com.web.gallary.exception.UpdateFailureException;
 import com.web.gallary.model.AccountModel;
@@ -37,10 +36,10 @@ public class AccountServiceImpl implements UserDetailsService {
 
 	private final AccountRepository accountRepository;
 	private final LoginConfig loginConfig;
-	
+
 	/**
 	 * アカウントIDからアカウント情報の存在を確認する
-	 * 
+	 *
 	 * @param	username					アカウントID
 	 * @return								{@link UserDetails}
 	 * @throws	UsernameNotFoundException	ユーザーが存在しない場合
@@ -48,18 +47,18 @@ public class AccountServiceImpl implements UserDetailsService {
 	@Override
 	@Transactional(readOnly = true)
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-		Account account = accountRepository.getByAccountId(username);
-		
-		if (Objects.isNull(account)) {
+		AccountModel accountModel = accountRepository.getByAccountId(username);
+
+		if (Objects.isNull(accountModel)) {
 			log.info("User not found. (username: {})", username);
 			throw new UsernameNotFoundException(MessageConst.USER_NOT_FOUND);
 		}
-		return new AccountPrincipal(account, loginConfig.getFailCount());
+		return new AccountPrincipal(accountModel, loginConfig.getFailCount());
 	}
-	
+
 	/**
 	 * アカウントを新規登録する
-	 * 
+	 *
 	 * @param	accountModel			{@link AccountModel}
 	 * @return							登録に成功した場合、true
 	 * @throws	RegistFailureException	登録に失敗した場合
@@ -70,10 +69,10 @@ public class AccountServiceImpl implements UserDetailsService {
 		if(!isExist) accountRepository.regist(accountModel);
 		return !isExist;
 	}
-	
+
 	/**
 	 * アカウントを更新する
-	 * 
+	 *
 	 * @param	accountModel			{@link AccountModel}
 	 * @return							更新に成功した場合、true
 	 * @throws UpdateFailureException	更新に失敗した場合
@@ -84,7 +83,7 @@ public class AccountServiceImpl implements UserDetailsService {
 		if(!isExist) accountRepository.update(accountModel);
 		return isExist;
 	}
-	
+
 	/**
 	 * アカウントIDからアカウント情報を取得する
 	 *
@@ -93,72 +92,55 @@ public class AccountServiceImpl implements UserDetailsService {
 	 */
 	@Transactional(readOnly = true)
 	public AccountModel getAccountById(String accountId) {
-		Account account = accountRepository.getByAccountId(accountId);
-		if (Objects.isNull(account)) {
-			return null;
-		}
-		return AccountModel.builder()
-				.accountNo(account.getAccountNo())
-				.accountId(account.getAccountId())
-				.accountName(account.getAccountName())
-				.password(account.getPassword())
-				.birthdate(account.getBirthdate())
-				.sexKbn(account.getSexKbn())
-				.birthplacePrefectureKbnCode(account.getBirthplacePrefectureKbnCode())
-				.residentPrefectureKbnCode(account.getResidentPrefectureKbnCode())
-				.freeMemo(account.getFreeMemo())
-				.authorityKbn(account.getAuthorityKbn())
-				.lastLoginDatetime(account.getLastLoginDatetime())
-				.loginFailureCount(account.getLoginFailureCount())
-				.build();
+		return accountRepository.getByAccountId(accountId);
 	}
-	
+
 	/**
 	 * アカウントの一覧を取得する
-	 * 
+	 *
 	 * @return	{@link AccountModel}
 	 */
 	@Transactional(readOnly = true)
 	public List<AccountModel> getAccountList() {
 		return accountRepository.getAccountList().stream().sorted(Comparator.comparing(AccountModel::getAccountId)).toList();
 	}
-	
+
 	/**
 	 * 認証成功
-	 * 
+	 *
 	 * @param	event					{@link AuthenticationSuccessEvent}
 	 * @throws	UpdateFailureException	更新に失敗した場合
 	 */
 	@EventListener
 	@Transactional
 	public void handle(AuthenticationSuccessEvent event) throws UpdateFailureException {
-		Account account = accountRepository.getByAccountId(event.getAuthentication().getName());
-		
-		AccountModel accountModel = AccountModel.builder()
-				.accountNo(account.getAccountNo())
+		AccountModel accountModel = accountRepository.getByAccountId(event.getAuthentication().getName());
+
+		AccountModel updateModel = AccountModel.builder()
+				.accountNo(accountModel.getAccountNo())
 				.lastLoginDatetime(OffsetDateTime.now(Consts.JST))
 				.loginFailureCount(0)
 				.build();
-		accountRepository.updateLoginFailureCount(accountModel);
+		accountRepository.updateLoginFailureCount(updateModel);
 	}
-	
+
 	/**
 	 * 認証失敗
-	 * 
+	 *
 	 * @param	event					{@link AuthenticationFailureBadCredentialsEvent}
 	 * @throws	UpdateFailureException	更新に失敗した場合
 	 */
 	@EventListener
 	@Transactional
 	public void handle(AuthenticationFailureBadCredentialsEvent event) throws UpdateFailureException {
-		Account account = accountRepository.getByAccountId(event.getAuthentication().getName());
-		
-		if(!Objects.isNull(account)) {
-			AccountModel accountModel = AccountModel.builder()
-					.accountNo(account.getAccountNo())
-					.loginFailureCount(account.getLoginFailureCount() + 1)
+		AccountModel accountModel = accountRepository.getByAccountId(event.getAuthentication().getName());
+
+		if(!Objects.isNull(accountModel)) {
+			AccountModel updateModel = AccountModel.builder()
+					.accountNo(accountModel.getAccountNo())
+					.loginFailureCount(accountModel.getLoginFailureCount() + 1)
 					.build();
-			accountRepository.updateLoginFailureCount(accountModel);
+			accountRepository.updateLoginFailureCount(updateModel);
 		}
 	}
 }

--- a/backend/src/main/java/com/web/gallary/service/impl/AuthServiceImpl.java
+++ b/backend/src/main/java/com/web/gallary/service/impl/AuthServiceImpl.java
@@ -16,10 +16,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.web.gallary.AccountPrincipal;
 import com.web.gallary.config.JwtConfig;
-import com.web.gallary.entity.Account;
-import com.web.gallary.entity.RefreshToken;
 import com.web.gallary.helper.JwtTokenProvider;
+import com.web.gallary.model.AccountModel;
 import com.web.gallary.model.AuthTokenModel;
+import com.web.gallary.model.RefreshTokenModel;
 import com.web.gallary.repository.AccountRepository;
 import com.web.gallary.repository.RefreshTokenRepository;
 import com.web.gallary.service.AuthService;
@@ -59,7 +59,7 @@ public class AuthServiceImpl implements AuthService {
 	 * ログイン認証を行い、トークンを発行する
 	 *
 	 * @param	accountId	アカウントID
-	 * @param	password	パスワード
+	 * @param	password	��スワード
 	 * @return				{@link AuthTokenModel}
 	 */
 	@Override
@@ -78,12 +78,12 @@ public class AuthServiceImpl implements AuthService {
 		String refreshToken = jwtTokenProvider.generateRefreshToken();
 
 		// リフレッシュトークンをDB保存（ハッシュ化して保存）
-		RefreshToken tokenEntity = RefreshToken.builder()
+		RefreshTokenModel refreshTokenModel = RefreshTokenModel.builder()
 				.accountNo(principal.getAccountNo())
 				.tokenHash(hashToken(refreshToken))
 				.expiresAt(OffsetDateTime.now().plusDays(jwtConfig.getRefreshTokenExpirationDays()))
 				.build();
-		refreshTokenRepository.save(tokenEntity);
+		refreshTokenRepository.save(refreshTokenModel);
 
 		return AuthTokenModel.builder()
 				.accessToken(accessToken)
@@ -93,7 +93,7 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	/**
-	 * リフレッシュトークンを検証し、新しいアクセストークンを発行する
+	 * リフレッシュトークンを検証し、新しいアクセストークンを発行す��
 	 *
 	 * @param	refreshToken	リフレッシュトークン
 	 * @return					{@link AuthTokenModel}
@@ -103,10 +103,10 @@ public class AuthServiceImpl implements AuthService {
 	@Transactional(readOnly = true)
 	public AuthTokenModel refresh(String refreshToken) {
 		String tokenHash = hashToken(refreshToken);
-		RefreshToken storedToken = refreshTokenRepository.findByTokenHash(tokenHash);
+		RefreshTokenModel storedToken = refreshTokenRepository.findByTokenHash(tokenHash);
 
 		if (storedToken == null || storedToken.getIsRevoked()) {
-			throw new IllegalArgumentException("無効なリフレッシュトークンです");
+			throw new IllegalArgumentException("無効なリフレッ���ュトークンです");
 		}
 
 		if (storedToken.getExpiresAt().isBefore(OffsetDateTime.now())) {
@@ -114,8 +114,8 @@ public class AuthServiceImpl implements AuthService {
 		}
 
 		// アカウント番号からアカウント情報を取得し、新しいアクセストークンを発行
-		Account account = accountRepository.getByAccountNo(storedToken.getAccountNo());
-		UserDetails userDetails = accountServiceImpl.loadUserByUsername(account.getAccountId());
+		AccountModel accountModel = accountRepository.getByAccountNo(storedToken.getAccountNo());
+		UserDetails userDetails = accountServiceImpl.loadUserByUsername(accountModel.getAccountId());
 		AccountPrincipal principal = (AccountPrincipal) userDetails;
 
 		String accessToken = jwtTokenProvider.generateAccessToken(principal);
@@ -130,7 +130,7 @@ public class AuthServiceImpl implements AuthService {
 	/**
 	 * ログアウトし、リフレッシュトークンを無効化する
 	 *
-	 * @param	refreshToken	リフレッシュトークン
+	 * @param	refreshToken	リフレッ��ュトークン
 	 */
 	@Override
 	@Transactional

--- a/backend/src/main/java/com/web/gallary/service/impl/AuthServiceImpl.java
+++ b/backend/src/main/java/com/web/gallary/service/impl/AuthServiceImpl.java
@@ -59,7 +59,7 @@ public class AuthServiceImpl implements AuthService {
 	 * ログイン認証を行い、トークンを発行する
 	 *
 	 * @param	accountId	アカウントID
-	 * @param	password	��スワード
+	 * @param	password	パスワード
 	 * @return				{@link AuthTokenModel}
 	 */
 	@Override
@@ -93,7 +93,7 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	/**
-	 * リフレッシュトークンを検証し、新しいアクセストークンを発行す��
+	 * リフレッシュトークンを検証し、新しいアクセストークンを発行する
 	 *
 	 * @param	refreshToken	リフレッシュトークン
 	 * @return					{@link AuthTokenModel}
@@ -130,7 +130,7 @@ public class AuthServiceImpl implements AuthService {
 	/**
 	 * ログアウトし、リフレッシュトークンを無効化する
 	 *
-	 * @param	refreshToken	リフレッ��ュトークン
+	 * @param	refreshToken	リフレッシュトークン
 	 */
 	@Override
 	@Transactional

--- a/backend/src/main/java/com/web/gallary/service/impl/AuthServiceImpl.java
+++ b/backend/src/main/java/com/web/gallary/service/impl/AuthServiceImpl.java
@@ -106,7 +106,7 @@ public class AuthServiceImpl implements AuthService {
 		RefreshTokenModel storedToken = refreshTokenRepository.findByTokenHash(tokenHash);
 
 		if (storedToken == null || storedToken.getIsRevoked()) {
-			throw new IllegalArgumentException("無効なリフレッ���ュトークンです");
+			throw new IllegalArgumentException("無効なリフレッシュトークンです");
 		}
 
 		if (storedToken.getExpiresAt().isBefore(OffsetDateTime.now())) {

--- a/backend/src/main/java/com/web/gallary/service/impl/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/web/gallary/service/impl/PhotoServiceImpl.java
@@ -15,7 +15,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.web.gallary.config.PhotoConfig;
 import com.web.gallary.constant.Consts;
-import com.web.gallary.entity.Account;
 import com.web.gallary.enumuration.DirectionEnum;
 import com.web.gallary.enumuration.ErrorEnum;
 import com.web.gallary.enumuration.SortPhotoEnum;
@@ -29,6 +28,7 @@ import com.web.gallary.model.PhotoDetailGetModel;
 import com.web.gallary.model.PhotoDetailModel;
 import com.web.gallary.model.PhotoFavoriteDeleteModel;
 import com.web.gallary.model.PhotoGetModel;
+import com.web.gallary.model.AccountModel;
 import com.web.gallary.model.PhotoListGetModel;
 import com.web.gallary.model.PhotoModel;
 import com.web.gallary.model.PhotoTagDeleteModel;
@@ -69,12 +69,12 @@ public class PhotoServiceImpl implements PhotoService {
 	@Override
 	@Transactional(readOnly = true)
 	public List<PhotoModel> getPhotoList(PhotoListGetModel photoListGetModel) {
-		Account account = accountRepository.getByAccountId(photoListGetModel.getPhotoAccountId());
-		
+		AccountModel accountModel = accountRepository.getByAccountId(photoListGetModel.getPhotoAccountId());
+
 		List<PhotoModel> photoModelList
 			= photoDetailRepository.getPhotoList(PhotoGetModel.builder()
 					.accountNo(photoListGetModel.getAccountNo())
-					.photoAccountNo(account.getAccountNo())
+					.photoAccountNo(accountModel.getAccountNo())
 					.build());
 		
 		return photoModelList.stream()
@@ -179,10 +179,10 @@ public class PhotoServiceImpl implements PhotoService {
 	public Boolean isReachedUpperLimit(Integer accountNo) {
 		if(Objects.isNull(accountNo)) return true;
 		
-		Account account = accountRepository.getByAccountNo(accountNo);
+		AccountModel accountModel = accountRepository.getByAccountNo(accountNo);
 		Integer count = photoMstRepository.count(accountNo);
-		
-		switch(account.getAuthorityKbn()) {
+
+		switch(accountModel.getAuthorityKbn()) {
 			case MINI:
 				return count > (photoConfig.getMiniUserUpperLimit() - 1);
 			case NORMAL:

--- a/backend/src/test/java/com/web/gallary/controller/integration/AccountRestControllerIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallary/controller/integration/AccountRestControllerIntegrationTest.java
@@ -37,6 +37,7 @@ import com.web.gallary.entity.Account;
 import com.web.gallary.enumuration.AuthorityEnum;
 import com.web.gallary.enumuration.ErrorEnum;
 import com.web.gallary.enumuration.SexEnum;
+import com.web.gallary.model.AccountModel;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -105,7 +106,7 @@ public class AccountRestControllerIntegrationTest {
 		void getAccount_success() throws Exception {
 			String accountId = "aaaaaaaa";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId(accountId)
 					.accountName("AAAAAAAA")
@@ -138,7 +139,7 @@ public class AccountRestControllerIntegrationTest {
 		void getAccount_birthdate_min_date() throws Exception {
 			String accountId = "bbbbbbbb";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(2)
 					.accountId(accountId)
 					.accountName("BBBBBBBB")
@@ -169,7 +170,7 @@ public class AccountRestControllerIntegrationTest {
 		@Order(3)
 		@DisplayName("異常系：他人のアカウントIDを指定した場合はForbidden")
 		void getAccount_forbidden() throws Exception {
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId("aaaaaaaa")
 					.accountName("AAAAAAAA")
@@ -344,7 +345,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountId = "aaaaaaaa";
 			String accountName = "AAAAAAAA";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId(accountId)
 					.accountName(accountName)
@@ -397,7 +398,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountId = "aaaaaaaab";
 			String accountName = "AAAAAAAA";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId("aaaaaaaa")
 					.accountName(accountName)
@@ -450,7 +451,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountId = "aaaaaaaa";
 			String accountName = "AAAAAAAA";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId(accountId)
 					.accountName(accountName)
@@ -503,7 +504,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountId = "aaaaaaaab";
 			String accountName = "AAAAAAAA";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId("aaaaaaaa")
 					.accountName(accountName)
@@ -555,7 +556,7 @@ public class AccountRestControllerIntegrationTest {
 		void update_duplicate_accountId() throws Exception {
 			String accountName = "AAAAAAAA";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId("aaaaaaaa")
 					.accountName(accountName)
@@ -588,7 +589,7 @@ public class AccountRestControllerIntegrationTest {
 		void update_BadRequestException_account_id() throws Exception {
 			String accountName = "AAAAAAAA";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId("aaaaaaaa")
 					.accountName(accountName)
@@ -615,7 +616,7 @@ public class AccountRestControllerIntegrationTest {
 		void update_BadRequestException_account_id_with_change_password() throws Exception {
 			String accountName = "AAAAAAAA";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId("aaaaaaaa")
 					.accountName(accountName)
@@ -643,7 +644,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountId = "aaaaaaaa";
 			String accountName = "AAAAAAAA";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId("aaaaaaaa")
 					.accountName(accountName)
@@ -671,7 +672,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountId = "zzzzzzzz";
 			String accountName = "AAAAAAAA";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(9)
 					.accountId(accountId)
 					.accountName(accountName)

--- a/backend/src/test/java/com/web/gallary/controller/integration/PhotoFavoriteControllerIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallary/controller/integration/PhotoFavoriteControllerIntegrationTest.java
@@ -30,10 +30,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.web.gallary.AccountPrincipal;
-import com.web.gallary.entity.Account;
 import com.web.gallary.entity.PhotoFavorite;
 import com.web.gallary.enumuration.AuthorityEnum;
 import com.web.gallary.enumuration.ErrorEnum;
+import com.web.gallary.model.AccountModel;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -53,7 +53,7 @@ public class PhotoFavoriteControllerIntegrationTest {
 	}
 
 	private Authentication createAuthentication() {
-		Account sessionAccount = Account.builder()
+		AccountModel sessionAccount = AccountModel.builder()
 				.accountNo(1)
 				.accountId("aaaaaaaa")
 				.accountName("AAAAAAAA")

--- a/backend/src/test/java/com/web/gallary/controller/integration/PhotoRestControllerIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallary/controller/integration/PhotoRestControllerIntegrationTest.java
@@ -40,8 +40,8 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import com.web.gallary.AccountPrincipal;
-import com.web.gallary.entity.Account;
 import com.web.gallary.entity.PhotoFavorite;
+import com.web.gallary.model.AccountModel;
 import com.web.gallary.entity.PhotoMst;
 import com.web.gallary.entity.PhotoTagMst;
 import com.web.gallary.enumuration.AuthorityEnum;
@@ -221,7 +221,7 @@ public class PhotoRestControllerIntegrationTest {
 					MediaType.MULTIPART_FORM_DATA_VALUE,
 					"sample image".getBytes());
 			
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(2)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
@@ -317,7 +317,7 @@ public class PhotoRestControllerIntegrationTest {
 					MediaType.MULTIPART_FORM_DATA_VALUE,
 					"sample image".getBytes());
 			
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(2)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
@@ -430,7 +430,7 @@ public class PhotoRestControllerIntegrationTest {
 		void savePhoto_updatePhoto_with_photoTag_and_photoAt() throws Exception {
 			String photoAccountId = "bbbbbbbb";
 			
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(2)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
@@ -550,7 +550,7 @@ public class PhotoRestControllerIntegrationTest {
 					MediaType.MULTIPART_FORM_DATA_VALUE,
 					"sample image".getBytes());
 			
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId("aaaaaaaa")
 					.accountName("AAAAAAAA")
@@ -588,7 +588,7 @@ public class PhotoRestControllerIntegrationTest {
 					MediaType.MULTIPART_FORM_DATA_VALUE,
 					"sample image".getBytes());
 			
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId("aaaaaaaa")
 					.accountName("AAAAAAAA")
@@ -621,7 +621,7 @@ public class PhotoRestControllerIntegrationTest {
 		void savePhoto_BadRequestException_file_and_filepath_is_null() throws Exception {
 			String photoAccountId = "bbbbbbbb";
 			
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(2)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
@@ -652,7 +652,7 @@ public class PhotoRestControllerIntegrationTest {
 		void savePhoto_BadRequestException_file_and_filepath_is_blank() throws Exception {
 			String photoAccountId = "bbbbbbbb";
 			
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(2)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
@@ -689,7 +689,7 @@ public class PhotoRestControllerIntegrationTest {
 					MediaType.MULTIPART_FORM_DATA_VALUE,
 					"sample image".getBytes());
 			
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(2)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
@@ -727,7 +727,7 @@ public class PhotoRestControllerIntegrationTest {
 					MediaType.MULTIPART_FORM_DATA_VALUE,
 					"sample image".getBytes());
 			
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(2)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
@@ -764,7 +764,7 @@ public class PhotoRestControllerIntegrationTest {
 		void savePhoto_UpdateFailureException() throws Exception {
 			String photoAccountId = "bbbbbbbb";
 			
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(2)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
@@ -809,7 +809,7 @@ public class PhotoRestControllerIntegrationTest {
 			String photoAccountId = "aaaaaaaa";
 			String loginAccountId = "aaaaaaaa";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId(loginAccountId)
 					.accountName("AAAAAAAA")
@@ -892,7 +892,7 @@ public class PhotoRestControllerIntegrationTest {
 			String photoAccountId = "aaaaaaaa";
 			String loginAccountId = "eeeeeeee";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId(loginAccountId)
 					.accountName("EEEEEEEE")
@@ -925,7 +925,7 @@ public class PhotoRestControllerIntegrationTest {
 			String photoAccountId = "aaaaaaaa";
 			String loginAccountId = "aaaaaaaa";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId(loginAccountId)
 					.accountName("AAAAAAAA")
@@ -957,7 +957,7 @@ public class PhotoRestControllerIntegrationTest {
 			String photoAccountId = "aaaaaaaa";
 			String loginAccountId = "aaaaaaaa";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId(loginAccountId)
 					.accountName("AAAAAAAA")
@@ -994,7 +994,7 @@ public class PhotoRestControllerIntegrationTest {
 		void getPhotoUpperLimit_not_reached() throws Exception {
 			String photoAccountId = "bbbbbbbb";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(2)
 					.accountId(photoAccountId)
 					.accountName("BBBBBBBB")
@@ -1021,7 +1021,7 @@ public class PhotoRestControllerIntegrationTest {
 		void getPhotoUpperLimit_reached() throws Exception {
 			String photoAccountId = "aaaaaaaa";
 
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(1)
 					.accountId(photoAccountId)
 					.accountName("AAAAAAAA")
@@ -1046,7 +1046,7 @@ public class PhotoRestControllerIntegrationTest {
 		@Order(3)
 		@DisplayName("正常系：他人のアカウントの場合はfalse")
 		void getPhotoUpperLimit_other_account() throws Exception {
-			Account sessionAccount = Account.builder()
+			AccountModel sessionAccount = AccountModel.builder()
 					.accountNo(2)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")

--- a/backend/src/test/java/com/web/gallary/repository/impl/AccountRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallary/repository/impl/AccountRepositoryImplTest.java
@@ -80,14 +80,25 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(accountList).when(accountMapper).select(accountCaptor.capture());
 			
-			Account actual = accountRepositoryImpl.getByAccountNo(1);
+			AccountModel actual = accountRepositoryImpl.getByAccountNo(1);
 
 			verify(accountMapper).select(any(Account.class));
 			Account accountCapture = accountCaptor.getValue();
 			assertEquals(1, accountCapture.getAccountNo());
 
 			assertNotNull(actual);
-			assertEquals(accountList.getFirst(), actual);
+			assertEquals(account.getAccountNo(), actual.getAccountNo());
+			assertEquals(account.getAccountId(), actual.getAccountId());
+			assertEquals(account.getAccountName(), actual.getAccountName());
+			assertEquals(account.getPassword(), actual.getPassword());
+			assertEquals(account.getBirthdate(), actual.getBirthdate());
+			assertEquals(account.getSexKbn(), actual.getSexKbn());
+			assertEquals(account.getBirthplacePrefectureKbnCode(), actual.getBirthplacePrefectureKbnCode());
+			assertEquals(account.getResidentPrefectureKbnCode(), actual.getResidentPrefectureKbnCode());
+			assertEquals(account.getFreeMemo(), actual.getFreeMemo());
+			assertEquals(account.getAuthorityKbn(), actual.getAuthorityKbn());
+			assertEquals(account.getLastLoginDatetime(), actual.getLastLoginDatetime());
+			assertEquals(account.getLoginFailureCount(), actual.getLoginFailureCount());
 		}
 		
 		@Test
@@ -97,7 +108,7 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(new ArrayList<Account>()).when(accountMapper).select(accountCaptor.capture());
 			
-			Account actual = accountRepositoryImpl.getByAccountNo(1);
+			AccountModel actual = accountRepositoryImpl.getByAccountNo(1);
 			
 			verify(accountMapper).select(any(Account.class));
 			Account accountCapture = accountCaptor.getValue();
@@ -141,14 +152,25 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(accountList).when(accountMapper).select(accountCaptor.capture());
 			
-			Account actual = accountRepositoryImpl.getByAccountId("aaaaaaaa");
+			AccountModel actual = accountRepositoryImpl.getByAccountId("aaaaaaaa");
 
 			verify(accountMapper).select(any(Account.class));
 			Account accountCapture = accountCaptor.getValue();
 			assertEquals("aaaaaaaa", accountCapture.getAccountId());
 
 			assertNotNull(actual);
-			assertEquals(accountList.getFirst(), actual);
+			assertEquals(account.getAccountNo(), actual.getAccountNo());
+			assertEquals(account.getAccountId(), actual.getAccountId());
+			assertEquals(account.getAccountName(), actual.getAccountName());
+			assertEquals(account.getPassword(), actual.getPassword());
+			assertEquals(account.getBirthdate(), actual.getBirthdate());
+			assertEquals(account.getSexKbn(), actual.getSexKbn());
+			assertEquals(account.getBirthplacePrefectureKbnCode(), actual.getBirthplacePrefectureKbnCode());
+			assertEquals(account.getResidentPrefectureKbnCode(), actual.getResidentPrefectureKbnCode());
+			assertEquals(account.getFreeMemo(), actual.getFreeMemo());
+			assertEquals(account.getAuthorityKbn(), actual.getAuthorityKbn());
+			assertEquals(account.getLastLoginDatetime(), actual.getLastLoginDatetime());
+			assertEquals(account.getLoginFailureCount(), actual.getLoginFailureCount());
 		}
 		
 		@Test
@@ -158,7 +180,7 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(new ArrayList<Account>()).when(accountMapper).select(accountCaptor.capture());
 			
-			Account actual = accountRepositoryImpl.getByAccountId("aaaaaaaa");
+			AccountModel actual = accountRepositoryImpl.getByAccountId("aaaaaaaa");
 			
 			verify(accountMapper).select(any(Account.class));
 			Account accountCapture = accountCaptor.getValue();

--- a/backend/src/test/java/com/web/gallary/repository/impl/RefreshTokenRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallary/repository/impl/RefreshTokenRepositoryImplTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import com.web.gallary.entity.RefreshToken;
 import com.web.gallary.mapper.RefreshTokenMapper;
+import com.web.gallary.model.RefreshTokenModel;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
@@ -38,17 +39,17 @@ public class RefreshTokenRepositoryImplTest {
 		@Order(1)
 		@DisplayName("正常系：リフレッシュトークンを保存する")
 		void save_success() {
-			RefreshToken refreshToken = RefreshToken.builder()
+			RefreshTokenModel refreshTokenModel = RefreshTokenModel.builder()
 					.accountNo(1)
 					.tokenHash("abc123hash")
 					.expiresAt(OffsetDateTime.now().plusDays(7))
 					.build();
 
-			doReturn(1).when(refreshTokenMapper).insert(refreshToken);
+			doReturn(1).when(refreshTokenMapper).insert(any(RefreshToken.class));
 
-			refreshTokenRepositoryImpl.save(refreshToken);
+			refreshTokenRepositoryImpl.save(refreshTokenModel);
 
-			verify(refreshTokenMapper, times(1)).insert(refreshToken);
+			verify(refreshTokenMapper, times(1)).insert(any(RefreshToken.class));
 		}
 	}
 
@@ -60,19 +61,24 @@ public class RefreshTokenRepositoryImplTest {
 		@Order(1)
 		@DisplayName("正常系：トークンハッシュに該当するリフレッシュトークンを取得する")
 		void findByTokenHash_success() {
-			RefreshToken expected = RefreshToken.builder()
+			OffsetDateTime expiresAt = OffsetDateTime.now().plusDays(7);
+			RefreshToken mapperResult = RefreshToken.builder()
 					.tokenId(1)
 					.accountNo(1)
 					.tokenHash("abc123hash")
-					.expiresAt(OffsetDateTime.now().plusDays(7))
+					.expiresAt(expiresAt)
 					.isRevoked(false)
 					.build();
 
-			doReturn(expected).when(refreshTokenMapper).selectByTokenHash("abc123hash");
+			doReturn(mapperResult).when(refreshTokenMapper).selectByTokenHash("abc123hash");
 
-			RefreshToken actual = refreshTokenRepositoryImpl.findByTokenHash("abc123hash");
+			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash("abc123hash");
 
-			assertEquals(expected, actual);
+			assertNotNull(actual);
+			assertEquals(1, actual.getAccountNo());
+			assertEquals("abc123hash", actual.getTokenHash());
+			assertEquals(expiresAt, actual.getExpiresAt());
+			assertFalse(actual.getIsRevoked());
 			verify(refreshTokenMapper, times(1)).selectByTokenHash("abc123hash");
 		}
 
@@ -82,7 +88,7 @@ public class RefreshTokenRepositoryImplTest {
 		void findByTokenHash_not_found() {
 			doReturn(null).when(refreshTokenMapper).selectByTokenHash("nonexistent");
 
-			RefreshToken actual = refreshTokenRepositoryImpl.findByTokenHash("nonexistent");
+			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash("nonexistent");
 
 			assertNull(actual);
 			verify(refreshTokenMapper, times(1)).selectByTokenHash("nonexistent");

--- a/backend/src/test/java/com/web/gallary/repository/impl/integration/AccountRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallary/repository/impl/integration/AccountRepositoryImplIntegrationTest.java
@@ -49,13 +49,9 @@ public class AccountRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントが取得できた場合")
 		void getByAccountNo_found() {
-			Account actual = accountRepositoryImpl.getByAccountNo(1);
-			
+			AccountModel actual = accountRepositoryImpl.getByAccountNo(1);
+
 			assertEquals(1, actual.getAccountNo());
-			assertEquals(1, actual.getCreatedBy());
-			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getCreatedAt());
-			assertEquals(1, actual.getUpdatedBy());
-			assertEquals(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getUpdatedAt());
 			assertFalse(actual.getIsDeleted());
 			assertEquals("aaaaaaaa", actual.getAccountId());
 			assertEquals("AAAAAAAA", actual.getAccountName());
@@ -69,12 +65,12 @@ public class AccountRepositoryImplIntegrationTest {
 			assertEquals(OffsetDateTime.of(2002, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getLastLoginDatetime());
 			assertEquals(0, actual.getLoginFailureCount());
 		}
-		
+
 		@Test
 		@Order(2)
 		@DisplayName("正常系：アカウントが取得できなかった場合")
 		void getByAccountNo_not_found() {
-			Account actual = accountRepositoryImpl.getByAccountNo(99);
+			AccountModel actual = accountRepositoryImpl.getByAccountNo(99);
 			assertNull(actual);
 		}
 	}
@@ -89,13 +85,9 @@ public class AccountRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントが取得できた場合")
 		void getByAccountId_found() {
-			Account actual = accountRepositoryImpl.getByAccountId("aaaaaaaa");
-			
+			AccountModel actual = accountRepositoryImpl.getByAccountId("aaaaaaaa");
+
 			assertEquals(1, actual.getAccountNo());
-			assertEquals(1, actual.getCreatedBy());
-			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getCreatedAt());
-			assertEquals(1, actual.getUpdatedBy());
-			assertEquals(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getUpdatedAt());
 			assertFalse(actual.getIsDeleted());
 			assertEquals("aaaaaaaa", actual.getAccountId());
 			assertEquals("AAAAAAAA", actual.getAccountName());
@@ -109,12 +101,12 @@ public class AccountRepositoryImplIntegrationTest {
 			assertEquals(OffsetDateTime.of(2002, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getLastLoginDatetime());
 			assertEquals(0, actual.getLoginFailureCount());
 		}
-		
+
 		@Test
 		@Order(2)
 		@DisplayName("正常系：アカウントが取得できなかった場合")
 		void getByAccountId_not_found() {
-			Account actual = accountRepositoryImpl.getByAccountId("zzzzzzzz");
+			AccountModel actual = accountRepositoryImpl.getByAccountId("zzzzzzzz");
 			assertNull(actual);
 		}
 	}

--- a/backend/src/test/java/com/web/gallary/repository/impl/integration/RefreshTokenRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallary/repository/impl/integration/RefreshTokenRepositoryImplIntegrationTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.web.gallary.entity.RefreshToken;
+import com.web.gallary.model.RefreshTokenModel;
 import com.web.gallary.repository.impl.RefreshTokenRepositoryImpl;
 
 @ActiveProfiles("test")
@@ -76,7 +77,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：リフレッシュトークンを保存する")
 		void save_success() {
-			RefreshToken refreshToken = RefreshToken.builder()
+			RefreshTokenModel refreshToken = RefreshTokenModel.builder()
 					.accountNo(1)
 					.tokenHash("new_token_hash")
 					.expiresAt(OffsetDateTime.now().plusDays(7))
@@ -104,10 +105,9 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：トークンハッシュに該当するリフレッシュトークンを取得する")
 		void findByTokenHash_success() {
-			RefreshToken actual = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1");
+			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1");
 
 			assertNotNull(actual);
-			assertEquals(1, actual.getTokenId());
 			assertEquals(1, actual.getAccountNo());
 			assertEquals("valid_token_hash_1", actual.getTokenHash());
 			assertFalse(actual.getIsRevoked());
@@ -117,10 +117,9 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：無効化済みのトークンも取得できる")
 		void findByTokenHash_revoked() {
-			RefreshToken actual = refreshTokenRepositoryImpl.findByTokenHash("revoked_token_hash_1");
+			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash("revoked_token_hash_1");
 
 			assertNotNull(actual);
-			assertEquals(2, actual.getTokenId());
 			assertTrue(actual.getIsRevoked());
 		}
 
@@ -128,7 +127,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@Order(3)
 		@DisplayName("正常系：該当するトークンが存在しない場合、nullを返す")
 		void findByTokenHash_not_found() {
-			RefreshToken actual = refreshTokenRepositoryImpl.findByTokenHash("nonexistent_hash");
+			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash("nonexistent_hash");
 
 			assertNull(actual);
 		}
@@ -154,7 +153,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 			}
 
 			// アカウント2のトークンは影響を受けない
-			RefreshToken account2Token = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_2");
+			RefreshTokenModel account2Token = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_2");
 			assertNotNull(account2Token);
 			assertFalse(account2Token.getIsRevoked());
 		}
@@ -178,17 +177,17 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@DisplayName("正常系：トークンハッシュに該当するリフレッシュトークンを無効化する")
 		void revokeByTokenHash_success() {
 			// 無効化前は有効
-			RefreshToken before = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1");
+			RefreshTokenModel before = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1");
 			assertFalse(before.getIsRevoked());
 
 			refreshTokenRepositoryImpl.revokeByTokenHash("valid_token_hash_1");
 
 			// 無効化後はis_revoked=true
-			RefreshToken after = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1");
+			RefreshTokenModel after = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1");
 			assertTrue(after.getIsRevoked());
 
 			// 他のトークンは影響を受けない
-			RefreshToken otherToken = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1b");
+			RefreshTokenModel otherToken = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1b");
 			assertFalse(otherToken.getIsRevoked());
 		}
 
@@ -221,11 +220,11 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 			assertEquals(4, afterCount);
 
 			// 期限切れトークン（token_id=3）が削除されていることを検証
-			RefreshToken deletedToken = refreshTokenRepositoryImpl.findByTokenHash("expired_token_hash_1");
+			RefreshTokenModel deletedToken = refreshTokenRepositoryImpl.findByTokenHash("expired_token_hash_1");
 			assertNull(deletedToken);
 
 			// 有効なトークンは残っている
-			RefreshToken validToken = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1");
+			RefreshTokenModel validToken = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1");
 			assertNotNull(validToken);
 		}
 	}

--- a/backend/src/test/java/com/web/gallary/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallary/service/impl/AccountServiceImplTest.java
@@ -31,7 +31,6 @@ import org.springframework.test.context.ActiveProfiles;
 
 import com.web.gallary.AccountPrincipal;
 import com.web.gallary.config.LoginConfig;
-import com.web.gallary.entity.Account;
 import com.web.gallary.exception.RegistFailureException;
 import com.web.gallary.exception.UpdateFailureException;
 import com.web.gallary.model.AccountModel;
@@ -62,7 +61,7 @@ public class AccountServiceImplTest {
 		void loadUserByUsername_success() {
 			String accountId = "aaaaaaaa";
 			String password = "AAAAAAAA";
-			Account account = Account.builder()
+			AccountModel account = AccountModel.builder()
 					.accountNo(1)
 					.accountId(accountId)
 					.loginFailureCount(0)
@@ -164,7 +163,7 @@ public class AccountServiceImplTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントが存在する場合")
 		void getAccountById_found() {
-			Account account = Account.builder()
+			AccountModel account = AccountModel.builder()
 					.accountNo(1)
 					.accountId("aaaaaaaa")
 					.accountName("AAAAAAAA")
@@ -253,7 +252,7 @@ public class AccountServiceImplTest {
 			Authentication authentication = new UsernamePasswordAuthenticationToken(username, password, authorities);
 			AuthenticationSuccessEvent event = new AuthenticationSuccessEvent(authentication);
 			
-			Account account = Account.builder().accountNo(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(username);
 			
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
@@ -289,7 +288,7 @@ public class AccountServiceImplTest {
 			Authentication authentication = new UsernamePasswordAuthenticationToken(username, password, authorities);
 			AuthenticationSuccessEvent event = new AuthenticationSuccessEvent(authentication);
 			
-			Account account = Account.builder().accountNo(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(username);
 			
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
@@ -333,7 +332,7 @@ public class AccountServiceImplTest {
 			
 			AuthenticationFailureBadCredentialsEvent event = new AuthenticationFailureBadCredentialsEvent(authentication, exception);
 			
-			Account account = Account.builder().accountNo(1).loginFailureCount(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1).loginFailureCount(1).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(username);
 			
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
@@ -394,7 +393,7 @@ public class AccountServiceImplTest {
 			
 			AuthenticationFailureBadCredentialsEvent event = new AuthenticationFailureBadCredentialsEvent(authentication, exception);
 			
-			Account account = Account.builder().accountNo(1).loginFailureCount(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1).loginFailureCount(1).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(username);
 			
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);

--- a/backend/src/test/java/com/web/gallary/service/impl/AuthServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallary/service/impl/AuthServiceImplTest.java
@@ -24,10 +24,10 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import com.web.gallary.AccountPrincipal;
 import com.web.gallary.config.JwtConfig;
-import com.web.gallary.entity.Account;
-import com.web.gallary.entity.RefreshToken;
 import com.web.gallary.helper.JwtTokenProvider;
+import com.web.gallary.model.AccountModel;
 import com.web.gallary.model.AuthTokenModel;
+import com.web.gallary.model.RefreshTokenModel;
 import com.web.gallary.repository.AccountRepository;
 import com.web.gallary.repository.RefreshTokenRepository;
 
@@ -86,7 +86,7 @@ class AuthServiceImplTest {
 			assertEquals(900L, result.getExpiresIn());
 
 			verify(refreshTokenRepository).revokeAllByAccountNo(1);
-			verify(refreshTokenRepository).save(any(RefreshToken.class));
+			verify(refreshTokenRepository).save(any(RefreshTokenModel.class));
 		}
 
 		@Test
@@ -120,8 +120,7 @@ class AuthServiceImplTest {
 		@DisplayName("正常系: リフレッシュトークンが有効な場合、新しいアクセストークンが返されること")
 		void refresh_success() {
 			String refreshToken = "valid-refresh-token";
-			RefreshToken storedToken = RefreshToken.builder()
-					.tokenId(1)
+			RefreshTokenModel storedToken = RefreshTokenModel.builder()
 					.accountNo(1)
 					.tokenHash("hashed-token")
 					.expiresAt(OffsetDateTime.now().plusDays(7))
@@ -130,7 +129,7 @@ class AuthServiceImplTest {
 
 			when(refreshTokenRepository.findByTokenHash(anyString())).thenReturn(storedToken);
 
-			Account account = Account.builder()
+			AccountModel account = AccountModel.builder()
 					.accountNo(1)
 					.accountId("testuser1")
 					.build();
@@ -151,8 +150,7 @@ class AuthServiceImplTest {
 		@Test
 		@DisplayName("異常系: リフレッシュトークンが無効化されている場合は例外がスローされること")
 		void refresh_revokedToken() {
-			RefreshToken storedToken = RefreshToken.builder()
-					.tokenId(1)
+			RefreshTokenModel storedToken = RefreshTokenModel.builder()
 					.accountNo(1)
 					.tokenHash("hashed-token")
 					.expiresAt(OffsetDateTime.now().plusDays(7))
@@ -169,8 +167,7 @@ class AuthServiceImplTest {
 		@Test
 		@DisplayName("異常系: リフレッシュトークンの有効期限が切れている場合は例外がスローされること")
 		void refresh_expiredToken() {
-			RefreshToken storedToken = RefreshToken.builder()
-					.tokenId(1)
+			RefreshTokenModel storedToken = RefreshTokenModel.builder()
 					.accountNo(1)
 					.tokenHash("hashed-token")
 					.expiresAt(OffsetDateTime.now().minusDays(1))

--- a/backend/src/test/java/com/web/gallary/service/impl/PhotoServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallary/service/impl/PhotoServiceImplTest.java
@@ -30,7 +30,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.web.gallary.config.PhotoConfig;
-import com.web.gallary.entity.Account;
+import com.web.gallary.model.AccountModel;
 import com.web.gallary.enumuration.AuthorityEnum;
 import com.web.gallary.enumuration.DirectionEnum;
 import com.web.gallary.enumuration.ErrorEnum;
@@ -239,7 +239,7 @@ public class PhotoServiceImplTest {
 			String accountId = "aaaaaaaa";
 			List<String> tags = new ArrayList<String>();
 			
-			Account account = Account.builder().accountNo(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(accountId);
 			
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
@@ -271,7 +271,7 @@ public class PhotoServiceImplTest {
 			String accountId = "aaaaaaaa";
 			List<String> tags = Arrays.asList("太陽", "海");
 			
-			Account account = Account.builder().accountNo(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(accountId);
 			
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
@@ -307,7 +307,7 @@ public class PhotoServiceImplTest {
 			String accountId = "aaaaaaaa";
 			List<String> tags = Arrays.asList("太陽", "海");
 			
-			Account account = Account.builder().accountNo(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(accountId);
 			
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
@@ -343,7 +343,7 @@ public class PhotoServiceImplTest {
 			String accountId = "aaaaaaaa";
 			List<String> tags = Arrays.asList("太陽", "海");
 			
-			Account account = Account.builder().accountNo(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(accountId);
 			
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
@@ -1021,7 +1021,7 @@ public class PhotoServiceImplTest {
 		@DisplayName("正常系：mini-userで、上限まで登録済みの場合")
 		void isReachedUpperLimit_mini_user_reached() {
 			Integer accountNo = 1;
-			Account account = Account.builder().authorityKbn(AuthorityEnum.MINI).build();
+			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.MINI).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(10).when(photoMstRepositoryImpl).count(accountNo);
 			doReturn(10).when(photoConfig).getMiniUserUpperLimit();
@@ -1033,7 +1033,7 @@ public class PhotoServiceImplTest {
 		@DisplayName("正常系：mini-userで、上限まで未登録の場合")
 		void isReachedUpperLimit_mini_user_not_reached() {
 			Integer accountNo = 1;
-			Account account = Account.builder().authorityKbn(AuthorityEnum.MINI).build();
+			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.MINI).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(9).when(photoMstRepositoryImpl).count(accountNo);
 			doReturn(10).when(photoConfig).getMiniUserUpperLimit();
@@ -1045,7 +1045,7 @@ public class PhotoServiceImplTest {
 		@DisplayName("正常系：normal-userで、上限まで登録済みの場合")
 		void isReachedUpperLimit_normal_user_reached() {
 			Integer accountNo = 1;
-			Account account = Account.builder().authorityKbn(AuthorityEnum.NORMAL).build();
+			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.NORMAL).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(1000).when(photoMstRepositoryImpl).count(accountNo);
 			doReturn(1000).when(photoConfig).getNormalUserUpperLimit();
@@ -1057,7 +1057,7 @@ public class PhotoServiceImplTest {
 		@DisplayName("正常系：normal-userで、上限まで未登録の場合")
 		void isReachedUpperLimit_normal_user_not_reached() {
 			Integer accountNo = 1;
-			Account account = Account.builder().authorityKbn(AuthorityEnum.NORMAL).build();
+			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.NORMAL).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(999).when(photoMstRepositoryImpl).count(accountNo);
 			doReturn(1000).when(photoConfig).getNormalUserUpperLimit();
@@ -1069,7 +1069,7 @@ public class PhotoServiceImplTest {
 		@DisplayName("正常系：special-userの場合")
 		void isReachedUpperLimit_special_user() {
 			Integer accountNo = 1;
-			Account account = Account.builder().authorityKbn(AuthorityEnum.SPECIAL).build();
+			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.SPECIAL).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(1000).when(photoMstRepositoryImpl).count(accountNo);
 			assertFalse(photoServiceImpl.isReachedUpperLimit(accountNo));
@@ -1080,7 +1080,7 @@ public class PhotoServiceImplTest {
 		@DisplayName("正常系：administratorの場合")
 		void isReachedUpperLimit_administrator() {
 			Integer accountNo = 1;
-			Account account = Account.builder().authorityKbn(AuthorityEnum.ADMINISTRATOR).build();
+			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.ADMINISTRATOR).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(1000).when(photoMstRepositoryImpl).count(accountNo);
 			assertFalse(photoServiceImpl.isReachedUpperLimit(accountNo));

--- a/backend/src/test/java/com/web/gallary/service/impl/integration/AuthServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallary/service/impl/integration/AuthServiceImplIntegrationTest.java
@@ -23,8 +23,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.web.gallary.entity.RefreshToken;
 import com.web.gallary.model.AuthTokenModel;
+import com.web.gallary.model.RefreshTokenModel;
 import com.web.gallary.repository.RefreshTokenRepository;
 import com.web.gallary.service.impl.AuthServiceImpl;
 
@@ -106,7 +106,7 @@ public class AuthServiceImplIntegrationTest {
 
 			// リフレッシュトークンがDBに保存されていることを検証
 			String tokenHash = hashToken(result.getRefreshToken());
-			RefreshToken storedToken = refreshTokenRepository.findByTokenHash(tokenHash);
+			RefreshTokenModel storedToken = refreshTokenRepository.findByTokenHash(tokenHash);
 			assertNotNull(storedToken);
 			assertEquals(1, storedToken.getAccountNo());
 			assertFalse(storedToken.getIsRevoked());
@@ -126,12 +126,12 @@ public class AuthServiceImplIntegrationTest {
 			String secondTokenHash = hashToken(secondResult.getRefreshToken());
 
 			// 1回目のトークンが無効化されていることを検証
-			RefreshToken firstToken = refreshTokenRepository.findByTokenHash(firstTokenHash);
+			RefreshTokenModel firstToken = refreshTokenRepository.findByTokenHash(firstTokenHash);
 			assertNotNull(firstToken);
 			assertTrue(firstToken.getIsRevoked());
 
 			// 2回目のトークンが有効であることを検証
-			RefreshToken secondToken = refreshTokenRepository.findByTokenHash(secondTokenHash);
+			RefreshTokenModel secondToken = refreshTokenRepository.findByTokenHash(secondTokenHash);
 			assertNotNull(secondToken);
 			assertFalse(secondToken.getIsRevoked());
 		}
@@ -255,7 +255,7 @@ public class AuthServiceImplIntegrationTest {
 			String tokenHash = hashToken(refreshToken);
 
 			// ログアウト前はトークンが有効
-			RefreshToken beforeLogout = refreshTokenRepository.findByTokenHash(tokenHash);
+			RefreshTokenModel beforeLogout = refreshTokenRepository.findByTokenHash(tokenHash);
 			assertNotNull(beforeLogout);
 			assertFalse(beforeLogout.getIsRevoked());
 
@@ -263,7 +263,7 @@ public class AuthServiceImplIntegrationTest {
 			authServiceImpl.logout(refreshToken);
 
 			// ログアウト後はトークンが無効化されている
-			RefreshToken afterLogout = refreshTokenRepository.findByTokenHash(tokenHash);
+			RefreshTokenModel afterLogout = refreshTokenRepository.findByTokenHash(tokenHash);
 			assertNotNull(afterLogout);
 			assertTrue(afterLogout.getIsRevoked());
 		}


### PR DESCRIPTION
## Summary
- ServiceクラスでEntityクラスを直接使用していた箇所を修正し、Repository経由のデータ受け渡しをすべてModelクラスに統一
- `RefreshTokenModel`を新規作成（ロジックで使用するプロパティのみ定義）
- `AccountModel`に`isDeleted`フィールドを追加（`AccountPrincipal.isEnabled()`で使用）
- `AccountRepository`の`getByAccountNo`/`getByAccountId`の戻り値を`Account` → `AccountModel`に変更
- `RefreshTokenRepository`の`save`/`findByTokenHash`を`RefreshToken` → `RefreshTokenModel`に変更
- Entity⇔Model変換処理をRepository実装側に集約

## Test plan
- [x] `./backend/gradlew -p backend build` でビルド・全テスト成功を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)