### PR TITLE
Model↔Entity変換をstatic from()メソッドに集約

### DIFF
--- a/backend/src/main/java/com/web/gallary/entity/Account.java
+++ b/backend/src/main/java/com/web/gallary/entity/Account.java
@@ -2,9 +2,15 @@ package com.web.gallary.entity;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.Objects;
+import java.util.Optional;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.web.gallary.constant.Consts;
 import com.web.gallary.enumuration.AuthorityEnum;
 import com.web.gallary.enumuration.SexEnum;
+import com.web.gallary.model.AccountModel;
 
 import lombok.Builder;
 import lombok.Data;
@@ -73,4 +79,81 @@ public class Account {
 	
 	/** ログイン失敗回数 */
 	private Integer loginFailureCount;
+
+	/**
+	 * アカウント登録用のAccountModelからAccountエンティティを生成する
+	 *
+	 * @param	model			{@link AccountModel}
+	 * @param	passwordEncoder	{@link PasswordEncoder}
+	 * @return					{@link Account}
+	 */
+	public static Account from(AccountModel model, PasswordEncoder passwordEncoder) {
+		return Account.builder()
+				.createdBy(0)
+				.updatedBy(0)
+				.accountId(model.getAccountId())
+				.accountName(model.getAccountName())
+				.password(passwordEncoder.encode(model.getPassword()))
+				.birthdate(
+					Optional.ofNullable(model.getBirthdate()).orElse(Consts.MIN_LOCAL_DATE))
+				.sexKbn(
+					Optional.ofNullable(model.getSexKbn()).orElse(SexEnum.NONE))
+				.birthplacePrefectureKbnCode(
+					Optional.ofNullable(model.getBirthplacePrefectureKbnCode()).orElse(Consts.STRING_NONE))
+				.residentPrefectureKbnCode(
+					Optional.ofNullable(model.getResidentPrefectureKbnCode()).orElse(Consts.STRING_NONE))
+				.freeMemo(
+					Optional.ofNullable(model.getFreeMemo()).orElse(Consts.STRING_EMPTY))
+				.authorityKbn(AuthorityEnum.MINI)
+				.lastLoginDatetime(Consts.MIN_OFFSET_DATE_TIME)
+				.loginFailureCount(0)
+				.build();
+	}
+
+	/**
+	 * アカウント更新用のAccountModelからAccountエンティティを生成する
+	 *
+	 * @param	model			{@link AccountModel}
+	 * @param	passwordEncoder	{@link PasswordEncoder}
+	 * @return					{@link Account}
+	 */
+	public static Account fromForUpdate(AccountModel model, PasswordEncoder passwordEncoder) {
+		Account account = Account.builder()
+				.accountId(model.getAccountId())
+				.accountName(model.getAccountName())
+				.birthdate(
+					Optional.ofNullable(model.getBirthdate()).orElse(Consts.MIN_LOCAL_DATE))
+				.sexKbn(
+					Optional.ofNullable(model.getSexKbn()).orElse(SexEnum.NONE))
+				.birthplacePrefectureKbnCode(
+					Optional.ofNullable(model.getBirthplacePrefectureKbnCode()).orElse(Consts.STRING_NONE))
+				.residentPrefectureKbnCode(
+					Optional.ofNullable(model.getResidentPrefectureKbnCode()).orElse(Consts.STRING_NONE))
+				.freeMemo(
+					Optional.ofNullable(model.getFreeMemo()).orElse(Consts.STRING_EMPTY))
+				.lastLoginDatetime(
+					Optional.ofNullable(model.getLastLoginDatetime()).orElse(Consts.MIN_OFFSET_DATE_TIME))
+				.loginFailureCount(
+					Optional.ofNullable(model.getLoginFailureCount()).orElse(0))
+				.build();
+
+		if (!Objects.isNull(model.getPassword())) {
+			account.setPassword(passwordEncoder.encode(model.getPassword()));
+		}
+
+		return account;
+	}
+
+	/**
+	 * ログイン失敗回数更新用のAccountModelからAccountエンティティを生成する
+	 *
+	 * @param	model	{@link AccountModel}
+	 * @return			{@link Account}
+	 */
+	public static Account fromForUpdateLoginFailure(AccountModel model) {
+		return Account.builder()
+				.lastLoginDatetime(model.getLastLoginDatetime())
+				.loginFailureCount(Optional.ofNullable(model.getLoginFailureCount()).orElse(0))
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/entity/Account.java
+++ b/backend/src/main/java/com/web/gallary/entity/Account.java
@@ -156,4 +156,53 @@ public class Account {
 				.loginFailureCount(Optional.ofNullable(model.getLoginFailureCount()).orElse(0))
 				.build();
 	}
+
+	/**
+	 * アカウント番号で検索するための条件用Accountエンティティを生成する
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @return				{@link Account}
+	 */
+	public static Account conditionByAccountNo(Integer accountNo) {
+		return Account.builder()
+				.accountNo(accountNo)
+				.build();
+	}
+
+	/**
+	 * アカウントIDで検索するための条件用Accountエンティティを生成する
+	 *
+	 * @param	accountId	アカウントID
+	 * @return				{@link Account}
+	 */
+	public static Account conditionByAccountId(String accountId) {
+		return Account.builder()
+				.accountId(accountId)
+				.build();
+	}
+
+	/**
+	 * アカウント存在チェック用の条件Accountエンティティを生成する
+	 *
+	 * @param	accountNo	検索対象外のアカウント番号
+	 * @param	accountId	アカウントID
+	 * @return				{@link Account}
+	 */
+	public static Account conditionForExistCheck(Integer accountNo, String accountId) {
+		return Account.builder()
+				.accountNo(accountNo)
+				.accountId(accountId)
+				.build();
+	}
+
+	/**
+	 * アカウント一覧取得用の条件Accountエンティティを生成する
+	 *
+	 * @return	{@link Account}
+	 */
+	public static Account conditionForList() {
+		return Account.builder()
+				.isDeleted(false)
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/entity/KbnMst.java
+++ b/backend/src/main/java/com/web/gallary/entity/KbnMst.java
@@ -49,4 +49,16 @@ public class KbnMst {
 
 	/** 説明 */
 	private String explanation;
+
+	/**
+	 * 条件用のKbnMstエンティティを生成する
+	 *
+	 * @param	kbnClassCode	区分分類コード
+	 * @return					{@link KbnMst}
+	 */
+	public static KbnMst condition(String kbnClassCode) {
+		return KbnMst.builder()
+				.kbnClassCode(kbnClassCode)
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/entity/PhotoFavorite.java
+++ b/backend/src/main/java/com/web/gallary/entity/PhotoFavorite.java
@@ -60,4 +60,17 @@ public class PhotoFavorite {
 				.favoritePhotoNo(model.getFavoritePhotoNo())
 				.build();
 	}
+
+	/**
+	 * 写真お気に入り全件削除用のPhotoFavoriteDeleteModelからPhotoFavoriteエンティティを生成する
+	 *
+	 * @param	model	{@link PhotoFavoriteDeleteModel}
+	 * @return			{@link PhotoFavorite}
+	 */
+	public static PhotoFavorite fromForClear(PhotoFavoriteDeleteModel model) {
+		return PhotoFavorite.builder()
+				.favoritePhotoAccountNo(model.getFavoritePhotoAccountNo())
+				.favoritePhotoNo(model.getFavoritePhotoNo())
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/entity/PhotoFavorite.java
+++ b/backend/src/main/java/com/web/gallary/entity/PhotoFavorite.java
@@ -2,6 +2,9 @@ package com.web.gallary.entity;
 
 import java.time.OffsetDateTime;
 
+import com.web.gallary.model.PhotoFavoriteDeleteModel;
+import com.web.gallary.model.PhotoFavoriteModel;
+
 import lombok.Builder;
 import lombok.Data;
 
@@ -28,4 +31,33 @@ public class PhotoFavorite {
 
 	/** 作成日時 */
 	private OffsetDateTime createdAt;
+
+	/**
+	 * PhotoFavoriteModelからPhotoFavoriteエンティティを生成する
+	 *
+	 * @param	model	{@link PhotoFavoriteModel}
+	 * @return			{@link PhotoFavorite}
+	 */
+	public static PhotoFavorite from(PhotoFavoriteModel model) {
+		return PhotoFavorite.builder()
+				.accountNo(model.getAccountNo())
+				.favoritePhotoAccountNo(model.getFavoritePhotoAccountNo())
+				.favoritePhotoNo(model.getFavoritePhotoNo())
+				.createdBy(model.getAccountNo())
+				.build();
+	}
+
+	/**
+	 * PhotoFavoriteDeleteModelからPhotoFavoriteエンティティを生成する
+	 *
+	 * @param	model	{@link PhotoFavoriteDeleteModel}
+	 * @return			{@link PhotoFavorite}
+	 */
+	public static PhotoFavorite from(PhotoFavoriteDeleteModel model) {
+		return PhotoFavorite.builder()
+				.accountNo(model.getAccountNo())
+				.favoritePhotoAccountNo(model.getFavoritePhotoAccountNo())
+				.favoritePhotoNo(model.getFavoritePhotoNo())
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/entity/PhotoMst.java
+++ b/backend/src/main/java/com/web/gallary/entity/PhotoMst.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import com.web.gallary.constant.Consts;
 import com.web.gallary.enumuration.DirectionEnum;
+import com.web.gallary.model.PhotoDeleteModel;
 import com.web.gallary.model.PhotoDetailModel;
 
 import lombok.Builder;
@@ -161,6 +162,45 @@ public class PhotoMst {
 		return PhotoMst.builder()
 				.accountNo(accountNo)
 				.photoNo(photoNo)
+				.build();
+	}
+
+	/**
+	 * 写真削除用のPhotoDeleteModelからターゲットPhotoMstエンティティを生成する
+	 *
+	 * @param	model	{@link PhotoDeleteModel}
+	 * @return			{@link PhotoMst}
+	 */
+	public static PhotoMst targetForDelete(PhotoDeleteModel model) {
+		return PhotoMst.builder()
+				.updatedBy(model.getAccountNo())
+				.isDeleted(true)
+				.build();
+	}
+
+	/**
+	 * 写真存在チェック用のPhotoDetailModelからPhotoMstエンティティを生成する
+	 *
+	 * @param	model	{@link PhotoDetailModel}
+	 * @return			{@link PhotoMst}
+	 */
+	public static PhotoMst conditionForExistCheck(PhotoDetailModel model) {
+		return PhotoMst.builder()
+				.accountNo(model.getAccountNo())
+				.imageFilePath(model.getImageFile().getOriginalFilename())
+				.build();
+	}
+
+	/**
+	 * 写真件数取得用の条件PhotoMstエンティティを生成する
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @return				{@link PhotoMst}
+	 */
+	public static PhotoMst conditionForCount(Integer accountNo) {
+		return PhotoMst.builder()
+				.accountNo(accountNo)
+				.isDeleted(false)
 				.build();
 	}
 }

--- a/backend/src/main/java/com/web/gallary/entity/PhotoMst.java
+++ b/backend/src/main/java/com/web/gallary/entity/PhotoMst.java
@@ -2,8 +2,11 @@ package com.web.gallary.entity;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
+import java.util.Optional;
 
+import com.web.gallary.constant.Consts;
 import com.web.gallary.enumuration.DirectionEnum;
+import com.web.gallary.model.PhotoDetailModel;
 
 import lombok.Builder;
 import lombok.Data;
@@ -74,4 +77,90 @@ public class PhotoMst {
 
 	/** ISO */
 	private Integer iso;
+
+	/**
+	 * 写真登録用のPhotoDetailModelからPhotoMstエンティティを生成する
+	 *
+	 * @param	model		{@link PhotoDetailModel}
+	 * @param	filePath	写真の保存ファイルパス
+	 * @param	newPhotoNo	新規採番した写真番号
+	 * @return				{@link PhotoMst}
+	 */
+	public static PhotoMst fromForRegist(PhotoDetailModel model, String filePath, Integer newPhotoNo) {
+		return PhotoMst.builder()
+				.accountNo(model.getAccountNo())
+				.photoNo(newPhotoNo)
+				.createdBy(model.getAccountNo())
+				.updatedBy(model.getAccountNo())
+				.photoAt(
+					Optional.ofNullable(model.getPhotoAt()).orElse(Consts.MIN_OFFSET_DATE_TIME))
+				.locationNo(
+					Optional.ofNullable(model.getLocationNo()).orElse(0))
+				.imageFilePath(filePath)
+				.photoJapaneseTitle(
+					Optional.ofNullable(model.getPhotoJapaneseTitle()).orElse(Consts.STRING_EMPTY))
+				.photoEnglishTitle(
+					Optional.ofNullable(model.getPhotoEnglishTitle()).orElse(Consts.STRING_EMPTY))
+				.caption(
+					Optional.ofNullable(model.getCaption()).orElse(Consts.STRING_EMPTY))
+				.directionKbn(
+					Optional.ofNullable(model.getDirectionKbn()).orElse(DirectionEnum.NONE))
+				.focalLength(
+					Optional.ofNullable(model.getFocalLength()).orElse(0))
+				.fValue(
+					Optional.ofNullable(model.getFValue()).orElse(BigDecimal.ZERO))
+				.shutterSpeed(
+					Optional.ofNullable(model.getShutterSpeed()).orElse(BigDecimal.ZERO))
+				.iso(
+					Optional.ofNullable(model.getIso()).orElse(0))
+				.build();
+	}
+
+	/**
+	 * 写真更新用のPhotoDetailModelからPhotoMstエンティティを生成する
+	 *
+	 * @param	model	{@link PhotoDetailModel}
+	 * @return			{@link PhotoMst}
+	 */
+	public static PhotoMst targetForUpdate(PhotoDetailModel model) {
+		return PhotoMst.builder()
+				.updatedBy(model.getAccountNo())
+				.isDeleted(false)
+				.photoAt(
+					Optional.ofNullable(model.getPhotoAt()).orElse(Consts.MIN_OFFSET_DATE_TIME))
+				.locationNo(
+					Optional.ofNullable(model.getLocationNo()).orElse(0))
+				.imageFilePath(model.getImageFilePath())
+				.photoJapaneseTitle(
+					Optional.ofNullable(model.getPhotoJapaneseTitle()).orElse(Consts.STRING_EMPTY))
+				.photoEnglishTitle(
+					Optional.ofNullable(model.getPhotoEnglishTitle()).orElse(Consts.STRING_EMPTY))
+				.caption(
+					Optional.ofNullable(model.getCaption()).orElse(Consts.STRING_EMPTY))
+				.directionKbn(
+					Optional.ofNullable(model.getDirectionKbn()).orElse(DirectionEnum.NONE))
+				.focalLength(
+					Optional.ofNullable(model.getFocalLength()).orElse(0))
+				.fValue(
+					Optional.ofNullable(model.getFValue()).orElse(BigDecimal.ZERO))
+				.shutterSpeed(
+					Optional.ofNullable(model.getShutterSpeed()).orElse(BigDecimal.ZERO))
+				.iso(
+					Optional.ofNullable(model.getIso()).orElse(0))
+				.build();
+	}
+
+	/**
+	 * 条件用のPhotoMstエンティティを生成する
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @param	photoNo		写真番号
+	 * @return				{@link PhotoMst}
+	 */
+	public static PhotoMst condition(Integer accountNo, Integer photoNo) {
+		return PhotoMst.builder()
+				.accountNo(accountNo)
+				.photoNo(photoNo)
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/entity/PhotoTagMst.java
+++ b/backend/src/main/java/com/web/gallary/entity/PhotoTagMst.java
@@ -2,6 +2,7 @@ package com.web.gallary.entity;
 
 import java.time.OffsetDateTime;
 
+import com.web.gallary.model.PhotoDetailGetModel;
 import com.web.gallary.model.PhotoTagDeleteModel;
 import com.web.gallary.model.PhotoTagModel;
 
@@ -79,6 +80,19 @@ public class PhotoTagMst {
 		return PhotoTagMst.builder()
 				.accountNo(accountNo)
 				.photoNo(photoNo)
+				.build();
+	}
+
+	/**
+	 * PhotoDetailGetModelから条件用のPhotoTagMstエンティティを生成する
+	 *
+	 * @param	model	{@link PhotoDetailGetModel}
+	 * @return			{@link PhotoTagMst}
+	 */
+	public static PhotoTagMst condition(PhotoDetailGetModel model) {
+		return PhotoTagMst.builder()
+				.accountNo(model.getPhotoAccountNo())
+				.photoNo(model.getPhotoNo())
 				.build();
 	}
 }

--- a/backend/src/main/java/com/web/gallary/entity/PhotoTagMst.java
+++ b/backend/src/main/java/com/web/gallary/entity/PhotoTagMst.java
@@ -3,6 +3,7 @@ package com.web.gallary.entity;
 import java.time.OffsetDateTime;
 
 import com.web.gallary.model.PhotoDetailGetModel;
+import com.web.gallary.model.PhotoGetModel;
 import com.web.gallary.model.PhotoTagDeleteModel;
 import com.web.gallary.model.PhotoTagModel;
 
@@ -93,6 +94,18 @@ public class PhotoTagMst {
 		return PhotoTagMst.builder()
 				.accountNo(model.getPhotoAccountNo())
 				.photoNo(model.getPhotoNo())
+				.build();
+	}
+
+	/**
+	 * PhotoGetModelから条件用のPhotoTagMstエンティティを生成する
+	 *
+	 * @param	model	{@link PhotoGetModel}
+	 * @return			{@link PhotoTagMst}
+	 */
+	public static PhotoTagMst condition(PhotoGetModel model) {
+		return PhotoTagMst.builder()
+				.accountNo(model.getPhotoAccountNo())
 				.build();
 	}
 }

--- a/backend/src/main/java/com/web/gallary/entity/PhotoTagMst.java
+++ b/backend/src/main/java/com/web/gallary/entity/PhotoTagMst.java
@@ -2,6 +2,7 @@ package com.web.gallary.entity;
 
 import java.time.OffsetDateTime;
 
+import com.web.gallary.model.PhotoTagDeleteModel;
 import com.web.gallary.model.PhotoTagModel;
 
 import lombok.Builder;
@@ -51,6 +52,19 @@ public class PhotoTagMst {
 				.createdBy(model.getAccountNo())
 				.tagJapaneseName(model.getTagJapaneseName())
 				.tagEnglishName(model.getTagEnglishName())
+				.build();
+	}
+
+	/**
+	 * 写真タグ削除用のPhotoTagDeleteModelからPhotoTagMstエンティティを生成する
+	 *
+	 * @param	model	{@link PhotoTagDeleteModel}
+	 * @return			{@link PhotoTagMst}
+	 */
+	public static PhotoTagMst fromForDelete(PhotoTagDeleteModel model) {
+		return PhotoTagMst.builder()
+				.accountNo(model.getAccountNo())
+				.photoNo(model.getPhotoNo())
 				.build();
 	}
 }

--- a/backend/src/main/java/com/web/gallary/entity/PhotoTagMst.java
+++ b/backend/src/main/java/com/web/gallary/entity/PhotoTagMst.java
@@ -2,6 +2,8 @@ package com.web.gallary.entity;
 
 import java.time.OffsetDateTime;
 
+import com.web.gallary.model.PhotoTagModel;
+
 import lombok.Builder;
 import lombok.Data;
 
@@ -34,4 +36,21 @@ public class PhotoTagMst {
 
 	/** タグ英語名 */
 	private String tagEnglishName;
+
+	/**
+	 * PhotoTagModelからPhotoTagMstエンティティを生成する
+	 *
+	 * @param	model	{@link PhotoTagModel}
+	 * @return			{@link PhotoTagMst}
+	 */
+	public static PhotoTagMst from(PhotoTagModel model) {
+		return PhotoTagMst.builder()
+				.accountNo(model.getAccountNo())
+				.photoNo(model.getPhotoNo())
+				.tagNo(model.getTagNo())
+				.createdBy(model.getAccountNo())
+				.tagJapaneseName(model.getTagJapaneseName())
+				.tagEnglishName(model.getTagEnglishName())
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/entity/PhotoTagMst.java
+++ b/backend/src/main/java/com/web/gallary/entity/PhotoTagMst.java
@@ -71,20 +71,6 @@ public class PhotoTagMst {
 	}
 
 	/**
-	 * 条件用のPhotoTagMstエンティティを生成する
-	 *
-	 * @param	accountNo	アカウント番号
-	 * @param	photoNo		写真番号（nullの場合はアカウント番号のみで検索）
-	 * @return				{@link PhotoTagMst}
-	 */
-	public static PhotoTagMst condition(Integer accountNo, Integer photoNo) {
-		return PhotoTagMst.builder()
-				.accountNo(accountNo)
-				.photoNo(photoNo)
-				.build();
-	}
-
-	/**
 	 * PhotoDetailGetModelから条件用のPhotoTagMstエンティティを生成する
 	 *
 	 * @param	model	{@link PhotoDetailGetModel}

--- a/backend/src/main/java/com/web/gallary/entity/PhotoTagMst.java
+++ b/backend/src/main/java/com/web/gallary/entity/PhotoTagMst.java
@@ -61,7 +61,7 @@ public class PhotoTagMst {
 	 * @param	model	{@link PhotoTagDeleteModel}
 	 * @return			{@link PhotoTagMst}
 	 */
-	public static PhotoTagMst fromForDelete(PhotoTagDeleteModel model) {
+	public static PhotoTagMst from(PhotoTagDeleteModel model) {
 		return PhotoTagMst.builder()
 				.accountNo(model.getAccountNo())
 				.photoNo(model.getPhotoNo())

--- a/backend/src/main/java/com/web/gallary/entity/PhotoTagMst.java
+++ b/backend/src/main/java/com/web/gallary/entity/PhotoTagMst.java
@@ -67,4 +67,18 @@ public class PhotoTagMst {
 				.photoNo(model.getPhotoNo())
 				.build();
 	}
+
+	/**
+	 * 条件用のPhotoTagMstエンティティを生成する
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @param	photoNo		写真番号（nullの場合はアカウント番号のみで検索）
+	 * @return				{@link PhotoTagMst}
+	 */
+	public static PhotoTagMst condition(Integer accountNo, Integer photoNo) {
+		return PhotoTagMst.builder()
+				.accountNo(accountNo)
+				.photoNo(photoNo)
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/entity/RefreshToken.java
+++ b/backend/src/main/java/com/web/gallary/entity/RefreshToken.java
@@ -2,6 +2,8 @@ package com.web.gallary.entity;
 
 import java.time.OffsetDateTime;
 
+import com.web.gallary.model.RefreshTokenModel;
+
 import lombok.Builder;
 import lombok.Data;
 
@@ -31,4 +33,18 @@ public class RefreshToken {
 
 	/** 無効化フラグ */
 	private Boolean isRevoked;
+
+	/**
+	 * RefreshTokenModelからRefreshTokenエンティティを生成する
+	 *
+	 * @param	model	{@link RefreshTokenModel}
+	 * @return			{@link RefreshToken}
+	 */
+	public static RefreshToken from(RefreshTokenModel model) {
+		return RefreshToken.builder()
+				.accountNo(model.getAccountNo())
+				.tokenHash(model.getTokenHash())
+				.expiresAt(model.getExpiresAt())
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/model/AccountModel.java
+++ b/backend/src/main/java/com/web/gallary/model/AccountModel.java
@@ -5,6 +5,7 @@ import java.time.OffsetDateTime;
 
 import com.web.gallary.controller.request.AccountRegistRequest;
 import com.web.gallary.controller.request.AccountUpdateRequest;
+import com.web.gallary.entity.Account;
 import com.web.gallary.enumuration.AuthorityEnum;
 import com.web.gallary.enumuration.SexEnum;
 
@@ -63,6 +64,30 @@ public class AccountModel {
 
 	/** 削除フラグ */
 	private Boolean isDeleted;
+
+	/**
+	 * AccountエンティティからAccountModelを生成する
+	 *
+	 * @param	entity	{@link Account}
+	 * @return			{@link AccountModel}
+	 */
+	public static AccountModel from(Account entity) {
+		return AccountModel.builder()
+				.accountNo(entity.getAccountNo())
+				.accountId(entity.getAccountId())
+				.accountName(entity.getAccountName())
+				.password(entity.getPassword())
+				.birthdate(entity.getBirthdate())
+				.sexKbn(entity.getSexKbn())
+				.birthplacePrefectureKbnCode(entity.getBirthplacePrefectureKbnCode())
+				.residentPrefectureKbnCode(entity.getResidentPrefectureKbnCode())
+				.freeMemo(entity.getFreeMemo())
+				.authorityKbn(entity.getAuthorityKbn())
+				.lastLoginDatetime(entity.getLastLoginDatetime())
+				.loginFailureCount(entity.getLoginFailureCount())
+				.isDeleted(entity.getIsDeleted())
+				.build();
+	}
 
 	/**
 	 * アカウント登録リクエストからAccountModelを生成する

--- a/backend/src/main/java/com/web/gallary/model/KbnMstModel.java
+++ b/backend/src/main/java/com/web/gallary/model/KbnMstModel.java
@@ -1,5 +1,7 @@
 package com.web.gallary.model;
 
+import com.web.gallary.entity.KbnMst;
+
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
@@ -53,4 +55,26 @@ public class KbnMstModel {
 	/** 説明 */
 	@NonNull
 	private String explanation;
+
+	/**
+	 * KbnMstエンティティからKbnMstModelを生成する
+	 *
+	 * @param	entity	{@link KbnMst}
+	 * @return			{@link KbnMstModel}
+	 */
+	public static KbnMstModel from(KbnMst entity) {
+		return KbnMstModel.builder()
+				.kbnClassCode(entity.getKbnClassCode())
+				.kbnCode(entity.getKbnCode())
+				.sortOrder(entity.getSortOrder())
+				.kbnGroupCode(entity.getKbnGroupCode())
+				.kbnClassJapaneseName(entity.getKbnClassJapaneseName())
+				.kbnGroupJapaneseName(entity.getKbnGroupJapaneseName())
+				.kbnJapaneseName(entity.getKbnJapaneseName())
+				.kbnClassEnglishName(entity.getKbnClassEnglishName())
+				.kbnGroupEnglishName(entity.getKbnGroupEnglishName())
+				.kbnEnglishName(entity.getKbnEnglishName())
+				.explanation(entity.getExplanation())
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/model/PhotoDetailModel.java
+++ b/backend/src/main/java/com/web/gallary/model/PhotoDetailModel.java
@@ -12,6 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.web.gallary.constant.Consts;
 import com.web.gallary.controller.request.PhotoSaveRequest;
+import com.web.gallary.dto.PhotoDetailDto;
 import com.web.gallary.enumuration.DirectionEnum;
 
 import lombok.Builder;
@@ -89,6 +90,38 @@ public class PhotoDetailModel {
 	
 	/** 写真タグリスト */
 	private List<PhotoTagModel> photoTagModelList;
+
+	/**
+	 * PhotoDetailDtoとタグリストからPhotoDetailModelを生成する
+	 *
+	 * @param	dto		{@link PhotoDetailDto}
+	 * @param	tagList	該当写真のタグリスト
+	 * @return			{@link PhotoDetailModel}
+	 */
+	public static PhotoDetailModel from(PhotoDetailDto dto, List<PhotoTagModel> tagList) {
+		return PhotoDetailModel.builder()
+				.accountNo(dto.getAccountNo())
+				.photoNo(dto.getPhotoNo())
+				.isFavorite(dto.getIsFavorite())
+				.photoAt(
+					dto.getPhotoAt().isEqual(Consts.MIN_OFFSET_DATE_TIME) ? null : dto.getPhotoAt().plusHours(9))
+				.locationNo(dto.getLocationNo())
+				.address(dto.getAddress())
+				.latitude(dto.getLatitude())
+				.longitude(dto.getLongitude())
+				.locationName(dto.getLocationName())
+				.imageFilePath(dto.getImageFilePath())
+				.photoJapaneseTitle(dto.getPhotoJapaneseTitle())
+				.photoEnglishTitle(dto.getPhotoEnglishTitle())
+				.caption(dto.getCaption())
+				.directionKbn(dto.getDirectionKbn())
+				.focalLength(dto.getFocalLength() != 0 ? dto.getFocalLength() : null)
+				.fValue(dto.getFValue().compareTo(BigDecimal.ZERO) == 1 ? dto.getFValue() : null)
+				.shutterSpeed(dto.getShutterSpeed().compareTo(BigDecimal.ZERO) == 1 ? dto.getShutterSpeed() : null)
+				.iso(dto.getIso() != 0 ? dto.getIso() : null)
+				.photoTagModelList(tagList)
+				.build();
+	}
 
 	/**
 	 * 写真保存リクエストからPhotoDetailModelを生成する

--- a/backend/src/main/java/com/web/gallary/model/PhotoDetailModel.java
+++ b/backend/src/main/java/com/web/gallary/model/PhotoDetailModel.java
@@ -13,6 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.web.gallary.constant.Consts;
 import com.web.gallary.controller.request.PhotoSaveRequest;
 import com.web.gallary.dto.PhotoDetailDto;
+import com.web.gallary.entity.PhotoTagMst;
 import com.web.gallary.enumuration.DirectionEnum;
 
 import lombok.Builder;
@@ -92,13 +93,14 @@ public class PhotoDetailModel {
 	private List<PhotoTagModel> photoTagModelList;
 
 	/**
-	 * PhotoDetailDtoとタグリストからPhotoDetailModelを生成する
+	 * PhotoDetailDtoとタグエンティティリストからPhotoDetailModelを生成する
 	 *
-	 * @param	dto		{@link PhotoDetailDto}
-	 * @param	tagList	該当写真のタグリスト
-	 * @return			{@link PhotoDetailModel}
+	 * @param	dto				{@link PhotoDetailDto}
+	 * @param	photoTagMstList	該当写真のタグエンティティリスト
+	 * @return					{@link PhotoDetailModel}
 	 */
-	public static PhotoDetailModel from(PhotoDetailDto dto, List<PhotoTagModel> tagList) {
+	public static PhotoDetailModel from(PhotoDetailDto dto, List<PhotoTagMst> photoTagMstList) {
+		List<PhotoTagModel> photoTagModelList = photoTagMstList.stream().map(PhotoTagModel::from).toList();
 		return PhotoDetailModel.builder()
 				.accountNo(dto.getAccountNo())
 				.photoNo(dto.getPhotoNo())
@@ -119,7 +121,7 @@ public class PhotoDetailModel {
 				.fValue(dto.getFValue().compareTo(BigDecimal.ZERO) == 1 ? dto.getFValue() : null)
 				.shutterSpeed(dto.getShutterSpeed().compareTo(BigDecimal.ZERO) == 1 ? dto.getShutterSpeed() : null)
 				.iso(dto.getIso() != 0 ? dto.getIso() : null)
-				.photoTagModelList(tagList)
+				.photoTagModelList(photoTagModelList)
 				.build();
 	}
 

--- a/backend/src/main/java/com/web/gallary/model/PhotoModel.java
+++ b/backend/src/main/java/com/web/gallary/model/PhotoModel.java
@@ -4,6 +4,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 import com.web.gallary.dto.PhotoDto;
+import com.web.gallary.entity.PhotoTagMst;
 import com.web.gallary.enumuration.DirectionEnum;
 
 import lombok.Builder;
@@ -57,13 +58,14 @@ public class PhotoModel {
 	private List<PhotoTagModel> photoTagModelList;
 
 	/**
-	 * PhotoDtoとタグリストからPhotoModelを生成する
+	 * PhotoDtoとタグエンティティリストからPhotoModelを生成する
 	 *
-	 * @param	dto		{@link PhotoDto}
-	 * @param	tagList	該当写真のタグリスト
-	 * @return			{@link PhotoModel}
+	 * @param	dto				{@link PhotoDto}
+	 * @param	photoTagMstList	該当写真のタグエンティティリスト
+	 * @return					{@link PhotoModel}
 	 */
-	public static PhotoModel from(PhotoDto dto, List<PhotoTagModel> tagList) {
+	public static PhotoModel from(PhotoDto dto, List<PhotoTagMst> photoTagMstList) {
+		List<PhotoTagModel> photoTagModelList = photoTagMstList.stream().map(PhotoTagModel::from).toList();
 		return PhotoModel.builder()
 				.accountNo(dto.getAccountNo())
 				.photoNo(dto.getPhotoNo())
@@ -73,7 +75,7 @@ public class PhotoModel {
 				.imageFilePath(dto.getImageFilePath())
 				.caption(dto.getCaption())
 				.directionKbn(dto.getDirectionKbn())
-				.photoTagModelList(tagList)
+				.photoTagModelList(photoTagModelList)
 				.build();
 	}
 }

--- a/backend/src/main/java/com/web/gallary/model/PhotoModel.java
+++ b/backend/src/main/java/com/web/gallary/model/PhotoModel.java
@@ -2,6 +2,7 @@ package com.web.gallary.model;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 
 import com.web.gallary.dto.PhotoDto;
 import com.web.gallary.entity.PhotoTagMst;
@@ -61,11 +62,16 @@ public class PhotoModel {
 	 * PhotoDtoとタグエンティティリストからPhotoModelを生成する
 	 *
 	 * @param	dto				{@link PhotoDto}
-	 * @param	photoTagMstList	該当写真のタグエンティティリスト
+	 * @param	photoTagMstList	全タグエンティティリスト（内部で該当写真のタグをフィルタリングする）
 	 * @return					{@link PhotoModel}
 	 */
 	public static PhotoModel from(PhotoDto dto, List<PhotoTagMst> photoTagMstList) {
-		List<PhotoTagModel> photoTagModelList = photoTagMstList.stream().map(PhotoTagModel::from).toList();
+		List<PhotoTagModel> photoTagModelList = photoTagMstList.stream()
+				.filter(tag ->
+					tag.getAccountNo().equals(dto.getAccountNo()) &&
+					Objects.equals(tag.getPhotoNo(), dto.getPhotoNo()))
+				.map(PhotoTagModel::from)
+				.toList();
 		return PhotoModel.builder()
 				.accountNo(dto.getAccountNo())
 				.photoNo(dto.getPhotoNo())

--- a/backend/src/main/java/com/web/gallary/model/PhotoModel.java
+++ b/backend/src/main/java/com/web/gallary/model/PhotoModel.java
@@ -3,6 +3,7 @@ package com.web.gallary.model;
 import java.time.OffsetDateTime;
 import java.util.List;
 
+import com.web.gallary.dto.PhotoDto;
 import com.web.gallary.enumuration.DirectionEnum;
 
 import lombok.Builder;
@@ -54,4 +55,25 @@ public class PhotoModel {
 	/** 写真タグリスト */
 	@NonNull
 	private List<PhotoTagModel> photoTagModelList;
+
+	/**
+	 * PhotoDtoとタグリストからPhotoModelを生成する
+	 *
+	 * @param	dto		{@link PhotoDto}
+	 * @param	tagList	該当写真のタグリスト
+	 * @return			{@link PhotoModel}
+	 */
+	public static PhotoModel from(PhotoDto dto, List<PhotoTagModel> tagList) {
+		return PhotoModel.builder()
+				.accountNo(dto.getAccountNo())
+				.photoNo(dto.getPhotoNo())
+				.favoriteCount(dto.getFavoriteCount())
+				.isFavorite(dto.getIsFavorite())
+				.photoAt(dto.getPhotoAt().plusHours(9))
+				.imageFilePath(dto.getImageFilePath())
+				.caption(dto.getCaption())
+				.directionKbn(dto.getDirectionKbn())
+				.photoTagModelList(tagList)
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/model/PhotoTagModel.java
+++ b/backend/src/main/java/com/web/gallary/model/PhotoTagModel.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import com.web.gallary.constant.Consts;
 import com.web.gallary.controller.request.PhotoTagSaveRequest;
+import com.web.gallary.entity.PhotoTagMst;
 
 import lombok.Builder;
 import lombok.NonNull;
@@ -32,6 +33,22 @@ public class PhotoTagModel {
 	/** タグ英語名 */
 	@NonNull
 	private String tagEnglishName;
+
+	/**
+	 * PhotoTagMstエンティティからPhotoTagModelを生成する
+	 *
+	 * @param	entity	{@link PhotoTagMst}
+	 * @return			{@link PhotoTagModel}
+	 */
+	public static PhotoTagModel from(PhotoTagMst entity) {
+		return PhotoTagModel.builder()
+				.accountNo(entity.getAccountNo())
+				.photoNo(entity.getPhotoNo())
+				.tagNo(entity.getTagNo())
+				.tagJapaneseName(entity.getTagJapaneseName())
+				.tagEnglishName(entity.getTagEnglishName())
+				.build();
+	}
 
 	/**
 	 * 写真タグ保存リクエストからPhotoTagModelを生成する

--- a/backend/src/main/java/com/web/gallary/model/RefreshTokenModel.java
+++ b/backend/src/main/java/com/web/gallary/model/RefreshTokenModel.java
@@ -2,6 +2,8 @@ package com.web.gallary.model;
 
 import java.time.OffsetDateTime;
 
+import com.web.gallary.entity.RefreshToken;
+
 import lombok.Builder;
 import lombok.Value;
 
@@ -25,4 +27,19 @@ public class RefreshTokenModel {
 
 	/** 無効化フラグ */
 	private Boolean isRevoked;
+
+	/**
+	 * RefreshTokenエンティティからRefreshTokenModelを生成する
+	 *
+	 * @param	entity	{@link RefreshToken}
+	 * @return			{@link RefreshTokenModel}
+	 */
+	public static RefreshTokenModel from(RefreshToken entity) {
+		return RefreshTokenModel.builder()
+				.accountNo(entity.getAccountNo())
+				.tokenHash(entity.getTokenHash())
+				.expiresAt(entity.getExpiresAt())
+				.isRevoked(entity.getIsRevoked())
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallary/repository/impl/AccountRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/AccountRepositoryImpl.java
@@ -1,18 +1,13 @@
 package com.web.gallary.repository.impl;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Repository;
 
-import com.web.gallary.constant.Consts;
 import com.web.gallary.entity.Account;
-import com.web.gallary.enumuration.AuthorityEnum;
 import com.web.gallary.enumuration.ErrorEnum;
-import com.web.gallary.enumuration.SexEnum;
 import com.web.gallary.exception.RegistFailureException;
 import com.web.gallary.exception.UpdateFailureException;
 import com.web.gallary.mapper.AccountMapper;
@@ -48,7 +43,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 
 		List<Account> accountList = accountMapper.select(account);
 
-		return accountList.isEmpty() ? null : toAccountModel(accountList.getFirst());
+		return accountList.isEmpty() ? null : AccountModel.from(accountList.getFirst());
 	}
 
 	/**
@@ -66,7 +61,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 
 		List<Account> accountList = accountMapper.select(account);
 
-		return accountList.isEmpty() ? null : toAccountModel(accountList.getFirst());
+		return accountList.isEmpty() ? null : AccountModel.from(accountList.getFirst());
 	}
 
 	/**
@@ -77,26 +72,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public void regist(AccountModel accountModel) throws RegistFailureException {
-		Account account = Account.builder()
-			.createdBy(0)
-			.updatedBy(0)
-			.accountId(accountModel.getAccountId())
-			.accountName(accountModel.getAccountName())
-			.password(passwordEncoder.encode(accountModel.getPassword()))
-			.birthdate(
-				Optional.ofNullable(accountModel.getBirthdate()).orElse(Consts.MIN_LOCAL_DATE))
-			.sexKbn(
-				Optional.ofNullable(accountModel.getSexKbn()).orElse(SexEnum.NONE))
-			.birthplacePrefectureKbnCode(
-				Optional.ofNullable(accountModel.getBirthplacePrefectureKbnCode()).orElse(Consts.STRING_NONE))
-			.residentPrefectureKbnCode(
-				Optional.ofNullable(accountModel.getResidentPrefectureKbnCode()).orElse(Consts.STRING_NONE))
-			.freeMemo(
-				Optional.ofNullable(accountModel.getFreeMemo()).orElse(Consts.STRING_EMPTY))
-			.authorityKbn(AuthorityEnum.MINI)
-			.lastLoginDatetime(Consts.MIN_OFFSET_DATE_TIME)
-			.loginFailureCount(0)
-			.build();
+		Account account = Account.from(accountModel, passwordEncoder);
 		
 		try {
 			accountMapper.insert(account);
@@ -116,30 +92,8 @@ public class AccountRepositoryImpl implements AccountRepository {
 	@Override
 	public void update(AccountModel accountModel) throws UpdateFailureException {
 		Account cndAccount = Account.builder().accountNo(accountModel.getAccountNo()).build();
-		
-		Account targetAccount = Account.builder()
-				.accountId(accountModel.getAccountId())
-				.accountName(accountModel.getAccountName())
-				.birthdate(
-					Optional.ofNullable(accountModel.getBirthdate()).orElse(Consts.MIN_LOCAL_DATE))
-				.sexKbn(
-					Optional.ofNullable(accountModel.getSexKbn()).orElse(SexEnum.NONE))
-				.birthplacePrefectureKbnCode(
-					Optional.ofNullable(accountModel.getBirthplacePrefectureKbnCode()).orElse(Consts.STRING_NONE))
-				.residentPrefectureKbnCode(
-					Optional.ofNullable(accountModel.getResidentPrefectureKbnCode()).orElse(Consts.STRING_NONE))
-				.freeMemo(
-					Optional.ofNullable(accountModel.getFreeMemo()).orElse(Consts.STRING_EMPTY))
-				.lastLoginDatetime(
-					Optional.ofNullable(accountModel.getLastLoginDatetime()).orElse(Consts.MIN_OFFSET_DATE_TIME))
-				.loginFailureCount(
-					Optional.ofNullable(accountModel.getLoginFailureCount()).orElse(0))
-				.build();
-		
-		if(!Objects.isNull(accountModel.getPassword())) {
-			targetAccount.setPassword(passwordEncoder.encode(accountModel.getPassword()));
-		}
-		
+		Account targetAccount = Account.fromForUpdate(accountModel, passwordEncoder);
+
 		if (accountMapper.update(cndAccount, targetAccount) < 1) {
 			log.warn("Account: Update Failed (AccountNo: {})", accountModel.getAccountNo());
 			throw new UpdateFailureException(ErrorEnum.FAIL_TO_UPDATE_ACCOUNT);
@@ -155,12 +109,8 @@ public class AccountRepositoryImpl implements AccountRepository {
 	@Override
 	public void updateLoginFailureCount(AccountModel accountModel) throws UpdateFailureException {
 		Account cndAccount = Account.builder().accountNo(accountModel.getAccountNo()).build();
-		
-		Account targetAccount = Account.builder()
-				.lastLoginDatetime(accountModel.getLastLoginDatetime())
-				.loginFailureCount(Optional.ofNullable(accountModel.getLoginFailureCount()).orElse(0))
-				.build();
-		
+		Account targetAccount = Account.fromForUpdateLoginFailure(accountModel);
+
 		if (accountMapper.update(cndAccount, targetAccount) < 1) {
 			log.warn("Account: Update Failed (AccountNo: {})", accountModel.getAccountNo());
 			throw new UpdateFailureException(ErrorEnum.FAIL_TO_UPDATE_ACCOUNT);
@@ -191,30 +141,6 @@ public class AccountRepositoryImpl implements AccountRepository {
 
 		List<Account> accountList = accountMapper.select(account);
 
-		return accountList.stream().map(this::toAccountModel).toList();
-	}
-
-	/**
-	 * AccountエンティティからAccountModelに変換する
-	 *
-	 * @param	account	{@link Account}
-	 * @return			{@link AccountModel}
-	 */
-	private AccountModel toAccountModel(Account account) {
-		return AccountModel.builder()
-				.accountNo(account.getAccountNo())
-				.accountId(account.getAccountId())
-				.accountName(account.getAccountName())
-				.password(account.getPassword())
-				.birthdate(account.getBirthdate())
-				.sexKbn(account.getSexKbn())
-				.birthplacePrefectureKbnCode(account.getBirthplacePrefectureKbnCode())
-				.residentPrefectureKbnCode(account.getResidentPrefectureKbnCode())
-				.freeMemo(account.getFreeMemo())
-				.authorityKbn(account.getAuthorityKbn())
-				.lastLoginDatetime(account.getLastLoginDatetime())
-				.loginFailureCount(account.getLoginFailureCount())
-				.isDeleted(account.getIsDeleted())
-				.build();
+		return accountList.stream().map(AccountModel::from).toList();
 	}
 }

--- a/backend/src/main/java/com/web/gallary/repository/impl/AccountRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/AccountRepositoryImpl.java
@@ -37,12 +37,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public AccountModel getByAccountNo(Integer accountNo) {
-		Account account = Account.builder()
-				.accountNo(accountNo)
-				.build();
-
-		List<Account> accountList = accountMapper.select(account);
-
+		List<Account> accountList = accountMapper.select(Account.conditionByAccountNo(accountNo));
 		return accountList.isEmpty() ? null : AccountModel.from(accountList.getFirst());
 	}
 
@@ -55,12 +50,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public AccountModel getByAccountId(String accountId) {
-		Account account = Account.builder()
-				.accountId(accountId)
-				.build();
-
-		List<Account> accountList = accountMapper.select(account);
-
+		List<Account> accountList = accountMapper.select(Account.conditionByAccountId(accountId));
 		return accountList.isEmpty() ? null : AccountModel.from(accountList.getFirst());
 	}
 
@@ -91,7 +81,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public void update(AccountModel accountModel) throws UpdateFailureException {
-		Account cndAccount = Account.builder().accountNo(accountModel.getAccountNo()).build();
+		Account cndAccount = Account.conditionByAccountNo(accountModel.getAccountNo());
 		Account targetAccount = Account.fromForUpdate(accountModel, passwordEncoder);
 
 		if (accountMapper.update(cndAccount, targetAccount) < 1) {
@@ -108,7 +98,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public void updateLoginFailureCount(AccountModel accountModel) throws UpdateFailureException {
-		Account cndAccount = Account.builder().accountNo(accountModel.getAccountNo()).build();
+		Account cndAccount = Account.conditionByAccountNo(accountModel.getAccountNo());
 		Account targetAccount = Account.fromForUpdateLoginFailure(accountModel);
 
 		if (accountMapper.update(cndAccount, targetAccount) < 1) {
@@ -126,8 +116,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public Boolean isExistAccount(Integer accountNo, String accountId) {
-		Account account =  Account.builder().accountNo(accountNo).accountId(accountId).build();
-		return accountMapper.isExistAccount(account);
+		return accountMapper.isExistAccount(Account.conditionForExistCheck(accountNo, accountId));
 	}
 	
 	/**
@@ -137,10 +126,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public List<AccountModel> getAccountList() {
-		Account account = Account.builder().isDeleted(false).build();
-
-		List<Account> accountList = accountMapper.select(account);
-
+		List<Account> accountList = accountMapper.select(Account.conditionForList());
 		return accountList.stream().map(AccountModel::from).toList();
 	}
 }

--- a/backend/src/main/java/com/web/gallary/repository/impl/KbnMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/KbnMstRepositoryImpl.java
@@ -28,10 +28,7 @@ public class KbnMstRepositoryImpl implements KbnMstRepository {
 	 */
 	@Override
 	public List<KbnMstModel> get(String kbnClassCode) {
-		KbnMst kbnMst = KbnMst.builder()
-				.kbnClassCode(kbnClassCode)
-				.build();
-		List<KbnMst> kbnMstList = kbnMstMapper.select(kbnMst);
+		List<KbnMst> kbnMstList = kbnMstMapper.select(KbnMst.condition(kbnClassCode));
 
 		return kbnMstList.stream().map(KbnMstModel::from).toList();
 	}

--- a/backend/src/main/java/com/web/gallary/repository/impl/KbnMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/KbnMstRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.web.gallary.repository.impl;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
@@ -32,28 +31,8 @@ public class KbnMstRepositoryImpl implements KbnMstRepository {
 		KbnMst kbnMst = KbnMst.builder()
 				.kbnClassCode(kbnClassCode)
 				.build();
-		List<KbnMst> KbnMstList = kbnMstMapper.select(kbnMst);
-		
-		List<KbnMstModel> kbnMstModelList = new ArrayList<KbnMstModel>();
-		
-		KbnMstList.stream().forEach(kbnMstData -> {
-			kbnMstModelList.add(
-					KbnMstModel.builder()
-						.kbnClassCode(kbnMstData.getKbnClassCode())
-						.kbnCode(kbnMstData.getKbnCode())
-						.sortOrder(kbnMstData.getSortOrder())
-						.kbnGroupCode(kbnMstData.getKbnGroupCode())
-						.kbnClassJapaneseName(kbnMstData.getKbnClassJapaneseName())
-						.kbnGroupJapaneseName(kbnMstData.getKbnGroupJapaneseName())
-						.kbnJapaneseName(kbnMstData.getKbnJapaneseName())
-						.kbnClassEnglishName(kbnMstData.getKbnClassEnglishName())
-						.kbnGroupEnglishName(kbnMstData.getKbnGroupEnglishName())
-						.kbnEnglishName(kbnMstData.getKbnEnglishName())
-						.explanation(kbnMstData.getExplanation())
-						.build()
-				);
-		});
-		
-		return kbnMstModelList;
+		List<KbnMst> kbnMstList = kbnMstMapper.select(kbnMst);
+
+		return kbnMstList.stream().map(KbnMstModel::from).toList();
 	}
 }

--- a/backend/src/main/java/com/web/gallary/repository/impl/PhotoDetailRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/PhotoDetailRepositoryImpl.java
@@ -57,8 +57,8 @@ public class PhotoDetailRepositoryImpl implements PhotoDetailRepository {
 		List<PhotoModel> photoModelList = new ArrayList<PhotoModel>();
 		photoDtoList.stream().forEach(photoDto -> {
 			List<PhotoTagModel> tagList = photoTagModelList.stream().filter(photoTagModel ->
-					photoTagModel.getAccountNo() == photoDto.getAccountNo() &&
-					photoTagModel.getPhotoNo()   == photoDto.getPhotoNo()
+                    photoTagModel.getAccountNo().equals(photoDto.getAccountNo()) &&
+                            Objects.equals(photoTagModel.getPhotoNo(), photoDto.getPhotoNo())
 				).toList();
 			photoModelList.add(PhotoModel.from(photoDto, tagList));
 		});
@@ -85,7 +85,7 @@ public class PhotoDetailRepositoryImpl implements PhotoDetailRepository {
 		}
 		
 		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(
-				PhotoTagMst.condition(photoDetailGetModel.getPhotoAccountNo(), photoDetailGetModel.getPhotoNo()));
+				PhotoTagMst.condition(photoDetailGetModel));
 
 		List<PhotoTagModel> photoTagModelList = photoTagMstList.stream().map(PhotoTagModel::from).toList();
 

--- a/backend/src/main/java/com/web/gallary/repository/impl/PhotoDetailRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/PhotoDetailRepositoryImpl.java
@@ -50,13 +50,9 @@ public class PhotoDetailRepositoryImpl implements PhotoDetailRepository {
 		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(
 				PhotoTagMst.condition(photoGetModel));
 
-		return photoDtoList.stream().map(photoDto -> {
-			List<PhotoTagMst> tagMstList = photoTagMstList.stream().filter(tag ->
-					tag.getAccountNo().equals(photoDto.getAccountNo()) &&
-					Objects.equals(tag.getPhotoNo(), photoDto.getPhotoNo())
-				).toList();
-			return PhotoModel.from(photoDto, tagMstList);
-		}).toList();
+		return photoDtoList.stream()
+				.map(photoDto -> PhotoModel.from(photoDto, photoTagMstList))
+				.toList();
 	}
 	
 	/**

--- a/backend/src/main/java/com/web/gallary/repository/impl/PhotoDetailRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/PhotoDetailRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.web.gallary.repository.impl;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -20,7 +19,6 @@ import com.web.gallary.model.PhotoDetailGetModel;
 import com.web.gallary.model.PhotoDetailModel;
 import com.web.gallary.model.PhotoGetModel;
 import com.web.gallary.model.PhotoModel;
-import com.web.gallary.model.PhotoTagModel;
 import com.web.gallary.repository.PhotoDetailRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -52,18 +50,13 @@ public class PhotoDetailRepositoryImpl implements PhotoDetailRepository {
 		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(
 				PhotoTagMst.condition(photoGetModel));
 
-		List<PhotoTagModel> photoTagModelList = photoTagMstList.stream().map(PhotoTagModel::from).toList();
-
-		List<PhotoModel> photoModelList = new ArrayList<PhotoModel>();
-		photoDtoList.stream().forEach(photoDto -> {
-			List<PhotoTagModel> tagList = photoTagModelList.stream().filter(photoTagModel ->
-                    photoTagModel.getAccountNo().equals(photoDto.getAccountNo()) &&
-                            Objects.equals(photoTagModel.getPhotoNo(), photoDto.getPhotoNo())
+		return photoDtoList.stream().map(photoDto -> {
+			List<PhotoTagMst> tagMstList = photoTagMstList.stream().filter(tag ->
+					tag.getAccountNo().equals(photoDto.getAccountNo()) &&
+					Objects.equals(tag.getPhotoNo(), photoDto.getPhotoNo())
 				).toList();
-			photoModelList.add(PhotoModel.from(photoDto, tagList));
-		});
-
-		return photoModelList;
+			return PhotoModel.from(photoDto, tagMstList);
+		}).toList();
 	}
 	
 	/**

--- a/backend/src/main/java/com/web/gallary/repository/impl/PhotoDetailRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/PhotoDetailRepositoryImpl.java
@@ -50,7 +50,7 @@ public class PhotoDetailRepositoryImpl implements PhotoDetailRepository {
 		List<PhotoDto> photoDtoList = photoDetailMapper.getPhotoList(photoListGetDto);
 		
 		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(
-				PhotoTagMst.condition(photoGetModel.getPhotoAccountNo(), null));
+				PhotoTagMst.condition(photoGetModel));
 
 		List<PhotoTagModel> photoTagModelList = photoTagMstList.stream().map(PhotoTagModel::from).toList();
 

--- a/backend/src/main/java/com/web/gallary/repository/impl/PhotoDetailRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/PhotoDetailRepositoryImpl.java
@@ -49,10 +49,8 @@ public class PhotoDetailRepositoryImpl implements PhotoDetailRepository {
 		PhotoListGetDto photoListGetDto = modelMapper.map(photoGetModel, PhotoListGetDto.class);
 		List<PhotoDto> photoDtoList = photoDetailMapper.getPhotoList(photoListGetDto);
 		
-		PhotoTagMst photoTagMst = PhotoTagMst.builder()
-				.accountNo(photoGetModel.getPhotoAccountNo())
-				.build();
-		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(photoTagMst);
+		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(
+				PhotoTagMst.condition(photoGetModel.getPhotoAccountNo(), null));
 
 		List<PhotoTagModel> photoTagModelList = photoTagMstList.stream().map(PhotoTagModel::from).toList();
 
@@ -86,11 +84,8 @@ public class PhotoDetailRepositoryImpl implements PhotoDetailRepository {
 			throw new PhotoNotFoundException(ErrorEnum.PHOTO_NOT_FOUND);
 		}
 		
-		PhotoTagMst photoTagMst = PhotoTagMst.builder()
-				.accountNo(photoDetailGetModel.getPhotoAccountNo())
-				.photoNo(photoDetailGetModel.getPhotoNo())
-				.build();
-		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(photoTagMst);
+		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(
+				PhotoTagMst.condition(photoDetailGetModel.getPhotoAccountNo(), photoDetailGetModel.getPhotoNo()));
 
 		List<PhotoTagModel> photoTagModelList = photoTagMstList.stream().map(PhotoTagModel::from).toList();
 

--- a/backend/src/main/java/com/web/gallary/repository/impl/PhotoDetailRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/PhotoDetailRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.web.gallary.repository.impl;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -8,7 +7,6 @@ import java.util.Objects;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Repository;
 
-import com.web.gallary.constant.Consts;
 import com.web.gallary.dto.PhotoDetailDto;
 import com.web.gallary.dto.PhotoDetailGetDto;
 import com.web.gallary.dto.PhotoDto;
@@ -55,37 +53,18 @@ public class PhotoDetailRepositoryImpl implements PhotoDetailRepository {
 				.accountNo(photoGetModel.getPhotoAccountNo())
 				.build();
 		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(photoTagMst);
-		
-		List<PhotoTagModel> photoTagModelList
-			= photoTagMstList.stream().map(photoTagModel -> PhotoTagModel.builder()
-					.accountNo(photoTagModel.getAccountNo())
-					.photoNo(photoTagModel.getPhotoNo())
-					.tagNo(photoTagModel.getTagNo())
-					.tagJapaneseName(photoTagModel.getTagJapaneseName())
-					.tagEnglishName(photoTagModel.getTagEnglishName())
-					.build()
-				).toList();
-		
+
+		List<PhotoTagModel> photoTagModelList = photoTagMstList.stream().map(PhotoTagModel::from).toList();
+
 		List<PhotoModel> photoModelList = new ArrayList<PhotoModel>();
 		photoDtoList.stream().forEach(photoDto -> {
-			PhotoModel photoModel = PhotoModel.builder()
-					.accountNo(photoDto.getAccountNo())
-					.photoNo(photoDto.getPhotoNo())
-					.favoriteCount(photoDto.getFavoriteCount())
-					.isFavorite(photoDto.getIsFavorite())
-					.photoAt(photoDto.getPhotoAt().plusHours(9))
-					.imageFilePath(photoDto.getImageFilePath())
-					.caption(photoDto.getCaption())
-					.directionKbn(photoDto.getDirectionKbn())
-					.photoTagModelList(
-							photoTagModelList.stream().filter(photoTagModel -> 
-								photoTagModel.getAccountNo() == photoDto.getAccountNo() &&
-								photoTagModel.getPhotoNo()   == photoDto.getPhotoNo()
-						).toList())
-					.build();
-			photoModelList.add(photoModel);
+			List<PhotoTagModel> tagList = photoTagModelList.stream().filter(photoTagModel ->
+					photoTagModel.getAccountNo() == photoDto.getAccountNo() &&
+					photoTagModel.getPhotoNo()   == photoDto.getPhotoNo()
+				).toList();
+			photoModelList.add(PhotoModel.from(photoDto, tagList));
 		});
-		
+
 		return photoModelList;
 	}
 	
@@ -113,40 +92,8 @@ public class PhotoDetailRepositoryImpl implements PhotoDetailRepository {
 				.build();
 		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(photoTagMst);
 
-		List<PhotoTagModel> photoTagModelList
-			= photoTagMstList.stream().map(photoTagModel -> PhotoTagModel.builder()
-					.accountNo(photoTagModel.getAccountNo())
-					.photoNo(photoTagModel.getPhotoNo())
-					.tagNo(photoTagModel.getTagNo())
-					.tagJapaneseName(photoTagModel.getTagJapaneseName())
-					.tagEnglishName(photoTagModel.getTagEnglishName())
-					.build()
-				).toList();
-		
-		PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-				.accountNo(photoDetailDto.getAccountNo())
-				.photoNo(photoDetailDto.getPhotoNo())
-				.isFavorite(photoDetailDto.getIsFavorite())
-				.photoAt(
-					photoDetailDto.getPhotoAt()
-						.isEqual(Consts.MIN_OFFSET_DATE_TIME) ? null : photoDetailDto.getPhotoAt().plusHours(9))
-				.locationNo(photoDetailDto.getLocationNo())
-				.address(photoDetailDto.getAddress())
-				.latitude(photoDetailDto.getLatitude())
-				.longitude(photoDetailDto.getLongitude())
-				.locationName(photoDetailDto.getLocationName())
-				.imageFilePath(photoDetailDto.getImageFilePath())
-				.photoJapaneseTitle(photoDetailDto.getPhotoJapaneseTitle())
-				.photoEnglishTitle(photoDetailDto.getPhotoEnglishTitle())
-				.caption(photoDetailDto.getCaption())
-				.directionKbn(photoDetailDto.getDirectionKbn())
-				.focalLength(photoDetailDto.getFocalLength() != 0 ? photoDetailDto.getFocalLength() : null)
-				.fValue(photoDetailDto.getFValue().compareTo(BigDecimal.ZERO) == 1 ? photoDetailDto.getFValue(): null)
-				.shutterSpeed(photoDetailDto.getShutterSpeed().compareTo(BigDecimal.ZERO) == 1 ? photoDetailDto.getShutterSpeed() : null)
-				.iso(photoDetailDto.getIso() != 0 ? photoDetailDto.getIso() : null)
-				.photoTagModelList(photoTagModelList)
-				.build();
-		
-		return photoDetailModel;
+		List<PhotoTagModel> photoTagModelList = photoTagMstList.stream().map(PhotoTagModel::from).toList();
+
+		return PhotoDetailModel.from(photoDetailDto, photoTagModelList);
 	}
 }

--- a/backend/src/main/java/com/web/gallary/repository/impl/PhotoDetailRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/PhotoDetailRepositoryImpl.java
@@ -87,8 +87,6 @@ public class PhotoDetailRepositoryImpl implements PhotoDetailRepository {
 		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(
 				PhotoTagMst.condition(photoDetailGetModel));
 
-		List<PhotoTagModel> photoTagModelList = photoTagMstList.stream().map(PhotoTagModel::from).toList();
-
-		return PhotoDetailModel.from(photoDetailDto, photoTagModelList);
+		return PhotoDetailModel.from(photoDetailDto, photoTagMstList);
 	}
 }

--- a/backend/src/main/java/com/web/gallary/repository/impl/PhotoFavoriteRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/PhotoFavoriteRepositoryImpl.java
@@ -69,11 +69,7 @@ public class PhotoFavoriteRepositoryImpl implements PhotoFavoriteRepository{
 	 */
 	@Override
 	public void clear(PhotoFavoriteDeleteModel favoriteDeleteModel) {
-		PhotoFavorite photoFavorite = PhotoFavorite.builder()
-				.favoritePhotoAccountNo(favoriteDeleteModel.getFavoritePhotoAccountNo())
-				.favoritePhotoNo(favoriteDeleteModel.getFavoritePhotoNo())
-				.build();
-		
+		PhotoFavorite photoFavorite = PhotoFavorite.fromForClear(favoriteDeleteModel);
 		photoFavoriteMapper.delete(photoFavorite);
 	}
 }

--- a/backend/src/main/java/com/web/gallary/repository/impl/PhotoFavoriteRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/PhotoFavoriteRepositoryImpl.java
@@ -33,12 +33,7 @@ public class PhotoFavoriteRepositoryImpl implements PhotoFavoriteRepository{
 	 */
 	@Override
 	public void regist(PhotoFavoriteModel favoriteModel) throws RegistFailureException {
-		PhotoFavorite photoFavorite = PhotoFavorite.builder()
-				.accountNo(favoriteModel.getAccountNo())
-				.favoritePhotoAccountNo(favoriteModel.getFavoritePhotoAccountNo())
-				.favoritePhotoNo(favoriteModel.getFavoritePhotoNo())
-				.createdBy(favoriteModel.getAccountNo())
-				.build();
+		PhotoFavorite photoFavorite = PhotoFavorite.from(favoriteModel);
 		
 		try {
 			photoFavoriteMapper.insert(photoFavorite);
@@ -58,11 +53,7 @@ public class PhotoFavoriteRepositoryImpl implements PhotoFavoriteRepository{
 	 */
 	@Override
 	public void delete(PhotoFavoriteDeleteModel favoriteDeleteModel) throws UpdateFailureException {
-		PhotoFavorite photoFavorite = PhotoFavorite.builder()
-				.accountNo(favoriteDeleteModel.getAccountNo())
-				.favoritePhotoAccountNo(favoriteDeleteModel.getFavoritePhotoAccountNo())
-				.favoritePhotoNo(favoriteDeleteModel.getFavoritePhotoNo())
-				.build();
+		PhotoFavorite photoFavorite = PhotoFavorite.from(favoriteDeleteModel);
 		
 		if (photoFavoriteMapper.delete(photoFavorite) < 1) {
 			log.warn("PhotoFavorite: Delete Failed (AccountNo: {}, FavoritePhotoAccountNo: {}, FavoritePhotoNo: {})",

--- a/backend/src/main/java/com/web/gallary/repository/impl/PhotoMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/PhotoMstRepositoryImpl.java
@@ -1,14 +1,11 @@
 package com.web.gallary.repository.impl;
 
-import java.math.BigDecimal;
 import java.util.Optional;
 
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Repository;
 
-import com.web.gallary.constant.Consts;
 import com.web.gallary.entity.PhotoMst;
-import com.web.gallary.enumuration.DirectionEnum;
 import com.web.gallary.enumuration.ErrorEnum;
 import com.web.gallary.exception.RegistFailureException;
 import com.web.gallary.exception.UpdateFailureException;
@@ -40,33 +37,7 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 */
 	@Override
 	public void regist(PhotoDetailModel photoDetailModel, String filePath, Integer newPhotoNo) throws RegistFailureException {
-		PhotoMst photoMst = PhotoMst.builder()
-				.accountNo(photoDetailModel.getAccountNo())
-				.photoNo(newPhotoNo)
-				.createdBy(photoDetailModel.getAccountNo())
-				.updatedBy(photoDetailModel.getAccountNo())
-				.photoAt(
-					Optional.ofNullable(photoDetailModel.getPhotoAt()).orElse(Consts.MIN_OFFSET_DATE_TIME))
-				.locationNo(
-					Optional.ofNullable(photoDetailModel.getLocationNo()).orElse(0))
-				.imageFilePath(filePath)
-				.photoJapaneseTitle(
-					Optional.ofNullable(photoDetailModel.getPhotoJapaneseTitle()).orElse(Consts.STRING_EMPTY))
-				.photoEnglishTitle(
-					Optional.ofNullable(photoDetailModel.getPhotoEnglishTitle()).orElse(Consts.STRING_EMPTY))
-				.caption(
-					Optional.ofNullable(photoDetailModel.getCaption()).orElse(Consts.STRING_EMPTY))
-				.directionKbn(
-					Optional.ofNullable(photoDetailModel.getDirectionKbn()).orElse(DirectionEnum.NONE))
-				.focalLength(
-					Optional.ofNullable(photoDetailModel.getFocalLength()).orElse(0))
-				.fValue(
-					Optional.ofNullable(photoDetailModel.getFValue()).orElse(BigDecimal.ZERO))
-				.shutterSpeed(
-					Optional.ofNullable(photoDetailModel.getShutterSpeed()).orElse(BigDecimal.ZERO))
-				.iso(
-					Optional.ofNullable(photoDetailModel.getIso()).orElse(0))
-				.build();
+		PhotoMst photoMst = PhotoMst.fromForRegist(photoDetailModel, filePath, newPhotoNo);
 		
 		try {
 			photoMstMapper.insert(photoMst);
@@ -85,36 +56,8 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 */
 	@Override
 	public void update(PhotoDetailModel photoDetailModel) throws UpdateFailureException {
-		PhotoMst cndPhotoMst = PhotoMst.builder()
-				.accountNo(photoDetailModel.getAccountNo())
-				.photoNo(photoDetailModel.getPhotoNo())
-				.build();
-		
-		PhotoMst targetPhotoMst = PhotoMst.builder()
-				.updatedBy(photoDetailModel.getAccountNo())
-				.isDeleted(false)
-				.photoAt(
-					Optional.ofNullable(photoDetailModel.getPhotoAt()).orElse(Consts.MIN_OFFSET_DATE_TIME))
-				.locationNo(
-					Optional.ofNullable(photoDetailModel.getLocationNo()).orElse(0))
-				.imageFilePath(photoDetailModel.getImageFilePath())
-				.photoJapaneseTitle(
-					Optional.ofNullable(photoDetailModel.getPhotoJapaneseTitle()).orElse(Consts.STRING_EMPTY))
-				.photoEnglishTitle(
-					Optional.ofNullable(photoDetailModel.getPhotoEnglishTitle()).orElse(Consts.STRING_EMPTY))
-				.caption(
-					Optional.ofNullable(photoDetailModel.getCaption()).orElse(Consts.STRING_EMPTY))
-				.directionKbn(
-					Optional.ofNullable(photoDetailModel.getDirectionKbn()).orElse(DirectionEnum.NONE))
-				.focalLength(
-					Optional.ofNullable(photoDetailModel.getFocalLength()).orElse(0))
-				.fValue(
-					Optional.ofNullable(photoDetailModel.getFValue()).orElse(BigDecimal.ZERO))
-				.shutterSpeed(
-					Optional.ofNullable(photoDetailModel.getShutterSpeed()).orElse(BigDecimal.ZERO))
-				.iso(
-					Optional.ofNullable(photoDetailModel.getIso()).orElse(0))
-				.build();
+		PhotoMst cndPhotoMst = PhotoMst.condition(photoDetailModel.getAccountNo(), photoDetailModel.getPhotoNo());
+		PhotoMst targetPhotoMst = PhotoMst.targetForUpdate(photoDetailModel);
 		
 		if (photoMstMapper.update(cndPhotoMst, targetPhotoMst) < 1) {
 			log.warn("PhotoMst: Update Failed (AccountNo: {}, PhotoNo: {})", cndPhotoMst.getAccountNo(), cndPhotoMst.getPhotoNo());
@@ -130,11 +73,7 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 */
 	@Override
 	public void delete(PhotoDeleteModel photoDeleteModel) throws UpdateFailureException {
-		PhotoMst cndPhotoMst = PhotoMst.builder()
-				.accountNo(photoDeleteModel.getAccountNo())
-				.photoNo(photoDeleteModel.getPhotoNo())
-				.build();
-		
+		PhotoMst cndPhotoMst = PhotoMst.condition(photoDeleteModel.getAccountNo(), photoDeleteModel.getPhotoNo());
 		PhotoMst targetPhotoMst = PhotoMst.builder()
 				.updatedBy(photoDeleteModel.getAccountNo())
 				.isDeleted(true)

--- a/backend/src/main/java/com/web/gallary/repository/impl/PhotoMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/PhotoMstRepositoryImpl.java
@@ -74,10 +74,7 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	@Override
 	public void delete(PhotoDeleteModel photoDeleteModel) throws UpdateFailureException {
 		PhotoMst cndPhotoMst = PhotoMst.condition(photoDeleteModel.getAccountNo(), photoDeleteModel.getPhotoNo());
-		PhotoMst targetPhotoMst = PhotoMst.builder()
-				.updatedBy(photoDeleteModel.getAccountNo())
-				.isDeleted(true)
-				.build();
+		PhotoMst targetPhotoMst = PhotoMst.targetForDelete(photoDeleteModel);
 		
 		if (photoMstMapper.update(cndPhotoMst, targetPhotoMst) < 1) {
 			log.warn("PhotoMst: Delete Failed (AccountNo: {}, PhotoNo: {})", cndPhotoMst.getAccountNo(), cndPhotoMst.getPhotoNo());
@@ -105,11 +102,7 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 */
 	@Override
 	public Boolean isExistPhoto(PhotoDetailModel photoDetailModel) {
-		PhotoMst photoMst = PhotoMst.builder()
-				.accountNo(photoDetailModel.getAccountNo())
-				.imageFilePath(photoDetailModel.getImageFile().getOriginalFilename())
-				.build();
-		return photoMstMapper.isExistPhoto(photoMst);
+		return photoMstMapper.isExistPhoto(PhotoMst.conditionForExistCheck(photoDetailModel));
 	}
 	
 	/**
@@ -120,7 +113,6 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 */
 	@Override
 	public Integer count(Integer accountNo) {
-		PhotoMst photoMst = PhotoMst.builder().accountNo(accountNo).isDeleted(false).build();
-		return photoMstMapper.count(photoMst);
+		return photoMstMapper.count(PhotoMst.conditionForCount(accountNo));
 	}
 }

--- a/backend/src/main/java/com/web/gallary/repository/impl/PhotoTagMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/PhotoTagMstRepositoryImpl.java
@@ -32,14 +32,7 @@ public class PhotoTagMstRepositoryImpl implements PhotoTagMstRepository {
 	 */
 	@Override
 	public void regist(PhotoTagModel photoTagModel) throws RegistFailureException {
-		PhotoTagMst photoTagMst = PhotoTagMst.builder()
-				.accountNo(photoTagModel.getAccountNo())
-				.photoNo(photoTagModel.getPhotoNo())
-				.tagNo(photoTagModel.getTagNo())
-				.createdBy(photoTagModel.getAccountNo())
-				.tagJapaneseName(photoTagModel.getTagJapaneseName())
-				.tagEnglishName(photoTagModel.getTagEnglishName())
-				.build();
+		PhotoTagMst photoTagMst = PhotoTagMst.from(photoTagModel);
 		
 		try {
 			photoTagMstMapper.insert(photoTagMst);

--- a/backend/src/main/java/com/web/gallary/repository/impl/PhotoTagMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/PhotoTagMstRepositoryImpl.java
@@ -51,7 +51,7 @@ public class PhotoTagMstRepositoryImpl implements PhotoTagMstRepository {
 	 */
 	@Override
 	public void clear(PhotoTagDeleteModel photoTagDeleteModel) {
-		PhotoTagMst photoTagMst = PhotoTagMst.fromForDelete(photoTagDeleteModel);
+		PhotoTagMst photoTagMst = PhotoTagMst.from(photoTagDeleteModel);
 		photoTagMstMapper.delete(photoTagMst);
 	}
 }

--- a/backend/src/main/java/com/web/gallary/repository/impl/PhotoTagMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/PhotoTagMstRepositoryImpl.java
@@ -51,11 +51,7 @@ public class PhotoTagMstRepositoryImpl implements PhotoTagMstRepository {
 	 */
 	@Override
 	public void clear(PhotoTagDeleteModel photoTagDeleteModel) {
-		PhotoTagMst photoTagMst = PhotoTagMst.builder()
-				.accountNo(photoTagDeleteModel.getAccountNo())
-				.photoNo(photoTagDeleteModel.getPhotoNo())
-				.build();
-		
+		PhotoTagMst photoTagMst = PhotoTagMst.fromForDelete(photoTagDeleteModel);
 		photoTagMstMapper.delete(photoTagMst);
 	}
 }

--- a/backend/src/main/java/com/web/gallary/repository/impl/RefreshTokenRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallary/repository/impl/RefreshTokenRepositoryImpl.java
@@ -22,11 +22,7 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
 
 	@Override
 	public void save(RefreshTokenModel refreshTokenModel) {
-		RefreshToken refreshToken = RefreshToken.builder()
-				.accountNo(refreshTokenModel.getAccountNo())
-				.tokenHash(refreshTokenModel.getTokenHash())
-				.expiresAt(refreshTokenModel.getExpiresAt())
-				.build();
+		RefreshToken refreshToken = RefreshToken.from(refreshTokenModel);
 		refreshTokenMapper.insert(refreshToken);
 	}
 
@@ -36,12 +32,7 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
 		if (refreshToken == null) {
 			return null;
 		}
-		return RefreshTokenModel.builder()
-				.accountNo(refreshToken.getAccountNo())
-				.tokenHash(refreshToken.getTokenHash())
-				.expiresAt(refreshToken.getExpiresAt())
-				.isRevoked(refreshToken.getIsRevoked())
-				.build();
+		return RefreshTokenModel.from(refreshToken);
 	}
 
 	@Override


### PR DESCRIPTION
## Summary
- RepositoryImplクラスにインラインで記述されていたModel→Entity / Entity→Model / Dto→Modelの変換ロジックを、EntityクラスとModelクラスのstatic `from()`メソッドに集約
- RepositoryImplからは`from()`メソッドを呼び出すだけにし、変換責務の一元管理と再利用性を向上
- 対象: Account, PhotoMst, PhotoTagMst, PhotoFavorite, KbnMst, RefreshToken, PhotoModel, PhotoDetailModel

## Test plan
- [x] `./backend/gradlew -p backend compileJava` が成功すること
- [x] `./backend/gradlew -p backend test` が全件パスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)