### PR TITLE
PostgreSQLのserial→bigserial移行とJavaのInteger→Long変換

### DIFF
--- a/backend/src/main/java/com/web/gallery/AccountPrincipal.java
+++ b/backend/src/main/java/com/web/gallery/AccountPrincipal.java
@@ -43,7 +43,7 @@ public class AccountPrincipal implements UserDetails {
 	 *
 	 * @return	アカウント番号
 	 */
-	public Integer getAccountNo() {
+	public Long getAccountNo() {
 		return accountModel.getAccountNo();
 	}
 

--- a/backend/src/main/java/com/web/gallery/controller/PhotoRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/PhotoRestController.java
@@ -110,8 +110,8 @@ public class PhotoRestController {
 	@GetMapping(ApiRoutes.API_PHOTO_DETAIL)
 	public ResponseEntity<PhotoDetailGetResponse> getPhotoDetail(
 			@PathVariable String photoAccountId,
-			@PathVariable Integer photoNo,
-			Integer accountNo) throws PhotoNotFoundException {
+			@PathVariable Long photoNo,
+			Long accountNo) throws PhotoNotFoundException {
 
 		PhotoDetailModel photoDetailModel = photoService.getPhotoDetail(
 				PhotoDetailGetModel.of(sessionHelper.getAccountNo(), accountNo, photoNo));
@@ -162,7 +162,7 @@ public class PhotoRestController {
 		
 		List<PhotoDetailModel> photoDetailModelList = List.of(PhotoDetailModel.from(photoSaveRequest));
 
-		Integer savedPhotoNo = photoService.savePhotos(photoAccountId, photoDetailModelList);
+		Long savedPhotoNo = photoService.savePhotos(photoAccountId, photoDetailModelList);
 
 		String savedImageFilePath;
 		if (Objects.isNull(photoSaveRequest.getPhotoNo()) && !Objects.isNull(photoSaveRequest.getImageFile())) {

--- a/backend/src/main/java/com/web/gallery/controller/request/PhotoDeleteRequest.java
+++ b/backend/src/main/java/com/web/gallery/controller/request/PhotoDeleteRequest.java
@@ -13,12 +13,12 @@ public class PhotoDeleteRequest {
 	/** アカウント番号 */
 	@NotNull(message = "{validation.common.notBlank}")
 	@Positive(message = "{validation.common.positive}")
-	private Integer accountNo;
-	
+	private Long accountNo;
+
 	/** 写真番号 */
 	@NotNull(message = "{validation.common.notBlank}")
 	@Positive(message = "{validation.common.positive}")
-	private Integer photoNo;
+	private Long photoNo;
 	
 	/** 画像ファイルパス */
 	@NotBlank(message = "{validation.common.notBlank}")

--- a/backend/src/main/java/com/web/gallery/controller/request/PhotoDetailRequest.java
+++ b/backend/src/main/java/com/web/gallery/controller/request/PhotoDetailRequest.java
@@ -12,10 +12,10 @@ public class PhotoDetailRequest {
 	/** アカウント番号 */
 	@NotNull(message = "{validation.common.notBlank}")
 	@Positive(message = "{validation.common.positive}")
-	private Integer accountNo;
-	
+	private Long accountNo;
+
 	/** 写真番号 */
 	@NotNull(message = "{validation.common.notBlank}")
 	@Positive(message = "{validation.common.positive}")
-	private Integer photoNo;
+	private Long photoNo;
 }

--- a/backend/src/main/java/com/web/gallery/controller/request/PhotoFavoriteDeleteRequest.java
+++ b/backend/src/main/java/com/web/gallery/controller/request/PhotoFavoriteDeleteRequest.java
@@ -12,10 +12,10 @@ public class PhotoFavoriteDeleteRequest {
 	/** お気に入り写真アカウント番号 */
 	@NotNull(message = "{validation.common.notBlank}")
 	@Positive(message = "{validation.common.positive}")
-	private Integer favoritePhotoAccountNo;
-	
+	private Long favoritePhotoAccountNo;
+
 	/** お気に入り写真番号 */
 	@NotNull(message = "{validation.common.notBlank}")
 	@Positive(message = "{validation.common.positive}")
-	private Integer favoritePhotoNo;
+	private Long favoritePhotoNo;
 }

--- a/backend/src/main/java/com/web/gallery/controller/request/PhotoFavoriteRegistRequest.java
+++ b/backend/src/main/java/com/web/gallery/controller/request/PhotoFavoriteRegistRequest.java
@@ -12,10 +12,10 @@ public class PhotoFavoriteRegistRequest {
 	/** お気に入り写真アカウント番号 */
 	@NotNull(message = "{validation.common.notBlank}")
 	@Positive(message = "{validation.common.positive}")
-	private Integer favoritePhotoAccountNo;
-	
+	private Long favoritePhotoAccountNo;
+
 	/** お気に入り写真番号 */
 	@NotNull(message = "{validation.common.notBlank}")
 	@Positive(message = "{validation.common.positive}")
-	private Integer favoritePhotoNo;
+	private Long favoritePhotoNo;
 }

--- a/backend/src/main/java/com/web/gallery/controller/request/PhotoSaveRequest.java
+++ b/backend/src/main/java/com/web/gallery/controller/request/PhotoSaveRequest.java
@@ -22,11 +22,11 @@ public class PhotoSaveRequest {
 	/** アカウント番号 */
 	@NotNull(message = "{validation.common.notBlank}")
 	@Positive(message = "{validation.common.positive}")
-	private Integer accountNo;
-	
+	private Long accountNo;
+
 	/** 写真番号 */
 	@Positive(message = "{validation.common.positive}")
-	private Integer photoNo;
+	private Long photoNo;
 
 	/** お気に入り数 */
 	private Integer favoriteCount;
@@ -39,7 +39,7 @@ public class PhotoSaveRequest {
 	private LocalDateTime photoAt;
 	
 	/** ロケーション番号 */
-	private Integer locationNo;
+	private Long locationNo;
 	
 	/** 住所 */
 	private String address;

--- a/backend/src/main/java/com/web/gallery/controller/request/PhotoSettingRequest.java
+++ b/backend/src/main/java/com/web/gallery/controller/request/PhotoSettingRequest.java
@@ -16,10 +16,10 @@ import lombok.Data;
 @Data
 public class PhotoSettingRequest {
 	/** アカウント番号 */
-	private Integer accountNo;
-	
+	private Long accountNo;
+
 	/** 写真番号 */
-	private Integer photoNo;
+	private Long photoNo;
 	
 	/** お気に入り */
 	private Boolean isFavorite;
@@ -28,7 +28,7 @@ public class PhotoSettingRequest {
 	private OffsetDateTime photoAt;
 	
 	/** ロケーション番号 */
-	private Integer locationNo;
+	private Long locationNo;
 	
 	/** 住所 */
 	private String address;

--- a/backend/src/main/java/com/web/gallery/controller/request/PhotoTagRequest.java
+++ b/backend/src/main/java/com/web/gallery/controller/request/PhotoTagRequest.java
@@ -8,13 +8,13 @@ import lombok.Data;
 @Data
 public class PhotoTagRequest {
 	/** アカウント番号 */
-	private Integer accountNo;
+	private Long accountNo;
 
 	/** 写真番号 */
-	private Integer photoNo;
+	private Long photoNo;
 
 	/** タグ番号 */
-	private Integer tagNo;
+	private Long tagNo;
 
 	/** タグ日本語名 */
 	private String tagJapaneseName;

--- a/backend/src/main/java/com/web/gallery/controller/request/PhotoTagSaveRequest.java
+++ b/backend/src/main/java/com/web/gallery/controller/request/PhotoTagSaveRequest.java
@@ -12,15 +12,15 @@ import lombok.Data;
 public class PhotoTagSaveRequest {
 	/** アカウント番号 */
 	@Positive(message = "{validation.common.positive}")
-	private Integer accountNo;
+	private Long accountNo;
 
 	/** 写真番号 */
 	@Positive(message = "{validation.common.positive}")
-	private Integer photoNo;
+	private Long photoNo;
 
 	/** タグ番号 */
 	@Positive(message = "{validation.common.positive}")
-	private Integer tagNo;
+	private Long tagNo;
 
 	/** タグ日本語名 */
 	@NotBlank(message = "{validation.common.notBlank}")

--- a/backend/src/main/java/com/web/gallery/controller/response/PhotoDetailGetResponse.java
+++ b/backend/src/main/java/com/web/gallery/controller/response/PhotoDetailGetResponse.java
@@ -19,10 +19,10 @@ import lombok.Data;
 @Builder
 public class PhotoDetailGetResponse {
 	/** アカウント番号 */
-	private Integer accountNo;
+	private Long accountNo;
 
 	/** 写真番号 */
-	private Integer photoNo;
+	private Long photoNo;
 
 	/** お気に入り */
 	private Boolean isFavorite;
@@ -31,7 +31,7 @@ public class PhotoDetailGetResponse {
 	private OffsetDateTime photoAt;
 
 	/** ロケーション番号 */
-	private Integer locationNo;
+	private Long locationNo;
 
 	/** 住所 */
 	private String address;

--- a/backend/src/main/java/com/web/gallery/controller/response/PhotoEditResponse.java
+++ b/backend/src/main/java/com/web/gallery/controller/response/PhotoEditResponse.java
@@ -21,7 +21,7 @@ public class PhotoEditResponse {
 	private String message;
 
 	/** 写真番号 */
-	private Integer photoNo;
+	private Long photoNo;
 
 	/** 画像ファイルパス */
 	private String imageFilePath;
@@ -34,7 +34,7 @@ public class PhotoEditResponse {
 	 * @param	imageFilePath	画像ファイルパス
 	 * @return					{@link PhotoEditResponse}
 	 */
-	public static PhotoEditResponse of(String message, Integer photoNo, String imageFilePath) {
+	public static PhotoEditResponse of(String message, Long photoNo, String imageFilePath) {
 		return PhotoEditResponse.builder()
 				.httpStatus(HttpStatus.OK.value())
 				.isSuccess(true)

--- a/backend/src/main/java/com/web/gallery/controller/response/PhotoListResponse.java
+++ b/backend/src/main/java/com/web/gallery/controller/response/PhotoListResponse.java
@@ -13,10 +13,10 @@ import lombok.Data;
 @Builder
 public class PhotoListResponse {
 	/** アカウント番号 */
-	private Integer accountNo;
+	private Long accountNo;
 
 	/** 写真番号 */
-	private Integer photoNo;
+	private Long photoNo;
 
 	/** お気に入り */
 	private Boolean isFavorite;

--- a/backend/src/main/java/com/web/gallery/controller/response/PhotoTagResponse.java
+++ b/backend/src/main/java/com/web/gallery/controller/response/PhotoTagResponse.java
@@ -12,13 +12,13 @@ import lombok.Data;
 @Builder
 public class PhotoTagResponse {
 	/** アカウント番号 */
-	private Integer accountNo;
+	private Long accountNo;
 
 	/** 写真番号 */
-	private Integer photoNo;
+	private Long photoNo;
 
 	/** タグ番号 */
-	private Integer tagNo;
+	private Long tagNo;
 
 	/** タグ日本語名 */
 	private String tagJapaneseName;

--- a/backend/src/main/java/com/web/gallery/dto/PhotoDetailDto.java
+++ b/backend/src/main/java/com/web/gallery/dto/PhotoDetailDto.java
@@ -13,10 +13,10 @@ import lombok.Data;
 @Data
 public class PhotoDetailDto {
 	/** アカウントNo */
-	private Integer accountNo;
-	
+	private Long accountNo;
+
 	/** 写真番号 */
-	private Integer photoNo;
+	private Long photoNo;
 
 	/** お気に入り */
 	private Boolean isFavorite;
@@ -25,7 +25,7 @@ public class PhotoDetailDto {
 	private OffsetDateTime photoAt;
 	
 	/** ロケーション番号 */
-	private Integer locationNo;
+	private Long locationNo;
 	
 	/** 住所 */
 	private String address;

--- a/backend/src/main/java/com/web/gallery/dto/PhotoDetailGetDto.java
+++ b/backend/src/main/java/com/web/gallery/dto/PhotoDetailGetDto.java
@@ -8,11 +8,11 @@ import lombok.Data;
 @Data
 public class PhotoDetailGetDto {
 	/** ログイン中のアカウントNo */
-	private Integer accountNo;
-	
+	private Long accountNo;
+
 	/** 写真のアカウントNo */
-	private Integer photoAccountNo;
-	
+	private Long photoAccountNo;
+
 	/** 写真番号 */
-	private Integer photoNo;
+	private Long photoNo;
 }

--- a/backend/src/main/java/com/web/gallery/dto/PhotoDto.java
+++ b/backend/src/main/java/com/web/gallery/dto/PhotoDto.java
@@ -12,10 +12,10 @@ import lombok.Data;
 @Data
 public class PhotoDto {
 	/** アカウントNo */
-	private Integer accountNo;
-	
+	private Long accountNo;
+
 	/** 写真番号 */
-	private Integer photoNo;
+	private Long photoNo;
 
 	/** お気に入り数 */
 	private Integer favoriteCount;

--- a/backend/src/main/java/com/web/gallery/dto/PhotoListGetDto.java
+++ b/backend/src/main/java/com/web/gallery/dto/PhotoListGetDto.java
@@ -8,8 +8,8 @@ import lombok.Data;
 @Data
 public class PhotoListGetDto {
 	/** ログイン中のアカウントNo */
-	private Integer accountNo;
-	
+	private Long accountNo;
+
 	/** 写真のアカウントNo */
-	private Integer photoAccountNo;
+	private Long photoAccountNo;
 }

--- a/backend/src/main/java/com/web/gallery/entity/Account.java
+++ b/backend/src/main/java/com/web/gallery/entity/Account.java
@@ -22,16 +22,16 @@ import lombok.Data;
 @Builder
 public class Account {
 	/** アカウント番号 */
-	private Integer accountNo;
+	private Long accountNo;
 
 	/** 作成者 */
-	private Integer createdBy;
+	private Long createdBy;
 
 	/** 作成日時 */
 	private OffsetDateTime createdAt;
 
 	/** 更新者 */
-	private Integer updatedBy;
+	private Long updatedBy;
 
 	/** 更新日時 */
 	private OffsetDateTime updatedAt;
@@ -89,8 +89,8 @@ public class Account {
 	 */
 	public static Account from(AccountModel model, PasswordEncoder passwordEncoder) {
 		return Account.builder()
-				.createdBy(0)
-				.updatedBy(0)
+				.createdBy(0L)
+				.updatedBy(0L)
 				.accountId(model.getAccountId())
 				.accountName(model.getAccountName())
 				.password(passwordEncoder.encode(model.getPassword()))
@@ -163,7 +163,7 @@ public class Account {
 	 * @param	accountNo	アカウント番号
 	 * @return				{@link Account}
 	 */
-	public static Account conditionByAccountNo(Integer accountNo) {
+	public static Account conditionByAccountNo(Long accountNo) {
 		return Account.builder()
 				.accountNo(accountNo)
 				.build();
@@ -188,7 +188,7 @@ public class Account {
 	 * @param	accountId	アカウントID
 	 * @return				{@link Account}
 	 */
-	public static Account conditionForExistCheck(Integer accountNo, String accountId) {
+	public static Account conditionForExistCheck(Long accountNo, String accountId) {
 		return Account.builder()
 				.accountNo(accountNo)
 				.accountId(accountId)

--- a/backend/src/main/java/com/web/gallery/entity/PhotoFavorite.java
+++ b/backend/src/main/java/com/web/gallery/entity/PhotoFavorite.java
@@ -15,19 +15,19 @@ import lombok.Data;
 @Builder
 public class PhotoFavorite {
 	/** ID */
-	private Integer id;
+	private Long id;
 
 	/** アカウント番号 */
-	private Integer accountNo;
+	private Long accountNo;
 
 	/** お気に入り写真アカウント番号 */
-	private Integer favoritePhotoAccountNo;
+	private Long favoritePhotoAccountNo;
 
 	/** お気に入り写真番号 */
-	private Integer favoritePhotoNo;
+	private Long favoritePhotoNo;
 
 	/** 作成者 */
-	private Integer createdBy;
+	private Long createdBy;
 
 	/** 作成日時 */
 	private OffsetDateTime createdAt;

--- a/backend/src/main/java/com/web/gallery/entity/PhotoMst.java
+++ b/backend/src/main/java/com/web/gallery/entity/PhotoMst.java
@@ -19,22 +19,22 @@ import lombok.Data;
 @Builder
 public class PhotoMst {
 	/** ID */
-	private Integer id;
+	private Long id;
 
 	/** アカウント番号 */
-	private Integer accountNo;
+	private Long accountNo;
 
 	/** 写真番号 */
-	private Integer photoNo;
+	private Long photoNo;
 
 	/** 作成者 */
-	private Integer createdBy;
+	private Long createdBy;
 
 	/** 作成日時 */
 	private OffsetDateTime createdAt;
 
 	/** 更新者 */
-	private Integer updatedBy;
+	private Long updatedBy;
 
 	/** 更新日時 */
 	private OffsetDateTime updatedAt;
@@ -46,7 +46,7 @@ public class PhotoMst {
 	private OffsetDateTime photoAt;
 
 	/** ロケーション番号 */
-	private Integer locationNo;
+	private Long locationNo;
 
 	/** 画像ファイルパス */
 	private String imageFilePath;
@@ -87,7 +87,7 @@ public class PhotoMst {
 	 * @param	newPhotoNo	新規採番した写真番号
 	 * @return				{@link PhotoMst}
 	 */
-	public static PhotoMst fromForRegist(PhotoDetailModel model, String filePath, Integer newPhotoNo) {
+	public static PhotoMst fromForRegist(PhotoDetailModel model, String filePath, Long newPhotoNo) {
 		return PhotoMst.builder()
 				.accountNo(model.getAccountNo())
 				.photoNo(newPhotoNo)
@@ -96,7 +96,7 @@ public class PhotoMst {
 				.photoAt(
 					Optional.ofNullable(model.getPhotoAt()).orElse(Consts.MIN_OFFSET_DATE_TIME))
 				.locationNo(
-					Optional.ofNullable(model.getLocationNo()).orElse(0))
+					Optional.ofNullable(model.getLocationNo()).orElse(0L))
 				.imageFilePath(filePath)
 				.photoJapaneseTitle(
 					Optional.ofNullable(model.getPhotoJapaneseTitle()).orElse(Consts.STRING_EMPTY))
@@ -130,7 +130,7 @@ public class PhotoMst {
 				.photoAt(
 					Optional.ofNullable(model.getPhotoAt()).orElse(Consts.MIN_OFFSET_DATE_TIME))
 				.locationNo(
-					Optional.ofNullable(model.getLocationNo()).orElse(0))
+					Optional.ofNullable(model.getLocationNo()).orElse(0L))
 				.imageFilePath(model.getImageFilePath())
 				.photoJapaneseTitle(
 					Optional.ofNullable(model.getPhotoJapaneseTitle()).orElse(Consts.STRING_EMPTY))
@@ -158,7 +158,7 @@ public class PhotoMst {
 	 * @param	photoNo		写真番号
 	 * @return				{@link PhotoMst}
 	 */
-	public static PhotoMst condition(Integer accountNo, Integer photoNo) {
+	public static PhotoMst condition(Long accountNo, Long photoNo) {
 		return PhotoMst.builder()
 				.accountNo(accountNo)
 				.photoNo(photoNo)
@@ -197,7 +197,7 @@ public class PhotoMst {
 	 * @param	accountNo	アカウント番号
 	 * @return				{@link PhotoMst}
 	 */
-	public static PhotoMst conditionForCount(Integer accountNo) {
+	public static PhotoMst conditionForCount(Long accountNo) {
 		return PhotoMst.builder()
 				.accountNo(accountNo)
 				.isDeleted(false)

--- a/backend/src/main/java/com/web/gallery/entity/PhotoTagMst.java
+++ b/backend/src/main/java/com/web/gallery/entity/PhotoTagMst.java
@@ -17,19 +17,19 @@ import lombok.Data;
 @Builder
 public class PhotoTagMst {
 	/** ID */
-	private Integer id;
+	private Long id;
 
 	/** アカウント番号 */
-	private Integer accountNo;
+	private Long accountNo;
 
 	/** 写真番号 */
-	private Integer photoNo;
+	private Long photoNo;
 
 	/** タグ番号 */
-	private Integer tagNo;
+	private Long tagNo;
 
 	/** 作成者 */
-	private Integer createdBy;
+	private Long createdBy;
 
 	/** 作成日時 */
 	private OffsetDateTime createdAt;

--- a/backend/src/main/java/com/web/gallery/entity/RefreshToken.java
+++ b/backend/src/main/java/com/web/gallery/entity/RefreshToken.java
@@ -17,10 +17,10 @@ import lombok.Data;
 @Builder
 public class RefreshToken {
 	/** トークンID */
-	private Integer tokenId;
+	private Long tokenId;
 
 	/** アカウント番号 */
-	private Integer accountNo;
+	private Long accountNo;
 
 	/** トークンハッシュ */
 	private String tokenHash;

--- a/backend/src/main/java/com/web/gallery/helper/SessionHelper.java
+++ b/backend/src/main/java/com/web/gallery/helper/SessionHelper.java
@@ -16,8 +16,8 @@ public class SessionHelper {
 	 * 
 	 * @return	アカウント番号
 	 */
-	public Integer getAccountNo() {
-		Integer accountNo = null;
+	public Long getAccountNo() {
+		Long accountNo = null;
 
 		Authentication authentication =
 				SecurityContextHolder.getContext().getAuthentication();

--- a/backend/src/main/java/com/web/gallery/mapper/PhotoMstMapper.java
+++ b/backend/src/main/java/com/web/gallery/mapper/PhotoMstMapper.java
@@ -41,7 +41,7 @@ public interface PhotoMstMapper {
 	 * @param	accountNo	アカウント番号
 	 * @return				最大の写真番号
 	 */
-	public Integer getMaxPhotoNo(Integer accountNo);
+	public Long getMaxPhotoNo(Long accountNo);
 	
 	/**
 	 * ファイル名から登録済みの写真家判定する

--- a/backend/src/main/java/com/web/gallery/mapper/RefreshTokenMapper.java
+++ b/backend/src/main/java/com/web/gallery/mapper/RefreshTokenMapper.java
@@ -35,7 +35,7 @@ public interface RefreshTokenMapper {
 	 * @param	accountNo	アカウント番号
 	 * @return				更新件数
 	 */
-	public Integer revokeAllByAccountNo(@Param("accountNo") Integer accountNo);
+	public Integer revokeAllByAccountNo(@Param("accountNo") Long accountNo);
 
 	/**
 	 * トークンハッシュに該当するリフ���ッシュトークンを無効化する

--- a/backend/src/main/java/com/web/gallery/model/AccountModel.java
+++ b/backend/src/main/java/com/web/gallery/model/AccountModel.java
@@ -19,7 +19,7 @@ import lombok.Value;
 @Builder
 public class AccountModel {
 	/** アカウント番号 */
-	private Integer accountNo;
+	private Long accountNo;
 	
 	/** アカウントID */
 	private String accountId;
@@ -116,7 +116,7 @@ public class AccountModel {
 	 * @param	accountNo	アカウント番号
 	 * @return				{@link AccountModel}
 	 */
-	public static AccountModel from(AccountUpdateRequest request, Integer accountNo) {
+	public static AccountModel from(AccountUpdateRequest request, Long accountNo) {
 		return AccountModel.builder()
 				.accountNo(accountNo)
 				.accountId(request.getAccountId())

--- a/backend/src/main/java/com/web/gallery/model/PhotoDeleteModel.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoDeleteModel.java
@@ -14,11 +14,11 @@ import lombok.Value;
 public class PhotoDeleteModel {
 	/** アカウント番号 */
 	@NonNull
-	private Integer accountNo;
-	
+	private Long accountNo;
+
 	/** 写真番号 */
 	@NonNull
-	private Integer photoNo;
+	private Long photoNo;
 	
 	/** 画像ファイルパス */
 	@NonNull

--- a/backend/src/main/java/com/web/gallery/model/PhotoDetailGetModel.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoDetailGetModel.java
@@ -11,15 +11,15 @@ import lombok.Value;
 @Builder
 public class PhotoDetailGetModel {
 	/** ログイン中のアカウントNo */
-	private Integer accountNo;
-	
+	private Long accountNo;
+
 	/** 写真のアカウントNo */
 	@NonNull
-	private Integer photoAccountNo;
-	
+	private Long photoAccountNo;
+
 	/** 写真番号 */
 	@NonNull
-	private Integer photoNo;
+	private Long photoNo;
 
 	/**
 	 * パラメータからPhotoDetailGetModelを生成する
@@ -29,7 +29,7 @@ public class PhotoDetailGetModel {
 	 * @param	photoNo			写真番号
 	 * @return					{@link PhotoDetailGetModel}
 	 */
-	public static PhotoDetailGetModel of(Integer accountNo, Integer photoAccountNo, Integer photoNo) {
+	public static PhotoDetailGetModel of(Long accountNo, Long photoAccountNo, Long photoNo) {
 		return PhotoDetailGetModel.builder()
 				.accountNo(accountNo)
 				.photoAccountNo(photoAccountNo)

--- a/backend/src/main/java/com/web/gallery/model/PhotoDetailModel.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoDetailModel.java
@@ -28,10 +28,10 @@ import lombok.Value;
 public class PhotoDetailModel {
 	/** アカウント番号 */
 	@NonNull
-	private Integer accountNo;
-	
+	private Long accountNo;
+
 	/** 写真番号 */
-	private Integer photoNo;
+	private Long photoNo;
 
 	/** お気に入り */
 	private Boolean isFavorite;
@@ -40,7 +40,7 @@ public class PhotoDetailModel {
 	private OffsetDateTime photoAt;
 	
 	/** ロケーション番号 */
-	private Integer locationNo;
+	private Long locationNo;
 	
 	/** 住所 */
 	private String address;

--- a/backend/src/main/java/com/web/gallery/model/PhotoFavoriteDeleteModel.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoFavoriteDeleteModel.java
@@ -11,13 +11,13 @@ import lombok.Value;
 @Builder
 public class PhotoFavoriteDeleteModel {
 	/** アカウント番号 */
-	private Integer accountNo;
-	
+	private Long accountNo;
+
 	/** お気に入り写真アカウント番号 */
 	@NonNull
-	private Integer favoritePhotoAccountNo;
-	
+	private Long favoritePhotoAccountNo;
+
 	/** 写真番号 */
 	@NonNull
-	private Integer favoritePhotoNo;
+	private Long favoritePhotoNo;
 }

--- a/backend/src/main/java/com/web/gallery/model/PhotoFavoriteModel.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoFavoriteModel.java
@@ -15,15 +15,15 @@ import lombok.Value;
 public class PhotoFavoriteModel {
 	/** アカウント番号 */
 	@NonNull
-	private Integer accountNo;
-	
+	private Long accountNo;
+
 	/** お気に入り写真アカウント番号 */
 	@NonNull
-	private Integer favoritePhotoAccountNo;
-	
+	private Long favoritePhotoAccountNo;
+
 	/** 写真番号 */
 	@NonNull
-	private Integer favoritePhotoNo;
+	private Long favoritePhotoNo;
 
 	/**
 	 * お気に入り登録リクエストからPhotoFavoriteModelを生成する
@@ -32,7 +32,7 @@ public class PhotoFavoriteModel {
 	 * @param	accountNo	アカウント番号
 	 * @return				{@link PhotoFavoriteModel}
 	 */
-	public static PhotoFavoriteModel from(PhotoFavoriteRegistRequest request, Integer accountNo) {
+	public static PhotoFavoriteModel from(PhotoFavoriteRegistRequest request, Long accountNo) {
 		return PhotoFavoriteModel.builder()
 				.accountNo(accountNo)
 				.favoritePhotoAccountNo(request.getFavoritePhotoAccountNo())
@@ -47,7 +47,7 @@ public class PhotoFavoriteModel {
 	 * @param	accountNo	アカウント番号
 	 * @return				{@link PhotoFavoriteModel}
 	 */
-	public static PhotoFavoriteModel from(PhotoFavoriteDeleteRequest request, Integer accountNo) {
+	public static PhotoFavoriteModel from(PhotoFavoriteDeleteRequest request, Long accountNo) {
 		return PhotoFavoriteModel.builder()
 				.accountNo(accountNo)
 				.favoritePhotoAccountNo(request.getFavoritePhotoAccountNo())

--- a/backend/src/main/java/com/web/gallery/model/PhotoGetModel.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoGetModel.java
@@ -11,9 +11,9 @@ import lombok.Value;
 @Builder
 public class PhotoGetModel {
 	/** ログイン中のアカウントNo */
-	private Integer accountNo;
-	
+	private Long accountNo;
+
 	/** 写真のアカウントNo */
 	@NonNull
-	private Integer photoAccountNo;
+	private Long photoAccountNo;
 }

--- a/backend/src/main/java/com/web/gallery/model/PhotoListGetModel.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoListGetModel.java
@@ -21,7 +21,7 @@ import lombok.Value;
 @Builder
 public class PhotoListGetModel {
 	/** ログイン中のアカウントNo */
-	private Integer accountNo;
+	private Long accountNo;
 	
 	/** 写真のアカウントID */
 	@NonNull
@@ -59,7 +59,7 @@ public class PhotoListGetModel {
 	 * @param	photoAccountId	写真のアカウントID
 	 * @return					{@link PhotoListGetModel}
 	 */
-	public static PhotoListGetModel from(PhotoListRequest request, Integer accountNo, String photoAccountId) {
+	public static PhotoListGetModel from(PhotoListRequest request, Long accountNo, String photoAccountId) {
 		Optional<String> tagsOpt = Optional.ofNullable(request.getTagList());
 		List<String> tagList = tagsOpt.map(tag ->
 				new ArrayList<String>(Arrays.asList(tag.replace(Consts.FULL_SPACE, Consts.HALF_SPACE).split(Consts.HALF_SPACE))))

--- a/backend/src/main/java/com/web/gallery/model/PhotoModel.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoModel.java
@@ -20,11 +20,11 @@ import lombok.Value;
 public class PhotoModel {
 	/** アカウント番号 */
 	@NonNull
-	private Integer accountNo;
-	
+	private Long accountNo;
+
 	/** 写真番号 */
 	@NonNull
-	private Integer photoNo;
+	private Long photoNo;
 
 	/** お気に入り数 */
 	@NonNull

--- a/backend/src/main/java/com/web/gallery/model/PhotoTagDeleteModel.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoTagDeleteModel.java
@@ -12,9 +12,9 @@ import lombok.Value;
 public class PhotoTagDeleteModel {
 	/** アカウント番号 */
 	@NonNull
-	private Integer accountNo;
+	private Long accountNo;
 
 	/** 写真番号 */
 	@NonNull
-	private Integer photoNo;
+	private Long photoNo;
 }

--- a/backend/src/main/java/com/web/gallery/model/PhotoTagModel.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoTagModel.java
@@ -18,13 +18,13 @@ import lombok.Value;
 public class PhotoTagModel {
 	/** アカウント番号 */
 	@NonNull
-	private Integer accountNo;
+	private Long accountNo;
 
 	/** 写真番号 */
-	private Integer photoNo;
+	private Long photoNo;
 
 	/** タグ番号 */
-	private Integer tagNo;
+	private Long tagNo;
 
 	/** タグ日本語名 */
 	@NonNull

--- a/backend/src/main/java/com/web/gallery/model/RefreshTokenModel.java
+++ b/backend/src/main/java/com/web/gallery/model/RefreshTokenModel.java
@@ -17,7 +17,7 @@ import lombok.Value;
 @Builder
 public class RefreshTokenModel {
 	/** アカウント番号 */
-	private Integer accountNo;
+	private Long accountNo;
 
 	/** トークンハッシュ */
 	private String tokenHash;

--- a/backend/src/main/java/com/web/gallery/repository/AccountRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/AccountRepository.java
@@ -17,7 +17,7 @@ public interface AccountRepository {
 	 * @return	AccountModel	{@link AccountModel}<p>
 	 * 							取得できない場合はnullを返す
 	 */
-	AccountModel getByAccountNo(Integer accountNo);
+	AccountModel getByAccountNo(Long accountNo);
 
 	/**
 	 * Accountテーブルで該当するレコードを取得する
@@ -59,7 +59,7 @@ public interface AccountRepository {
 	 * @param	accountId	アカウントID
 	 * @return				true：存在する
 	 */
-	Boolean isExistAccount(Integer accountNo, String accountId);
+	Boolean isExistAccount(Long accountNo, String accountId);
 
 	/**
 	 * アカウントの一覧を取得する

--- a/backend/src/main/java/com/web/gallery/repository/PhotoMstRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/PhotoMstRepository.java
@@ -17,7 +17,7 @@ public interface PhotoMstRepository {
 	 * @param	newPhotoNo				新規採番した写真番号
 	 * @throws	RegistFailureException	登録に失敗した場合
 	 */
-	void regist(PhotoDetailModel photoDetailModel, String filePath, Integer newPhotoNo) throws RegistFailureException;
+	void regist(PhotoDetailModel photoDetailModel, String filePath, Long newPhotoNo) throws RegistFailureException;
 	
 	/**
 	 * 写真マスタを更新する
@@ -41,7 +41,7 @@ public interface PhotoMstRepository {
 	 * @param	accountNo	アカウント番号
 	 * @return				新規採番した写真番号
 	 */
-	Integer getNewPhotoNo(Integer accountNo);
+	Long getNewPhotoNo(Long accountNo);
 	
 	/**
 	 * 同じファイル名の写真が存在するかチェックする
@@ -57,5 +57,5 @@ public interface PhotoMstRepository {
 	 * @param	accountNo	アカウント番号
 	 * @return				登録件数
 	 */
-	Integer count(Integer accountNo);
+	Integer count(Long accountNo);
 }

--- a/backend/src/main/java/com/web/gallery/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/RefreshTokenRepository.java
@@ -29,7 +29,7 @@ public interface RefreshTokenRepository {
 	 *
 	 * @param	accountNo	アカウント番号
 	 */
-	void revokeAllByAccountNo(Integer accountNo);
+	void revokeAllByAccountNo(Long accountNo);
 
 	/**
 	 * トークンハッシュに該当するリフレッシュトークンを無効化する

--- a/backend/src/main/java/com/web/gallery/repository/impl/AccountRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/AccountRepositoryImpl.java
@@ -36,7 +36,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 * 							取得できない場合はnullを返す
 	 */
 	@Override
-	public AccountModel getByAccountNo(Integer accountNo) {
+	public AccountModel getByAccountNo(Long accountNo) {
 		List<Account> accountList = accountMapper.select(Account.conditionByAccountNo(accountNo));
 		return accountList.isEmpty() ? null : AccountModel.from(accountList.getFirst());
 	}
@@ -115,7 +115,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 * @return				true：存在する
 	 */
 	@Override
-	public Boolean isExistAccount(Integer accountNo, String accountId) {
+	public Boolean isExistAccount(Long accountNo, String accountId) {
 		return accountMapper.isExistAccount(Account.conditionForExistCheck(accountNo, accountId));
 	}
 	

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
@@ -36,7 +36,7 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 * @throws	RegistFailureException	登録に失敗した場合
 	 */
 	@Override
-	public void regist(PhotoDetailModel photoDetailModel, String filePath, Integer newPhotoNo) throws RegistFailureException {
+	public void regist(PhotoDetailModel photoDetailModel, String filePath, Long newPhotoNo) throws RegistFailureException {
 		PhotoMst photoMst = PhotoMst.fromForRegist(photoDetailModel, filePath, newPhotoNo);
 		
 		try {
@@ -89,9 +89,9 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 * @return				新規採番した写真番号
 	 */
 	@Override
-	public Integer getNewPhotoNo(Integer accountNo) {
-		Integer photoNo = photoMstMapper.getMaxPhotoNo(accountNo);
-		return Optional.ofNullable(photoNo).map(num -> num + 1).orElse(1);
+	public Long getNewPhotoNo(Long accountNo) {
+		Long photoNo = photoMstMapper.getMaxPhotoNo(accountNo);
+		return Optional.ofNullable(photoNo).map(num -> num + 1).orElse(1L);
 	}
 	
 	/**
@@ -112,7 +112,7 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 * @return				登録件数
 	 */
 	@Override
-	public Integer count(Integer accountNo) {
+	public Integer count(Long accountNo) {
 		return photoMstMapper.count(PhotoMst.conditionForCount(accountNo));
 	}
 }

--- a/backend/src/main/java/com/web/gallery/repository/impl/RefreshTokenRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/RefreshTokenRepositoryImpl.java
@@ -36,7 +36,7 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
 	}
 
 	@Override
-	public void revokeAllByAccountNo(Integer accountNo) {
+	public void revokeAllByAccountNo(Long accountNo) {
 		refreshTokenMapper.revokeAllByAccountNo(accountNo);
 	}
 

--- a/backend/src/main/java/com/web/gallery/service/PhotoService.java
+++ b/backend/src/main/java/com/web/gallery/service/PhotoService.java
@@ -43,7 +43,7 @@ public interface PhotoService {
 	 * @throws	UpdateFailureException	更新に失敗した場合
 	 * @return							登録・更新した写真番号
 	 */
-	Integer savePhotos(String accountId, List<PhotoDetailModel> photoDetailModelList) throws FileDuplicateException, RegistFailureException, UpdateFailureException;
+	Long savePhotos(String accountId, List<PhotoDetailModel> photoDetailModelList) throws FileDuplicateException, RegistFailureException, UpdateFailureException;
 	
 	/**
 	 * 写真を削除する
@@ -60,5 +60,5 @@ public interface PhotoService {
 	 * @param	accountNo	アカウント番号
 	 * @return				上限に達している場合、true
 	 */
-	Boolean isReachedUpperLimit(Integer accountNo);
+	Boolean isReachedUpperLimit(Long accountNo);
 }

--- a/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
@@ -111,12 +111,12 @@ public class PhotoServiceImpl implements PhotoService {
 	 */
 	@Override
 	@Transactional
-	public Integer savePhotos(String accountId, List<PhotoDetailModel> photoDetailModelList) throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+	public Long savePhotos(String accountId, List<PhotoDetailModel> photoDetailModelList) throws FileDuplicateException, RegistFailureException, UpdateFailureException {
 		if(Objects.isNull(photoDetailModelList)) return null;
 		if(photoDetailModelList.isEmpty()) return null;
 
-		Integer photoNo = photoMstRepository.getNewPhotoNo(photoDetailModelList.getFirst().getAccountNo());
-		Integer savedPhotoNo = photoNo;
+		Long photoNo = photoMstRepository.getNewPhotoNo(photoDetailModelList.getFirst().getAccountNo());
+		Long savedPhotoNo = photoNo;
 		String filePath = photoConfig.getOutputPath() + accountId + "/";
 
 		for(PhotoDetailModel photoDetailModel : photoDetailModelList){
@@ -176,7 +176,7 @@ public class PhotoServiceImpl implements PhotoService {
 	 */
 	@Override
 	@Transactional(readOnly = true)
-	public Boolean isReachedUpperLimit(Integer accountNo) {
+	public Boolean isReachedUpperLimit(Long accountNo) {
 		if(Objects.isNull(accountNo)) return true;
 		
 		AccountModel accountModel = accountRepository.getByAccountNo(accountNo);
@@ -274,7 +274,7 @@ public class PhotoServiceImpl implements PhotoService {
 	 * @param	newPhotoNo				新規採番された写真番号
 	 * @throws	RegistFailureException	登録に失敗した場合
 	 */
-	private void registPhotoTags(List<PhotoTagModel> photoTagModelList, Integer newPhotoNo) throws RegistFailureException {
+	private void registPhotoTags(List<PhotoTagModel> photoTagModelList, Long newPhotoNo) throws RegistFailureException {
 		if(Objects.isNull(photoTagModelList)) return; 
 		
 		int tagNo = 1;
@@ -282,7 +282,7 @@ public class PhotoServiceImpl implements PhotoService {
 			PhotoTagModel photoTagRegistModel = PhotoTagModel.builder()
 					.accountNo(photoTagModel.getAccountNo())
 					.photoNo(!Objects.isNull(newPhotoNo) ? newPhotoNo : photoTagModel.getPhotoNo())
-					.tagNo(tagNo)
+					.tagNo((long) tagNo)
 					.tagJapaneseName(photoTagModel.getTagJapaneseName())
 					.tagEnglishName(photoTagModel.getTagEnglishName())
 					.build();
@@ -312,7 +312,7 @@ public class PhotoServiceImpl implements PhotoService {
 	 * @param	accountNo	削除する写真のアカウント番号
 	 * @param	photoNo		削除する写真の写真番号
 	 */
-	private void deletePhotoTags(Integer accountNo, Integer photoNo) {
+	private void deletePhotoTags(Long accountNo, Long photoNo) {
 		photoTagMstRepository.clear(
 			PhotoTagDeleteModel.builder()
 				.accountNo(accountNo)

--- a/backend/src/main/resources/com/web/gallery/mapper/PhotoMstMapper.xml
+++ b/backend/src/main/resources/com/web/gallery/mapper/PhotoMstMapper.xml
@@ -111,7 +111,7 @@
 		</where>
 	</update>
 	
-	<select id="getMaxPhotoNo" parameterType="Integer" resultType="Integer">
+	<select id="getMaxPhotoNo" parameterType="Long" resultType="Long">
 		SELECT
 			MAX(photo_no) AS photoNo
 		FROM

--- a/backend/src/main/resources/com/web/gallery/mapper/RefreshTokenMapper.xml
+++ b/backend/src/main/resources/com/web/gallery/mapper/RefreshTokenMapper.xml
@@ -34,7 +34,7 @@
 			token_hash = #{tokenHash}
 	</select>
 
-	<update id="revokeAllByAccountNo" parameterType="Integer">
+	<update id="revokeAllByAccountNo" parameterType="Long">
 		UPDATE common.refresh_token
 		SET is_revoked = TRUE
 		WHERE account_no = #{accountNo}

--- a/backend/src/test/java/com/web/gallery/controller/AccountRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/AccountRestControllerTest.java
@@ -124,7 +124,7 @@ public class AccountRestControllerTest {
 			doReturn(accountId).when(sessionHelper).getAccountId();
 
 			AccountModel accountModel = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId(accountId)
 					.accountName("AAAAAAAA")
 					.birthdate(LocalDate.of(2000, 1, 1))
@@ -156,7 +156,7 @@ public class AccountRestControllerTest {
 			doReturn(accountId).when(sessionHelper).getAccountId();
 
 			AccountModel accountModel = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId(accountId)
 					.accountName("AAAAAAAA")
 					.birthdate(Consts.MIN_LOCAL_DATE)
@@ -306,7 +306,7 @@ public class AccountRestControllerTest {
 		void update_not_change_accountID_and_password() throws Exception {
 			String accountId = "aaaaaaaa";
 
-			doReturn(1).when(sessionHelper).getAccountNo();
+			doReturn(1L).when(sessionHelper).getAccountNo();
 			doReturn(accountId).when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
@@ -323,7 +323,7 @@ public class AccountRestControllerTest {
 				.andExpect(jsonPath("$.message").value(""));
 
 			AccountModel accountModel = accountModelCaptor.getValue();
-			assertEquals(1, accountModel.getAccountNo());
+			assertEquals(1L, accountModel.getAccountNo());
 			assertEquals(accountId, accountModel.getAccountId());
 			assertEquals("AAAAAAAA", accountModel.getAccountName());
 			assertNull(accountModel.getPassword());
@@ -343,7 +343,7 @@ public class AccountRestControllerTest {
 		void update_change_accountID() throws Exception {
 			String accountId = "aaaaaaaa";
 
-			doReturn(1).when(sessionHelper).getAccountNo();
+			doReturn(1L).when(sessionHelper).getAccountNo();
 			doReturn("bbbbbbbb").when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
@@ -360,7 +360,7 @@ public class AccountRestControllerTest {
 				.andExpect(jsonPath("$.message").value(""));
 
 			AccountModel accountModel = accountModelCaptor.getValue();
-			assertEquals(1, accountModel.getAccountNo());
+			assertEquals(1L, accountModel.getAccountNo());
 			assertEquals(accountId, accountModel.getAccountId());
 			assertEquals("AAAAAAAA", accountModel.getAccountName());
 			assertNull(accountModel.getPassword());
@@ -372,7 +372,7 @@ public class AccountRestControllerTest {
 		void update_change_password() throws Exception {
 			String accountId = "aaaaaaaa";
 
-			doReturn(1).when(sessionHelper).getAccountNo();
+			doReturn(1L).when(sessionHelper).getAccountNo();
 			doReturn(accountId).when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
@@ -389,7 +389,7 @@ public class AccountRestControllerTest {
 				.andExpect(jsonPath("$.message").value(""));
 
 			AccountModel accountModel = accountModelCaptor.getValue();
-			assertEquals(1, accountModel.getAccountNo());
+			assertEquals(1L, accountModel.getAccountNo());
 			assertEquals(accountId, accountModel.getAccountId());
 			assertEquals("AAAAAAAA", accountModel.getAccountName());
 			assertEquals("password01", accountModel.getPassword());
@@ -401,7 +401,7 @@ public class AccountRestControllerTest {
 		void update_change_accountId_and_password() throws Exception {
 			String accountId = "aaaaaaaa";
 
-			doReturn(1).when(sessionHelper).getAccountNo();
+			doReturn(1L).when(sessionHelper).getAccountNo();
 			doReturn("bbbbbbbb").when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
@@ -418,7 +418,7 @@ public class AccountRestControllerTest {
 				.andExpect(jsonPath("$.message").value(""));
 
 			AccountModel accountModel = accountModelCaptor.getValue();
-			assertEquals(1, accountModel.getAccountNo());
+			assertEquals(1L, accountModel.getAccountNo());
 			assertEquals(accountId, accountModel.getAccountId());
 			assertEquals("password01", accountModel.getPassword());
 		}
@@ -429,7 +429,7 @@ public class AccountRestControllerTest {
 		void update_duplicate_accountId() throws Exception {
 			String accountId = "aaaaaaaa";
 
-			doReturn(1).when(sessionHelper).getAccountNo();
+			doReturn(1L).when(sessionHelper).getAccountNo();
 			doReturn("bbbbbbbb").when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
@@ -446,7 +446,7 @@ public class AccountRestControllerTest {
 				.andExpect(jsonPath("$.message").value(""));
 
 			AccountModel accountModel = accountModelCaptor.getValue();
-			assertEquals(1, accountModel.getAccountNo());
+			assertEquals(1L, accountModel.getAccountNo());
 			assertEquals(accountId, accountModel.getAccountId());
 			assertNull(accountModel.getPassword());
 		}
@@ -496,7 +496,7 @@ public class AccountRestControllerTest {
 		void update_UpdateFailureException() throws Exception {
 			String accountId = "aaaaaaaa";
 
-			doReturn(1).when(sessionHelper).getAccountNo();
+			doReturn(1L).when(sessionHelper).getAccountNo();
 
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
 			doThrow(UpdateFailureException.class).when(accountServiceImpl).updateAccount(accountModelCaptor.capture());
@@ -507,7 +507,7 @@ public class AccountRestControllerTest {
 				.andExpect(status().isConflict());
 
 			AccountModel accountModel = accountModelCaptor.getValue();
-			assertEquals(1, accountModel.getAccountNo());
+			assertEquals(1L, accountModel.getAccountNo());
 			assertEquals(accountId, accountModel.getAccountId());
 			assertEquals("AAAAAAAA", accountModel.getAccountName());
 			assertEquals("password01", accountModel.getPassword());

--- a/backend/src/test/java/com/web/gallery/controller/PhotoFavoriteControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/PhotoFavoriteControllerTest.java
@@ -67,7 +67,7 @@ public class PhotoFavoriteControllerTest {
 		@Order(1)
 		@DisplayName("正常系")
 		void addFavorite_success() throws Exception {
-			doReturn(1).when(sessionHelper).getAccountNo();
+			doReturn(1L).when(sessionHelper).getAccountNo();
 
 			ArgumentCaptor<PhotoFavoriteModel> photoFavoriteModelCaptor = ArgumentCaptor.forClass(PhotoFavoriteModel.class);
 			doNothing().when(photoFavoriteServiceImpl).addFavorite(photoFavoriteModelCaptor.capture());
@@ -81,9 +81,9 @@ public class PhotoFavoriteControllerTest {
 				.andExpect(jsonPath("$.message").value("お気に入りに追加しました。"));
 
 			PhotoFavoriteModel photoFavoriteModel = photoFavoriteModelCaptor.getValue();
-			assertEquals(1, photoFavoriteModel.getAccountNo());
-			assertEquals(2, photoFavoriteModel.getFavoritePhotoAccountNo());
-			assertEquals(3, photoFavoriteModel.getFavoritePhotoNo());
+			assertEquals(1L, photoFavoriteModel.getAccountNo());
+			assertEquals(2L, photoFavoriteModel.getFavoritePhotoAccountNo());
+			assertEquals(3L, photoFavoriteModel.getFavoritePhotoNo());
 		}
 
 		@Test
@@ -103,7 +103,7 @@ public class PhotoFavoriteControllerTest {
 		@Order(3)
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
 		void addFavorite_RegistFailureException() throws Exception {
-			doReturn(1).when(sessionHelper).getAccountNo();
+			doReturn(1L).when(sessionHelper).getAccountNo();
 
 			ArgumentCaptor<PhotoFavoriteModel> photoFavoriteModelCaptor = ArgumentCaptor.forClass(PhotoFavoriteModel.class);
 			doThrow(RegistFailureException.class).when(photoFavoriteServiceImpl).addFavorite(photoFavoriteModelCaptor.capture());
@@ -114,9 +114,9 @@ public class PhotoFavoriteControllerTest {
 				.andExpect(status().isConflict());
 
 			PhotoFavoriteModel photoFavoriteModel = photoFavoriteModelCaptor.getValue();
-			assertEquals(1, photoFavoriteModel.getAccountNo());
-			assertEquals(2, photoFavoriteModel.getFavoritePhotoAccountNo());
-			assertEquals(3, photoFavoriteModel.getFavoritePhotoNo());
+			assertEquals(1L, photoFavoriteModel.getAccountNo());
+			assertEquals(2L, photoFavoriteModel.getFavoritePhotoAccountNo());
+			assertEquals(3L, photoFavoriteModel.getFavoritePhotoNo());
 		}
 	}
 
@@ -128,7 +128,7 @@ public class PhotoFavoriteControllerTest {
 		@Order(1)
 		@DisplayName("正常系")
 		void deleteFavorite_success() throws Exception {
-			doReturn(1).when(sessionHelper).getAccountNo();
+			doReturn(1L).when(sessionHelper).getAccountNo();
 
 			ArgumentCaptor<PhotoFavoriteModel> photoFavoriteModelCaptor = ArgumentCaptor.forClass(PhotoFavoriteModel.class);
 			doNothing().when(photoFavoriteServiceImpl).deleteFavorite(photoFavoriteModelCaptor.capture());
@@ -142,9 +142,9 @@ public class PhotoFavoriteControllerTest {
 				.andExpect(jsonPath("$.message").value("お気に入りを解除しました。"));
 
 			PhotoFavoriteModel photoFavoriteModel = photoFavoriteModelCaptor.getValue();
-			assertEquals(1, photoFavoriteModel.getAccountNo());
-			assertEquals(2, photoFavoriteModel.getFavoritePhotoAccountNo());
-			assertEquals(3, photoFavoriteModel.getFavoritePhotoNo());
+			assertEquals(1L, photoFavoriteModel.getAccountNo());
+			assertEquals(2L, photoFavoriteModel.getFavoritePhotoAccountNo());
+			assertEquals(3L, photoFavoriteModel.getFavoritePhotoNo());
 		}
 
 		@Test
@@ -164,7 +164,7 @@ public class PhotoFavoriteControllerTest {
 		@Order(3)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
 		void deleteFavorite_UpdateFailureException() throws Exception {
-			doReturn(1).when(sessionHelper).getAccountNo();
+			doReturn(1L).when(sessionHelper).getAccountNo();
 
 			ArgumentCaptor<PhotoFavoriteModel> photoFavoriteModelCaptor = ArgumentCaptor.forClass(PhotoFavoriteModel.class);
 			doThrow(UpdateFailureException.class).when(photoFavoriteServiceImpl).deleteFavorite(photoFavoriteModelCaptor.capture());
@@ -175,9 +175,9 @@ public class PhotoFavoriteControllerTest {
 				.andExpect(status().isConflict());
 
 			PhotoFavoriteModel photoFavoriteModel = photoFavoriteModelCaptor.getValue();
-			assertEquals(1, photoFavoriteModel.getAccountNo());
-			assertEquals(2, photoFavoriteModel.getFavoritePhotoAccountNo());
-			assertEquals(3, photoFavoriteModel.getFavoritePhotoNo());
+			assertEquals(1L, photoFavoriteModel.getAccountNo());
+			assertEquals(2L, photoFavoriteModel.getFavoritePhotoAccountNo());
+			assertEquals(3L, photoFavoriteModel.getFavoritePhotoNo());
 		}
 	}
 }

--- a/backend/src/test/java/com/web/gallery/controller/PhotoRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/PhotoRestControllerTest.java
@@ -83,8 +83,8 @@ public class PhotoRestControllerTest {
 		private List<PhotoModel> createPhotoModelList() {
 			List<PhotoModel> photoList = new ArrayList<PhotoModel>();
 			photoList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.favoriteCount(1)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -94,8 +94,8 @@ public class PhotoRestControllerTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(2)
+					.accountNo(1L)
+					.photoNo(2L)
 					.favoriteCount(1)
 					.isFavorite(true)
 					.photoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -105,8 +105,8 @@ public class PhotoRestControllerTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(3)
+					.accountNo(1L)
+					.photoNo(3L)
 					.favoriteCount(1)
 					.isFavorite(true)
 					.photoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -116,8 +116,8 @@ public class PhotoRestControllerTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(4)
+					.accountNo(1L)
+					.photoNo(4L)
 					.favoriteCount(1)
 					.isFavorite(true)
 					.photoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -127,8 +127,8 @@ public class PhotoRestControllerTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(5)
+					.accountNo(1L)
+					.photoNo(5L)
 					.favoriteCount(1)
 					.isFavorite(true)
 					.photoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -138,8 +138,8 @@ public class PhotoRestControllerTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(6)
+					.accountNo(1L)
+					.photoNo(6L)
 					.favoriteCount(1)
 					.isFavorite(true)
 					.photoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -149,8 +149,8 @@ public class PhotoRestControllerTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(7)
+					.accountNo(1L)
+					.photoNo(7L)
 					.favoriteCount(1)
 					.isFavorite(true)
 					.photoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -167,7 +167,7 @@ public class PhotoRestControllerTest {
 		@Order(1)
 		@DisplayName("正常系：Nullのパラメータがある場合")
 		void getPhotoList_with_null_parameter() throws Exception {
-			doReturn(1).when(sessionHelper).getAccountNo();
+			doReturn(1L).when(sessionHelper).getAccountNo();
 
 			List<PhotoModel> photoList = createPhotoModelList();
 			ArgumentCaptor<PhotoListGetModel> photoListGetModelCaptor = ArgumentCaptor.forClass(PhotoListGetModel.class);
@@ -199,7 +199,7 @@ public class PhotoRestControllerTest {
 				.andExpect(jsonPath("$.photoList[2].directionKbn").value("horizontal"));
 
 			PhotoListGetModel photoListGetModel = photoListGetModelCaptor.getValue();
-			assertEquals(1, photoListGetModel.getAccountNo());
+			assertEquals(1L, photoListGetModel.getAccountNo());
 			assertEquals("aaaaaaaa", photoListGetModel.getPhotoAccountId());
 			assertEquals(DirectionEnum.NONE, photoListGetModel.getDirectionKbn());
 			assertFalse(photoListGetModel.getIsFavoriteOnly());
@@ -211,7 +211,7 @@ public class PhotoRestControllerTest {
 		@Order(2)
 		@DisplayName("正常系：タグに半角スペースが含まれている場合")
 		void getPhotoList_with_halfspace_tag() throws Exception {
-			doReturn(1).when(sessionHelper).getAccountNo();
+			doReturn(1L).when(sessionHelper).getAccountNo();
 
 			List<PhotoModel> photoList = createPhotoModelList().subList(0, 4);
 			ArgumentCaptor<PhotoListGetModel> photoListGetModelCaptor = ArgumentCaptor.forClass(PhotoListGetModel.class);
@@ -236,7 +236,7 @@ public class PhotoRestControllerTest {
 				.andExpect(jsonPath("$.photoList[0].directionKbn").value("horizontal"));
 
 			PhotoListGetModel photoListGetModel = photoListGetModelCaptor.getValue();
-			assertEquals(1, photoListGetModel.getAccountNo());
+			assertEquals(1L, photoListGetModel.getAccountNo());
 			assertEquals("aaaaaaaa", photoListGetModel.getPhotoAccountId());
 			assertEquals(DirectionEnum.VERTICAL, photoListGetModel.getDirectionKbn());
 			assertTrue(photoListGetModel.getIsFavoriteOnly());
@@ -249,7 +249,7 @@ public class PhotoRestControllerTest {
 		@Order(3)
 		@DisplayName("正常系：タグに全角スペースが含まれている場合")
 		void getPhotoList_with_fullspace_tag() throws Exception {
-			doReturn(1).when(sessionHelper).getAccountNo();
+			doReturn(1L).when(sessionHelper).getAccountNo();
 
 			List<PhotoModel> photoList = createPhotoModelList().subList(0, 4);
 			ArgumentCaptor<PhotoListGetModel> photoListGetModelCaptor = ArgumentCaptor.forClass(PhotoListGetModel.class);
@@ -274,7 +274,7 @@ public class PhotoRestControllerTest {
 				.andExpect(jsonPath("$.photoList[0].directionKbn").value("horizontal"));
 
 			PhotoListGetModel photoListGetModel = photoListGetModelCaptor.getValue();
-			assertEquals(1, photoListGetModel.getAccountNo());
+			assertEquals(1L, photoListGetModel.getAccountNo());
 			assertEquals("aaaaaaaa", photoListGetModel.getPhotoAccountId());
 			assertEquals(DirectionEnum.VERTICAL, photoListGetModel.getDirectionKbn());
 			assertTrue(photoListGetModel.getIsFavoriteOnly());
@@ -287,7 +287,7 @@ public class PhotoRestControllerTest {
 		@Order(4)
 		@DisplayName("正常系：写真が0件の場合")
 		void getPhotoList_not_found_photo() throws Exception {
-			doReturn(1).when(sessionHelper).getAccountNo();
+			doReturn(1L).when(sessionHelper).getAccountNo();
 
 			List<PhotoModel> photoList = new ArrayList<PhotoModel>();
 			ArgumentCaptor<PhotoListGetModel> photoListGetModelCaptor = ArgumentCaptor.forClass(PhotoListGetModel.class);
@@ -301,7 +301,7 @@ public class PhotoRestControllerTest {
 				.andExpect(jsonPath("$.photoList.length()").value(0));
 
 			PhotoListGetModel photoListGetModel = photoListGetModelCaptor.getValue();
-			assertEquals(1, photoListGetModel.getAccountNo());
+			assertEquals(1L, photoListGetModel.getAccountNo());
 			assertEquals("aaaaaaaa", photoListGetModel.getPhotoAccountId());
 			assertEquals(DirectionEnum.NONE, photoListGetModel.getDirectionKbn());
 			assertFalse(photoListGetModel.getIsFavoriteOnly());
@@ -327,12 +327,12 @@ public class PhotoRestControllerTest {
 					"sample image".getBytes());
 
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
-			doReturn(1).when(sessionHelper).getAccountNo();
-			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1);
+			doReturn(1L).when(sessionHelper).getAccountNo();
+			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1L);
 
 			ArgumentCaptor<List<PhotoDetailModel>> photoDetailModelCaptor = ArgumentCaptor.forClass(List.class);
 			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
-			doReturn(1).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
+			doReturn(1L).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
 
 			mockMvc.perform(multipart("/api/v1/accounts/aaaaaaaa/photos")
 					.file(multipartFile)
@@ -346,7 +346,7 @@ public class PhotoRestControllerTest {
 
 			List<PhotoDetailModel> photoDetailModelList = photoDetailModelCaptor.getValue();
 			assertEquals(1, photoDetailModelList.size());
-			assertEquals(1, photoDetailModelList.getFirst().getAccountNo());
+			assertEquals(1L, photoDetailModelList.getFirst().getAccountNo());
 			assertNull(photoDetailModelList.getFirst().getPhotoNo());
 			assertNull(photoDetailModelList.getFirst().getIsFavorite());
 			assertNull(photoDetailModelList.getFirst().getPhotoAt());
@@ -391,7 +391,7 @@ public class PhotoRestControllerTest {
 
 			ArgumentCaptor<List<PhotoDetailModel>> photoDetailModelCaptor = ArgumentCaptor.forClass(List.class);
 			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
-			doReturn(1).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
+			doReturn(1L).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
 
 			mockMvc.perform(multipart("/api/v1/accounts/aaaaaaaa/photos")
 					.file(multipartFile)
@@ -428,15 +428,15 @@ public class PhotoRestControllerTest {
 				.andExpect(jsonPath("$.message").value("写真登録が完了しました。"));
 
 			verify(sessionHelper, times(0)).getAccountNo();
-			verify(photoServiceImpl, times(0)).isReachedUpperLimit(1);
+			verify(photoServiceImpl, times(0)).isReachedUpperLimit(1L);
 
 			List<PhotoDetailModel> photoDetailModelList = photoDetailModelCaptor.getValue();
 			assertEquals(1, photoDetailModelList.size());
-			assertEquals(1, photoDetailModelList.getFirst().getAccountNo());
-			assertEquals(1, photoDetailModelList.getFirst().getPhotoNo());
+			assertEquals(1L, photoDetailModelList.getFirst().getAccountNo());
+			assertEquals(1L, photoDetailModelList.getFirst().getPhotoNo());
 			assertFalse(photoDetailModelList.getFirst().getIsFavorite());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9)), photoDetailModelList.getFirst().getPhotoAt());
-			assertEquals(1, photoDetailModelList.getFirst().getLocationNo());
+			assertEquals(1L, photoDetailModelList.getFirst().getLocationNo());
 			assertEquals(address, photoDetailModelList.getFirst().getAddress());
 			assertEquals(0, BigDecimal.valueOf(35.000).compareTo(photoDetailModelList.getFirst().getLatitude()));
 			assertEquals(0, BigDecimal.valueOf(135.000).compareTo(photoDetailModelList.getFirst().getLongitude()));
@@ -452,10 +452,10 @@ public class PhotoRestControllerTest {
 			assertEquals(0, BigDecimal.valueOf(0.001).compareTo(photoDetailModelList.getFirst().getShutterSpeed()));
 			assertEquals(100, photoDetailModelList.getFirst().getIso());
 
-			assertEquals(1, photoDetailModelList.getFirst().getPhotoTagModelList().get(0).getTagNo());
+			assertEquals(1L, photoDetailModelList.getFirst().getPhotoTagModelList().get(0).getTagNo());
 			assertEquals("太陽", photoDetailModelList.getFirst().getPhotoTagModelList().get(0).getTagJapaneseName());
 			assertEquals("sun", photoDetailModelList.getFirst().getPhotoTagModelList().get(0).getTagEnglishName());
-			assertEquals(2, photoDetailModelList.getFirst().getPhotoTagModelList().get(1).getTagNo());
+			assertEquals(2L, photoDetailModelList.getFirst().getPhotoTagModelList().get(1).getTagNo());
 			assertEquals("海", photoDetailModelList.getFirst().getPhotoTagModelList().get(1).getTagJapaneseName());
 			assertEquals("", photoDetailModelList.getFirst().getPhotoTagModelList().get(1).getTagEnglishName());
 
@@ -474,7 +474,7 @@ public class PhotoRestControllerTest {
 					.param("directionKbn", "VERTICAL"))
 				.andExpect(status().isForbidden());
 
-			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Integer.class));
+			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Long.class));
 			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(List.class));
 		}
 
@@ -484,8 +484,8 @@ public class PhotoRestControllerTest {
 		@DisplayName("異常系：登録上限に達している。PhotoNotAdditableExceptionをthrowする")
 		void savePhoto_PhotoNotAdditableException() throws Exception {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
-			doReturn(1).when(sessionHelper).getAccountNo();
-			doReturn(true).when(photoServiceImpl).isReachedUpperLimit(1);
+			doReturn(1L).when(sessionHelper).getAccountNo();
+			doReturn(true).when(photoServiceImpl).isReachedUpperLimit(1L);
 
 			mockMvc.perform(multipart("/api/v1/accounts/aaaaaaaa/photos")
 					.param("accountNo", "1")
@@ -501,8 +501,8 @@ public class PhotoRestControllerTest {
 		@DisplayName("異常系：画像ファイル、ファイルパスともにnull。BadRequestExceptionをthrowする")
 		void savePhoto_BadRequestException_file_and_filepath_is_null() throws Exception {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
-			doReturn(1).when(sessionHelper).getAccountNo();
-			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1);
+			doReturn(1L).when(sessionHelper).getAccountNo();
+			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1L);
 
 			mockMvc.perform(multipart("/api/v1/accounts/aaaaaaaa/photos")
 					.param("accountNo", "1")
@@ -518,8 +518,8 @@ public class PhotoRestControllerTest {
 		@DisplayName("異常系：画像ファイルがnull、ファイルパスがblank。BadRequestExceptionをthrowする")
 		void savePhoto_BadRequestException_file_and_filepath_is_blank() throws Exception {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
-			doReturn(1).when(sessionHelper).getAccountNo();
-			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1);
+			doReturn(1L).when(sessionHelper).getAccountNo();
+			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1L);
 
 			mockMvc.perform(multipart("/api/v1/accounts/aaaaaaaa/photos")
 					.param("accountNo", "1")
@@ -536,8 +536,8 @@ public class PhotoRestControllerTest {
 		@DisplayName("異常系：画像ファイル、ファイルパス以外のパラメータ不正。BadRequestExceptionをthrowする")
 		void savePhoto_BadRequestException_others() throws Exception {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
-			doReturn(1).when(sessionHelper).getAccountNo();
-			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1);
+			doReturn(1L).when(sessionHelper).getAccountNo();
+			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1L);
 
 			mockMvc.perform(multipart("/api/v1/accounts/aaaaaaaa/photos")
 					.param("accountNo", "1")
@@ -575,13 +575,13 @@ public class PhotoRestControllerTest {
 					.param("directionKbn", "VERTICAL"))
 				.andExpect(status().isConflict());
 
-			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Integer.class));
+			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Long.class));
 			verify(sessionHelper, times(0)).getAccountNo();
 
 			List<PhotoDetailModel> photoDetailModelList = photoDetailModelCaptor.getValue();
 			assertEquals(1, photoDetailModelList.size());
-			assertEquals(1, photoDetailModelList.getFirst().getAccountNo());
-			assertEquals(1, photoDetailModelList.getFirst().getPhotoNo());
+			assertEquals(1L, photoDetailModelList.getFirst().getAccountNo());
+			assertEquals(1L, photoDetailModelList.getFirst().getPhotoNo());
 			assertNull(photoDetailModelList.getFirst().getIsFavorite());
 			assertNull(photoDetailModelList.getFirst().getPhotoAt());
 			assertNull(photoDetailModelList.getFirst().getLocationNo());
@@ -630,13 +630,13 @@ public class PhotoRestControllerTest {
 					.param("directionKbn", "VERTICAL"))
 				.andExpect(status().isConflict());
 
-			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Integer.class));
+			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Long.class));
 			verify(sessionHelper, times(0)).getAccountNo();
 
 			List<PhotoDetailModel> photoDetailModelList = photoDetailModelCaptor.getValue();
 			assertEquals(1, photoDetailModelList.size());
-			assertEquals(1, photoDetailModelList.getFirst().getAccountNo());
-			assertEquals(1, photoDetailModelList.getFirst().getPhotoNo());
+			assertEquals(1L, photoDetailModelList.getFirst().getAccountNo());
+			assertEquals(1L, photoDetailModelList.getFirst().getPhotoNo());
 			assertNull(photoDetailModelList.getFirst().getIsFavorite());
 			assertNull(photoDetailModelList.getFirst().getPhotoAt());
 			assertNull(photoDetailModelList.getFirst().getLocationNo());
@@ -685,13 +685,13 @@ public class PhotoRestControllerTest {
 					.param("directionKbn", "VERTICAL"))
 				.andExpect(status().isConflict());
 
-			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Integer.class));
+			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Long.class));
 			verify(sessionHelper, times(0)).getAccountNo();
 
 			List<PhotoDetailModel> photoDetailModelList = photoDetailModelCaptor.getValue();
 			assertEquals(1, photoDetailModelList.size());
-			assertEquals(1, photoDetailModelList.getFirst().getAccountNo());
-			assertEquals(1, photoDetailModelList.getFirst().getPhotoNo());
+			assertEquals(1L, photoDetailModelList.getFirst().getAccountNo());
+			assertEquals(1L, photoDetailModelList.getFirst().getPhotoNo());
 			assertNull(photoDetailModelList.getFirst().getIsFavorite());
 			assertNull(photoDetailModelList.getFirst().getPhotoAt());
 			assertNull(photoDetailModelList.getFirst().getLocationNo());
@@ -742,8 +742,8 @@ public class PhotoRestControllerTest {
 
 			List<PhotoDeleteModel> photoDeleteModelList = photoDeleteModelCaptor.getValue();
 			assertEquals(1, photoDeleteModelList.size());
-			assertEquals(1, photoDeleteModelList.getFirst().getAccountNo());
-			assertEquals(1, photoDeleteModelList.getFirst().getPhotoNo());
+			assertEquals(1L, photoDeleteModelList.getFirst().getAccountNo());
+			assertEquals(1L, photoDeleteModelList.getFirst().getPhotoNo());
 			assertEquals(imageFilePath, photoDeleteModelList.getFirst().getImageFilePath());
 			assertEquals("aaaaaaaa", photoAcountIdCaptor.getValue());
 		}
@@ -796,8 +796,8 @@ public class PhotoRestControllerTest {
 
 			List<PhotoDeleteModel> photoDeleteModelList = photoDeleteModelCaptor.getValue();
 			assertEquals(1, photoDeleteModelList.size());
-			assertEquals(1, photoDeleteModelList.getFirst().getAccountNo());
-			assertEquals(1, photoDeleteModelList.getFirst().getPhotoNo());
+			assertEquals(1L, photoDeleteModelList.getFirst().getAccountNo());
+			assertEquals(1L, photoDeleteModelList.getFirst().getPhotoNo());
 			assertEquals(imageFilePath, photoDeleteModelList.getFirst().getImageFilePath());
 			assertEquals("aaaaaaaa", photoAcountIdCaptor.getValue());
 		}
@@ -810,8 +810,8 @@ public class PhotoRestControllerTest {
 		private List<PhotoModel> createPhotoList() {
 			List<PhotoModel> photoList = new ArrayList<PhotoModel>();
 			photoList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.favoriteCount(1)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -821,8 +821,8 @@ public class PhotoRestControllerTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(2)
+					.accountNo(1L)
+					.photoNo(2L)
 					.favoriteCount(1)
 					.isFavorite(true)
 					.photoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -832,8 +832,8 @@ public class PhotoRestControllerTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(3)
+					.accountNo(1L)
+					.photoNo(3L)
 					.favoriteCount(1)
 					.isFavorite(true)
 					.photoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -843,8 +843,8 @@ public class PhotoRestControllerTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(4)
+					.accountNo(1L)
+					.photoNo(4L)
 					.favoriteCount(1)
 					.isFavorite(true)
 					.photoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -854,8 +854,8 @@ public class PhotoRestControllerTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(5)
+					.accountNo(1L)
+					.photoNo(5L)
 					.favoriteCount(1)
 					.isFavorite(true)
 					.photoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -865,8 +865,8 @@ public class PhotoRestControllerTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(6)
+					.accountNo(1L)
+					.photoNo(6L)
 					.favoriteCount(1)
 					.isFavorite(true)
 					.photoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -876,8 +876,8 @@ public class PhotoRestControllerTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(7)
+					.accountNo(1L)
+					.photoNo(7L)
 					.favoriteCount(1)
 					.isFavorite(true)
 					.photoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -900,8 +900,8 @@ public class PhotoRestControllerTest {
 
 			PhotoListGetResponse actual = PhotoListGetResponse.from(photoList, pageNo, photoCountPerPage);
 			assertEquals(1, actual.getPhotoList().size());
-			assertEquals(1, actual.getPhotoList().getFirst().getAccountNo());
-			assertEquals(1, actual.getPhotoList().getFirst().getPhotoNo());
+			assertEquals(1L, actual.getPhotoList().getFirst().getAccountNo());
+			assertEquals(1L, actual.getPhotoList().getFirst().getPhotoNo());
 			assertFalse(actual.getPhotoList().getFirst().getIsFavorite());
 			assertEquals("https://localhost:8080/image/aaaaaaaa/DSC111.jpg", actual.getPhotoList().getFirst().getImageFilePath());
 			assertEquals("キャプション1", actual.getPhotoList().getFirst().getCaption());
@@ -919,20 +919,20 @@ public class PhotoRestControllerTest {
 
 			PhotoListGetResponse actual = PhotoListGetResponse.from(photoList, pageNo, photoCountPerPage);
 			assertEquals(3, actual.getPhotoList().size());
-			assertEquals(1, actual.getPhotoList().get(0).getAccountNo());
-			assertEquals(1, actual.getPhotoList().get(0).getPhotoNo());
+			assertEquals(1L, actual.getPhotoList().get(0).getAccountNo());
+			assertEquals(1L, actual.getPhotoList().get(0).getPhotoNo());
 			assertFalse(actual.getPhotoList().get(0).getIsFavorite());
 			assertEquals("https://localhost:8080/image/aaaaaaaa/DSC111.jpg", actual.getPhotoList().get(0).getImageFilePath());
 			assertEquals("キャプション1", actual.getPhotoList().get(0).getCaption());
 			assertEquals(DirectionEnum.VERTICAL, actual.getPhotoList().get(0).getDirectionKbn());
-			assertEquals(1, actual.getPhotoList().get(1).getAccountNo());
-			assertEquals(2, actual.getPhotoList().get(1).getPhotoNo());
+			assertEquals(1L, actual.getPhotoList().get(1).getAccountNo());
+			assertEquals(2L, actual.getPhotoList().get(1).getPhotoNo());
 			assertTrue(actual.getPhotoList().get(1).getIsFavorite());
 			assertEquals("https://localhost:8080/image/aaaaaaaa/DSC222.jpg", actual.getPhotoList().get(1).getImageFilePath());
 			assertEquals("キャプション2", actual.getPhotoList().get(1).getCaption());
 			assertEquals(DirectionEnum.HORIZONTAL, actual.getPhotoList().get(1).getDirectionKbn());
-			assertEquals(1, actual.getPhotoList().get(2).getAccountNo());
-			assertEquals(3, actual.getPhotoList().get(2).getPhotoNo());
+			assertEquals(1L, actual.getPhotoList().get(2).getAccountNo());
+			assertEquals(3L, actual.getPhotoList().get(2).getPhotoNo());
 			assertTrue(actual.getPhotoList().get(2).getIsFavorite());
 			assertEquals("https://localhost:8080/image/aaaaaaaa/DSC333.jpg", actual.getPhotoList().get(2).getImageFilePath());
 			assertEquals("キャプション3", actual.getPhotoList().get(2).getCaption());
@@ -950,8 +950,8 @@ public class PhotoRestControllerTest {
 
 			PhotoListGetResponse actual = PhotoListGetResponse.from(photoList, pageNo, photoCountPerPage);
 			assertEquals(1, actual.getPhotoList().size());
-			assertEquals(1, actual.getPhotoList().get(0).getAccountNo());
-			assertEquals(4, actual.getPhotoList().get(0).getPhotoNo());
+			assertEquals(1L, actual.getPhotoList().get(0).getAccountNo());
+			assertEquals(4L, actual.getPhotoList().get(0).getPhotoNo());
 			assertTrue(actual.getPhotoList().get(0).getIsFavorite());
 			assertEquals("https://localhost:8080/image/aaaaaaaa/DSC444.jpg", actual.getPhotoList().get(0).getImageFilePath());
 			assertEquals("キャプション4", actual.getPhotoList().get(0).getCaption());
@@ -969,20 +969,20 @@ public class PhotoRestControllerTest {
 
 			PhotoListGetResponse actual = PhotoListGetResponse.from(photoList, pageNo, photoCountPerPage);
 			assertEquals(3, actual.getPhotoList().size());
-			assertEquals(1, actual.getPhotoList().get(0).getAccountNo());
-			assertEquals(4, actual.getPhotoList().get(0).getPhotoNo());
+			assertEquals(1L, actual.getPhotoList().get(0).getAccountNo());
+			assertEquals(4L, actual.getPhotoList().get(0).getPhotoNo());
 			assertTrue(actual.getPhotoList().get(0).getIsFavorite());
 			assertEquals("https://localhost:8080/image/aaaaaaaa/DSC444.jpg", actual.getPhotoList().get(0).getImageFilePath());
 			assertEquals("キャプション4", actual.getPhotoList().get(0).getCaption());
 			assertEquals(DirectionEnum.HORIZONTAL, actual.getPhotoList().get(0).getDirectionKbn());
-			assertEquals(1, actual.getPhotoList().get(1).getAccountNo());
-			assertEquals(5, actual.getPhotoList().get(1).getPhotoNo());
+			assertEquals(1L, actual.getPhotoList().get(1).getAccountNo());
+			assertEquals(5L, actual.getPhotoList().get(1).getPhotoNo());
 			assertTrue(actual.getPhotoList().get(1).getIsFavorite());
 			assertEquals("https://localhost:8080/image/aaaaaaaa/DSC555.jpg", actual.getPhotoList().get(1).getImageFilePath());
 			assertEquals("キャプション5", actual.getPhotoList().get(1).getCaption());
 			assertEquals(DirectionEnum.HORIZONTAL, actual.getPhotoList().get(1).getDirectionKbn());
-			assertEquals(1, actual.getPhotoList().get(2).getAccountNo());
-			assertEquals(6, actual.getPhotoList().get(2).getPhotoNo());
+			assertEquals(1L, actual.getPhotoList().get(2).getAccountNo());
+			assertEquals(6L, actual.getPhotoList().get(2).getPhotoNo());
 			assertTrue(actual.getPhotoList().get(2).getIsFavorite());
 			assertEquals("https://localhost:8080/image/aaaaaaaa/DSC666.jpg", actual.getPhotoList().get(2).getImageFilePath());
 			assertEquals("キャプション6", actual.getPhotoList().get(2).getCaption());
@@ -1000,8 +1000,8 @@ public class PhotoRestControllerTest {
 		@DisplayName("正常系：自分のアカウントで上限未到達の場合")
 		void getPhotoUpperLimit_not_reached() throws Exception {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
-			doReturn(1).when(sessionHelper).getAccountNo();
-			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1);
+			doReturn(1L).when(sessionHelper).getAccountNo();
+			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1L);
 
 			mockMvc.perform(get("/api/v1/accounts/aaaaaaaa/photos/upper-limit"))
 				.andExpect(status().isOk())
@@ -1013,8 +1013,8 @@ public class PhotoRestControllerTest {
 		@DisplayName("正常系：自分のアカウントで上限到達の場合")
 		void getPhotoUpperLimit_reached() throws Exception {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
-			doReturn(1).when(sessionHelper).getAccountNo();
-			doReturn(true).when(photoServiceImpl).isReachedUpperLimit(1);
+			doReturn(1L).when(sessionHelper).getAccountNo();
+			doReturn(true).when(photoServiceImpl).isReachedUpperLimit(1L);
 
 			mockMvc.perform(get("/api/v1/accounts/aaaaaaaa/photos/upper-limit"))
 				.andExpect(status().isOk())
@@ -1031,7 +1031,7 @@ public class PhotoRestControllerTest {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.isReachedUpperLimit").value(false));
 
-			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Integer.class));
+			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Long.class));
 		}
 	}
 }

--- a/backend/src/test/java/com/web/gallery/controller/integration/AccountRestControllerIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/integration/AccountRestControllerIntegrationTest.java
@@ -107,7 +107,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountId = "aaaaaaaa";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId(accountId)
 					.accountName("AAAAAAAA")
 					.password("$2a$10$password1")
@@ -140,7 +140,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountId = "bbbbbbbb";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.accountId(accountId)
 					.accountName("BBBBBBBB")
 					.password("$2a$10$password2")
@@ -171,7 +171,7 @@ public class AccountRestControllerIntegrationTest {
 		@DisplayName("異常系：他人のアカウントIDを指定した場合はForbidden")
 		void getAccount_forbidden() throws Exception {
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.accountName("AAAAAAAA")
 					.password("$2a$10$password1")
@@ -204,10 +204,10 @@ public class AccountRestControllerIntegrationTest {
 			return jdbcTemplate.query(
 					"SELECT * FROM common.account where account_id='" + accountId + "'", (rs, rowNum) ->
 					Account.builder()
-						.accountNo(rs.getInt("account_no"))
-						.createdBy(rs.getInt("created_by"))
+						.accountNo(rs.getLong("account_no"))
+						.createdBy(rs.getLong("created_by"))
 						.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-						.updatedBy(rs.getInt("updated_by"))
+						.updatedBy(rs.getLong("updated_by"))
 						.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 						.isDeleted(rs.getBoolean("is_deleted"))
 						.accountId(rs.getString("account_id"))
@@ -250,9 +250,9 @@ public class AccountRestControllerIntegrationTest {
 			List<Account> actualData = getAccountList(accountId);
 
 			assertEquals(1, actualData.size());
-			assertEquals(4, actualData.getFirst().getAccountNo());
-			assertEquals(0, actualData.getFirst().getCreatedBy());
-			assertEquals(0, actualData.getFirst().getUpdatedBy());
+			assertEquals(4L, actualData.getFirst().getAccountNo());
+			assertEquals(0L, actualData.getFirst().getCreatedBy());
+			assertEquals(0L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals(accountId, actualData.getFirst().getAccountId());
 			assertEquals(accountName, actualData.getFirst().getAccountName());
@@ -318,10 +318,10 @@ public class AccountRestControllerIntegrationTest {
 			return jdbcTemplate.query(
 					"SELECT * FROM common.account where account_id='" + accountId + "'", (rs, rowNum) ->
 					Account.builder()
-						.accountNo(rs.getInt("account_no"))
-						.createdBy(rs.getInt("created_by"))
+						.accountNo(rs.getLong("account_no"))
+						.createdBy(rs.getLong("created_by"))
 						.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-						.updatedBy(rs.getInt("updated_by"))
+						.updatedBy(rs.getLong("updated_by"))
 						.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 						.isDeleted(rs.getBoolean("is_deleted"))
 						.accountId(rs.getString("account_id"))
@@ -346,7 +346,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountName = "AAAAAAAA";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId(accountId)
 					.accountName(accountName)
 					.password("$2a$10$password1")
@@ -373,10 +373,10 @@ public class AccountRestControllerIntegrationTest {
 
 			List<Account> actual = getAccountList(accountId);
 			assertEquals(1, actual.size());
-			assertEquals(1, actual.getFirst().getAccountNo());
-			assertEquals(1, actual.getFirst().getCreatedBy());
+			assertEquals(1L, actual.getFirst().getAccountNo());
+			assertEquals(1L, actual.getFirst().getCreatedBy());
 			assertNotEquals(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getFirst().getCreatedAt());
-			assertEquals(1, actual.getFirst().getUpdatedBy());
+			assertEquals(1L, actual.getFirst().getUpdatedBy());
 			assertFalse(actual.getFirst().getIsDeleted());
 			assertEquals(accountId, actual.getFirst().getAccountId());
 			assertEquals(accountName, actual.getFirst().getAccountName());
@@ -399,7 +399,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountName = "AAAAAAAA";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.accountName(accountName)
 					.password("$2a$10$password1")
@@ -426,10 +426,10 @@ public class AccountRestControllerIntegrationTest {
 
 			List<Account> actual = getAccountList(accountId);
 			assertEquals(1, actual.size());
-			assertEquals(1, actual.getFirst().getAccountNo());
-			assertEquals(1, actual.getFirst().getCreatedBy());
+			assertEquals(1L, actual.getFirst().getAccountNo());
+			assertEquals(1L, actual.getFirst().getCreatedBy());
 			assertNotEquals(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getFirst().getCreatedAt());
-			assertEquals(1, actual.getFirst().getUpdatedBy());
+			assertEquals(1L, actual.getFirst().getUpdatedBy());
 			assertFalse(actual.getFirst().getIsDeleted());
 			assertEquals(accountId, actual.getFirst().getAccountId());
 			assertEquals(accountName, actual.getFirst().getAccountName());
@@ -452,7 +452,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountName = "AAAAAAAA";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId(accountId)
 					.accountName(accountName)
 					.password("$2a$10$password1")
@@ -479,10 +479,10 @@ public class AccountRestControllerIntegrationTest {
 
 			List<Account> actual = getAccountList(accountId);
 			assertEquals(1, actual.size());
-			assertEquals(1, actual.getFirst().getAccountNo());
-			assertEquals(1, actual.getFirst().getCreatedBy());
+			assertEquals(1L, actual.getFirst().getAccountNo());
+			assertEquals(1L, actual.getFirst().getCreatedBy());
 			assertNotEquals(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getFirst().getCreatedAt());
-			assertEquals(1, actual.getFirst().getUpdatedBy());
+			assertEquals(1L, actual.getFirst().getUpdatedBy());
 			assertFalse(actual.getFirst().getIsDeleted());
 			assertEquals(accountId, actual.getFirst().getAccountId());
 			assertEquals(accountName, actual.getFirst().getAccountName());
@@ -505,7 +505,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountName = "AAAAAAAA";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.accountName(accountName)
 					.password("$2a$10$password1")
@@ -532,10 +532,10 @@ public class AccountRestControllerIntegrationTest {
 
 			List<Account> actual = getAccountList(accountId);
 			assertEquals(1, actual.size());
-			assertEquals(1, actual.getFirst().getAccountNo());
-			assertEquals(1, actual.getFirst().getCreatedBy());
+			assertEquals(1L, actual.getFirst().getAccountNo());
+			assertEquals(1L, actual.getFirst().getCreatedBy());
 			assertNotEquals(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getFirst().getCreatedAt());
-			assertEquals(1, actual.getFirst().getUpdatedBy());
+			assertEquals(1L, actual.getFirst().getUpdatedBy());
 			assertFalse(actual.getFirst().getIsDeleted());
 			assertEquals(accountId, actual.getFirst().getAccountId());
 			assertEquals(accountName, actual.getFirst().getAccountName());
@@ -557,7 +557,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountName = "AAAAAAAA";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.accountName(accountName)
 					.password("$2a$10$password1")
@@ -590,7 +590,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountName = "AAAAAAAA";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.accountName(accountName)
 					.password("$2a$10$password1")
@@ -617,7 +617,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountName = "AAAAAAAA";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.accountName(accountName)
 					.password("$2a$10$password1")
@@ -645,7 +645,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountName = "AAAAAAAA";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.accountName(accountName)
 					.password("$2a$10$password1")
@@ -673,7 +673,7 @@ public class AccountRestControllerIntegrationTest {
 			String accountName = "AAAAAAAA";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(9)
+					.accountNo(9L)
 					.accountId(accountId)
 					.accountName(accountName)
 					.password("$2a$10$password1")

--- a/backend/src/test/java/com/web/gallery/controller/integration/PhotoFavoriteControllerIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/integration/PhotoFavoriteControllerIntegrationTest.java
@@ -54,7 +54,7 @@ public class PhotoFavoriteControllerIntegrationTest {
 
 	private Authentication createAuthentication() {
 		AccountModel sessionAccount = AccountModel.builder()
-				.accountNo(1)
+				.accountNo(1L)
 				.accountId("aaaaaaaa")
 				.accountName("AAAAAAAA")
 				.password("$2a$10$password1")
@@ -95,17 +95,17 @@ public class PhotoFavoriteControllerIntegrationTest {
 			List<PhotoFavorite> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite WHERE account_no=1 and favorite_photo_account_no=2 and favorite_photo_no=1", (rs, rowNum) ->
 						PhotoFavorite.builder()
-							.accountNo(rs.getInt("account_no"))
-							.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-							.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+							.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.build());
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(2, actualData.getFirst().getFavoritePhotoAccountNo());
-			assertEquals(1, actualData.getFirst().getFavoritePhotoNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(2L, actualData.getFirst().getFavoritePhotoAccountNo());
+			assertEquals(1L, actualData.getFirst().getFavoritePhotoNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
 		}
 
 		@Test
@@ -177,10 +177,10 @@ public class PhotoFavoriteControllerIntegrationTest {
 			List<PhotoFavorite> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite WHERE account_no=1 and favorite_photo_account_no=1 and favorite_photo_no=1", (rs, rowNum) ->
 						PhotoFavorite.builder()
-							.accountNo(rs.getInt("account_no"))
-							.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-							.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+							.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.build());
 			assertEquals(0, actualData.size());
@@ -188,23 +188,23 @@ public class PhotoFavoriteControllerIntegrationTest {
 			List<PhotoFavorite> actualRestData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite", (rs, rowNum) ->
 						PhotoFavorite.builder()
-							.accountNo(rs.getInt("account_no"))
-							.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-							.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+							.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.build());
 
 			assertEquals(3, actualRestData.size());
-			assertEquals(1, actualRestData.get(0).getAccountNo());
-			assertEquals(1, actualRestData.get(0).getFavoritePhotoAccountNo());
-			assertEquals(2, actualRestData.get(0).getFavoritePhotoNo());
-			assertEquals(2, actualRestData.get(1).getAccountNo());
-			assertEquals(1, actualRestData.get(1).getFavoritePhotoAccountNo());
-			assertEquals(2, actualRestData.get(1).getFavoritePhotoNo());
-			assertEquals(2, actualRestData.get(2).getAccountNo());
-			assertEquals(2, actualRestData.get(2).getFavoritePhotoAccountNo());
-			assertEquals(1, actualRestData.get(2).getFavoritePhotoNo());
+			assertEquals(1L, actualRestData.get(0).getAccountNo());
+			assertEquals(1L, actualRestData.get(0).getFavoritePhotoAccountNo());
+			assertEquals(2L, actualRestData.get(0).getFavoritePhotoNo());
+			assertEquals(2L, actualRestData.get(1).getAccountNo());
+			assertEquals(1L, actualRestData.get(1).getFavoritePhotoAccountNo());
+			assertEquals(2L, actualRestData.get(1).getFavoritePhotoNo());
+			assertEquals(2L, actualRestData.get(2).getAccountNo());
+			assertEquals(2L, actualRestData.get(2).getFavoritePhotoAccountNo());
+			assertEquals(1L, actualRestData.get(2).getFavoritePhotoNo());
 		}
 
 		@Test

--- a/backend/src/test/java/com/web/gallery/controller/integration/PhotoRestControllerIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/integration/PhotoRestControllerIntegrationTest.java
@@ -222,7 +222,7 @@ public class PhotoRestControllerIntegrationTest {
 					"sample image".getBytes());
 			
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
 					.password("$2a$10$password2")
@@ -255,15 +255,15 @@ public class PhotoRestControllerIntegrationTest {
 			List<PhotoMst> actualPhotoMst = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no = 2 and photo_no=4", (rs, rowNum) ->
 					PhotoMst.builder()
-						.accountNo(rs.getInt("account_no"))
-						.photoNo(rs.getInt("photo_no"))
-						.createdBy(rs.getInt("created_by"))
+						.accountNo(rs.getLong("account_no"))
+						.photoNo(rs.getLong("photo_no"))
+						.createdBy(rs.getLong("created_by"))
 						.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-						.updatedBy(rs.getInt("updated_by"))
+						.updatedBy(rs.getLong("updated_by"))
 						.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 						.isDeleted(rs.getBoolean("is_deleted"))
 						.photoAt(rs.getObject("photo_at", OffsetDateTime.class))
-						.locationNo(rs.getInt("location_no"))
+						.locationNo(rs.getLong("location_no"))
 						.imageFilePath(rs.getString("image_file_path"))
 						.photoJapaneseTitle(rs.getString("photo_japanese_title"))
 						.photoEnglishTitle(rs.getString("photo_english_title"))
@@ -276,11 +276,11 @@ public class PhotoRestControllerIntegrationTest {
 						.build());
 			
 			assertEquals(1, actualPhotoMst.size());
-			assertEquals(2, actualPhotoMst.getFirst().getAccountNo());
-			assertEquals(4, actualPhotoMst.getFirst().getPhotoNo());
+			assertEquals(2L, actualPhotoMst.getFirst().getAccountNo());
+			assertEquals(4L, actualPhotoMst.getFirst().getPhotoNo());
 			assertFalse(actualPhotoMst.getFirst().getIsDeleted());
 			assertEquals(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualPhotoMst.getFirst().getPhotoAt().plusHours(9));
-			assertEquals(0, actualPhotoMst.getFirst().getLocationNo());
+			assertEquals(0L, actualPhotoMst.getFirst().getLocationNo());
 			assertEquals("https://www.xxx.com/bbbbbbbb/DSC111.jpg", actualPhotoMst.getFirst().getImageFilePath());
 			assertEquals("", actualPhotoMst.getFirst().getPhotoJapaneseTitle());
 			assertEquals("", actualPhotoMst.getFirst().getPhotoEnglishTitle());
@@ -295,10 +295,10 @@ public class PhotoRestControllerIntegrationTest {
 			List<PhotoTagMst> actualPhotoTagMst = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_tag_mst WHERE account_no=2 and photo_no=4", (rs, rowNum) ->
 							PhotoTagMst.builder()
-								.accountNo(rs.getInt("account_no"))
-								.photoNo(rs.getInt("photo_no"))
-								.tagNo(rs.getInt("tag_no"))
-								.createdBy(rs.getInt("created_by"))
+								.accountNo(rs.getLong("account_no"))
+								.photoNo(rs.getLong("photo_no"))
+								.tagNo(rs.getLong("tag_no"))
+								.createdBy(rs.getLong("created_by"))
 								.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 								.tagJapaneseName(rs.getObject("tag_japanese_name").toString())
 								.tagEnglishName(rs.getObject("tag_english_name").toString())
@@ -318,7 +318,7 @@ public class PhotoRestControllerIntegrationTest {
 					"sample image".getBytes());
 			
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
 					.password("$2a$10$password2")
@@ -362,15 +362,15 @@ public class PhotoRestControllerIntegrationTest {
 			List<PhotoMst> actualPhotoMst = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no = 2 and photo_no=4", (rs, rowNum) ->
 					PhotoMst.builder()
-						.accountNo(rs.getInt("account_no"))
-						.photoNo(rs.getInt("photo_no"))
-						.createdBy(rs.getInt("created_by"))
+						.accountNo(rs.getLong("account_no"))
+						.photoNo(rs.getLong("photo_no"))
+						.createdBy(rs.getLong("created_by"))
 						.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-						.updatedBy(rs.getInt("updated_by"))
+						.updatedBy(rs.getLong("updated_by"))
 						.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 						.isDeleted(rs.getBoolean("is_deleted"))
 						.photoAt(rs.getObject("photo_at", OffsetDateTime.class))
-						.locationNo(rs.getInt("location_no"))
+						.locationNo(rs.getLong("location_no"))
 						.imageFilePath(rs.getString("image_file_path"))
 						.photoJapaneseTitle(rs.getString("photo_japanese_title"))
 						.photoEnglishTitle(rs.getString("photo_english_title"))
@@ -383,11 +383,11 @@ public class PhotoRestControllerIntegrationTest {
 						.build());
 			
 			assertEquals(1, actualPhotoMst.size());
-			assertEquals(2, actualPhotoMst.getFirst().getAccountNo());
-			assertEquals(4, actualPhotoMst.getFirst().getPhotoNo());
+			assertEquals(2L, actualPhotoMst.getFirst().getAccountNo());
+			assertEquals(4L, actualPhotoMst.getFirst().getPhotoNo());
 			assertFalse(actualPhotoMst.getFirst().getIsDeleted());
 			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualPhotoMst.getFirst().getPhotoAt().plusHours(9));
-			assertEquals(0, actualPhotoMst.getFirst().getLocationNo());
+			assertEquals(0L, actualPhotoMst.getFirst().getLocationNo());
 			assertEquals("https://www.xxx.com/bbbbbbbb/DSC111.jpg", actualPhotoMst.getFirst().getImageFilePath());
 			assertEquals("タイトル111", actualPhotoMst.getFirst().getPhotoJapaneseTitle());
 			assertEquals("title111", actualPhotoMst.getFirst().getPhotoEnglishTitle());
@@ -402,24 +402,24 @@ public class PhotoRestControllerIntegrationTest {
 			List<PhotoTagMst> actualPhotoTagMst = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_tag_mst WHERE account_no=2 and photo_no=4", (rs, rowNum) ->
 							PhotoTagMst.builder()
-								.accountNo(rs.getInt("account_no"))
-								.photoNo(rs.getInt("photo_no"))
-								.tagNo(rs.getInt("tag_no"))
-								.createdBy(rs.getInt("created_by"))
+								.accountNo(rs.getLong("account_no"))
+								.photoNo(rs.getLong("photo_no"))
+								.tagNo(rs.getLong("tag_no"))
+								.createdBy(rs.getLong("created_by"))
 								.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 								.tagJapaneseName(rs.getObject("tag_japanese_name").toString())
 								.tagEnglishName(rs.getObject("tag_english_name").toString())
 								.build());
 			assertEquals(2, actualPhotoTagMst.size());
 			
-			assertEquals(2, actualPhotoTagMst.get(0).getAccountNo());
-			assertEquals(4, actualPhotoTagMst.get(0).getPhotoNo());
-			assertEquals(1, actualPhotoTagMst.get(0).getTagNo());
+			assertEquals(2L, actualPhotoTagMst.get(0).getAccountNo());
+			assertEquals(4L, actualPhotoTagMst.get(0).getPhotoNo());
+			assertEquals(1L, actualPhotoTagMst.get(0).getTagNo());
 			assertEquals("太陽", actualPhotoTagMst.get(0).getTagJapaneseName());
 			assertEquals("sun", actualPhotoTagMst.get(0).getTagEnglishName());
-			assertEquals(2, actualPhotoTagMst.get(1).getAccountNo());
-			assertEquals(4, actualPhotoTagMst.get(1).getPhotoNo());
-			assertEquals(2, actualPhotoTagMst.get(1).getTagNo());
+			assertEquals(2L, actualPhotoTagMst.get(1).getAccountNo());
+			assertEquals(4L, actualPhotoTagMst.get(1).getPhotoNo());
+			assertEquals(2L, actualPhotoTagMst.get(1).getTagNo());
 			assertEquals("青空", actualPhotoTagMst.get(1).getTagJapaneseName());
 			assertEquals("bluesky", actualPhotoTagMst.get(1).getTagEnglishName());
 		}
@@ -431,7 +431,7 @@ public class PhotoRestControllerIntegrationTest {
 			String photoAccountId = "bbbbbbbb";
 			
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
 					.password("$2a$10$password2")
@@ -477,15 +477,15 @@ public class PhotoRestControllerIntegrationTest {
 			List<PhotoMst> actualPhotoMst = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no = 2 and photo_no=1", (rs, rowNum) ->
 					PhotoMst.builder()
-						.accountNo(rs.getInt("account_no"))
-						.photoNo(rs.getInt("photo_no"))
-						.createdBy(rs.getInt("created_by"))
+						.accountNo(rs.getLong("account_no"))
+						.photoNo(rs.getLong("photo_no"))
+						.createdBy(rs.getLong("created_by"))
 						.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-						.updatedBy(rs.getInt("updated_by"))
+						.updatedBy(rs.getLong("updated_by"))
 						.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 						.isDeleted(rs.getBoolean("is_deleted"))
 						.photoAt(rs.getObject("photo_at", OffsetDateTime.class))
-						.locationNo(rs.getInt("location_no"))
+						.locationNo(rs.getLong("location_no"))
 						.imageFilePath(rs.getString("image_file_path"))
 						.photoJapaneseTitle(rs.getString("photo_japanese_title"))
 						.photoEnglishTitle(rs.getString("photo_english_title"))
@@ -498,11 +498,11 @@ public class PhotoRestControllerIntegrationTest {
 						.build());
 			
 			assertEquals(1, actualPhotoMst.size());
-			assertEquals(2, actualPhotoMst.getFirst().getAccountNo());
-			assertEquals(1, actualPhotoMst.getFirst().getPhotoNo());
+			assertEquals(2L, actualPhotoMst.getFirst().getAccountNo());
+			assertEquals(1L, actualPhotoMst.getFirst().getPhotoNo());
 			assertFalse(actualPhotoMst.getFirst().getIsDeleted());
 			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualPhotoMst.getFirst().getPhotoAt().plusHours(9));
-			assertEquals(0, actualPhotoMst.getFirst().getLocationNo());
+			assertEquals(0L, actualPhotoMst.getFirst().getLocationNo());
 			assertEquals("https://www.xxx.com/bbbbbbbb/DSC21.jpg", actualPhotoMst.getFirst().getImageFilePath());
 			assertEquals("タイトル111", actualPhotoMst.getFirst().getPhotoJapaneseTitle());
 			assertEquals("title111", actualPhotoMst.getFirst().getPhotoEnglishTitle());
@@ -517,24 +517,24 @@ public class PhotoRestControllerIntegrationTest {
 			List<PhotoTagMst> actualPhotoTagMst = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_tag_mst WHERE account_no=2 and photo_no=1", (rs, rowNum) ->
 							PhotoTagMst.builder()
-								.accountNo(rs.getInt("account_no"))
-								.photoNo(rs.getInt("photo_no"))
-								.tagNo(rs.getInt("tag_no"))
-								.createdBy(rs.getInt("created_by"))
+								.accountNo(rs.getLong("account_no"))
+								.photoNo(rs.getLong("photo_no"))
+								.tagNo(rs.getLong("tag_no"))
+								.createdBy(rs.getLong("created_by"))
 								.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 								.tagJapaneseName(rs.getObject("tag_japanese_name").toString())
 								.tagEnglishName(rs.getObject("tag_english_name").toString())
 								.build());
 			assertEquals(2, actualPhotoTagMst.size());
 			
-			assertEquals(2, actualPhotoTagMst.get(0).getAccountNo());
-			assertEquals(1, actualPhotoTagMst.get(0).getPhotoNo());
-			assertEquals(1, actualPhotoTagMst.get(0).getTagNo());
+			assertEquals(2L, actualPhotoTagMst.get(0).getAccountNo());
+			assertEquals(1L, actualPhotoTagMst.get(0).getPhotoNo());
+			assertEquals(1L, actualPhotoTagMst.get(0).getTagNo());
 			assertEquals("太陽", actualPhotoTagMst.get(0).getTagJapaneseName());
 			assertEquals("sun", actualPhotoTagMst.get(0).getTagEnglishName());
-			assertEquals(2, actualPhotoTagMst.get(1).getAccountNo());
-			assertEquals(1, actualPhotoTagMst.get(1).getPhotoNo());
-			assertEquals(2, actualPhotoTagMst.get(1).getTagNo());
+			assertEquals(2L, actualPhotoTagMst.get(1).getAccountNo());
+			assertEquals(1L, actualPhotoTagMst.get(1).getPhotoNo());
+			assertEquals(2L, actualPhotoTagMst.get(1).getTagNo());
 			assertEquals("青空", actualPhotoTagMst.get(1).getTagJapaneseName());
 			assertEquals("bluesky", actualPhotoTagMst.get(1).getTagEnglishName());
 		}
@@ -551,7 +551,7 @@ public class PhotoRestControllerIntegrationTest {
 					"sample image".getBytes());
 			
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.accountName("AAAAAAAA")
 					.password("$2a$10$password1")
@@ -589,7 +589,7 @@ public class PhotoRestControllerIntegrationTest {
 					"sample image".getBytes());
 			
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.accountName("AAAAAAAA")
 					.password("$2a$10$password1")
@@ -622,7 +622,7 @@ public class PhotoRestControllerIntegrationTest {
 			String photoAccountId = "bbbbbbbb";
 			
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
 					.password("$2a$10$password2")
@@ -653,7 +653,7 @@ public class PhotoRestControllerIntegrationTest {
 			String photoAccountId = "bbbbbbbb";
 			
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
 					.password("$2a$10$password2")
@@ -690,7 +690,7 @@ public class PhotoRestControllerIntegrationTest {
 					"sample image".getBytes());
 			
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
 					.password("$2a$10$password2")
@@ -728,7 +728,7 @@ public class PhotoRestControllerIntegrationTest {
 					"sample image".getBytes());
 			
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
 					.password("$2a$10$password2")
@@ -765,7 +765,7 @@ public class PhotoRestControllerIntegrationTest {
 			String photoAccountId = "bbbbbbbb";
 			
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
 					.password("$2a$10$password2")
@@ -810,7 +810,7 @@ public class PhotoRestControllerIntegrationTest {
 			String loginAccountId = "aaaaaaaa";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId(loginAccountId)
 					.accountName("AAAAAAAA")
 					.password("$2a$10$password1")
@@ -837,15 +837,15 @@ public class PhotoRestControllerIntegrationTest {
 			List<PhotoMst> actualPhotoMst = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no = 1 and photo_no=1", (rs, rowNum) ->
 					PhotoMst.builder()
-						.accountNo(rs.getInt("account_no"))
-						.photoNo(rs.getInt("photo_no"))
-						.createdBy(rs.getInt("created_by"))
+						.accountNo(rs.getLong("account_no"))
+						.photoNo(rs.getLong("photo_no"))
+						.createdBy(rs.getLong("created_by"))
 						.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-						.updatedBy(rs.getInt("updated_by"))
+						.updatedBy(rs.getLong("updated_by"))
 						.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 						.isDeleted(rs.getBoolean("is_deleted"))
 						.photoAt(rs.getObject("photo_at", OffsetDateTime.class))
-						.locationNo(rs.getInt("location_no"))
+						.locationNo(rs.getLong("location_no"))
 						.imageFilePath(rs.getString("image_file_path"))
 						.photoJapaneseTitle(rs.getString("photo_japanese_title"))
 						.photoEnglishTitle(rs.getString("photo_english_title"))
@@ -862,10 +862,10 @@ public class PhotoRestControllerIntegrationTest {
 			List<PhotoTagMst> actualPhotoTagMst = jdbcTemplate.query(
 						"SELECT * FROM photo.photo_tag_mst WHERE account_no=1 and photo_no=1", (rs, rowNum) ->
 							PhotoTagMst.builder()
-								.accountNo(rs.getInt("account_no"))
-								.photoNo(rs.getInt("photo_no"))
-								.tagNo(rs.getInt("tag_no"))
-								.createdBy(rs.getInt("created_by"))
+								.accountNo(rs.getLong("account_no"))
+								.photoNo(rs.getLong("photo_no"))
+								.tagNo(rs.getLong("tag_no"))
+								.createdBy(rs.getLong("created_by"))
 								.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 								.tagJapaneseName(rs.getObject("tag_japanese_name").toString())
 								.tagEnglishName(rs.getObject("tag_english_name").toString())
@@ -876,10 +876,10 @@ public class PhotoRestControllerIntegrationTest {
 			List<PhotoFavorite> actualPhotoFavoriteData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite WHERE favorite_photo_account_no=1 and favorite_photo_no=1", (rs, rowNum) ->
 						PhotoFavorite.builder()
-							.accountNo(rs.getInt("account_no"))
-							.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-							.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+							.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.build());
 			assertEquals(0, actualPhotoFavoriteData.size());
@@ -893,7 +893,7 @@ public class PhotoRestControllerIntegrationTest {
 			String loginAccountId = "eeeeeeee";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId(loginAccountId)
 					.accountName("EEEEEEEE")
 					.password("$2a$10$password5")
@@ -926,7 +926,7 @@ public class PhotoRestControllerIntegrationTest {
 			String loginAccountId = "aaaaaaaa";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId(loginAccountId)
 					.accountName("AAAAAAAA")
 					.password("$2a$10$password1")
@@ -958,7 +958,7 @@ public class PhotoRestControllerIntegrationTest {
 			String loginAccountId = "aaaaaaaa";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId(loginAccountId)
 					.accountName("AAAAAAAA")
 					.password("$2a$10$password1")
@@ -995,7 +995,7 @@ public class PhotoRestControllerIntegrationTest {
 			String photoAccountId = "bbbbbbbb";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.accountId(photoAccountId)
 					.accountName("BBBBBBBB")
 					.password("$2a$10$password2")
@@ -1022,7 +1022,7 @@ public class PhotoRestControllerIntegrationTest {
 			String photoAccountId = "aaaaaaaa";
 
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId(photoAccountId)
 					.accountName("AAAAAAAA")
 					.password("$2a$10$password1")
@@ -1047,7 +1047,7 @@ public class PhotoRestControllerIntegrationTest {
 		@DisplayName("正常系：他人のアカウントの場合はfalse")
 		void getPhotoUpperLimit_other_account() throws Exception {
 			AccountModel sessionAccount = AccountModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.accountId("bbbbbbbb")
 					.accountName("BBBBBBBB")
 					.password("$2a$10$password2")

--- a/backend/src/test/java/com/web/gallery/helper/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/web/gallery/helper/JwtTokenProviderTest.java
@@ -47,7 +47,7 @@ class JwtTokenProviderTest {
 		@DisplayName("正常系: アクセストークンが生成されること")
 		void generateAccessToken_success() {
 			when(principal.getUsername()).thenReturn("testuser1");
-			when(principal.getAccountNo()).thenReturn(1);
+			when(principal.getAccountNo()).thenReturn(1L);
 			when(principal.getAccountName()).thenReturn("テストユーザー");
 			doReturn(Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")))
 					.when(principal).getAuthorities();
@@ -62,7 +62,7 @@ class JwtTokenProviderTest {
 		@DisplayName("正常系: 生成されたトークンからアカウントIDが取得できること")
 		void generateAccessToken_containsAccountId() {
 			when(principal.getUsername()).thenReturn("testuser1");
-			when(principal.getAccountNo()).thenReturn(1);
+			when(principal.getAccountNo()).thenReturn(1L);
 			when(principal.getAccountName()).thenReturn("テストユーザー");
 			doReturn(Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")))
 					.when(principal).getAuthorities();
@@ -105,7 +105,7 @@ class JwtTokenProviderTest {
 		@DisplayName("正常系: 有効なトークンのクレームが取得できること")
 		void validateAccessToken_success() {
 			when(principal.getUsername()).thenReturn("testuser1");
-			when(principal.getAccountNo()).thenReturn(1);
+			when(principal.getAccountNo()).thenReturn(1L);
 			when(principal.getAccountName()).thenReturn("テストユーザー");
 			doReturn(Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")))
 					.when(principal).getAuthorities();
@@ -136,7 +136,7 @@ class JwtTokenProviderTest {
 		@DisplayName("正常系: 有効なトークンの場合はtrueを返すこと")
 		void isTokenValid_validToken() {
 			when(principal.getUsername()).thenReturn("testuser1");
-			when(principal.getAccountNo()).thenReturn(1);
+			when(principal.getAccountNo()).thenReturn(1L);
 			when(principal.getAccountName()).thenReturn("テストユーザー");
 			doReturn(Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")))
 					.when(principal).getAuthorities();

--- a/backend/src/test/java/com/web/gallery/helper/SessionHelperTest.java
+++ b/backend/src/test/java/com/web/gallery/helper/SessionHelperTest.java
@@ -46,9 +46,9 @@ public class SessionHelperTest {
 		@DisplayName("正常系：セッションに存在し、アカウント番号を返す")
 		void getAccountNo_found() {
 			doReturn(accountPrincipal).when(authentication).getPrincipal();
-			doReturn(1).when(accountPrincipal).getAccountNo();
+			doReturn(1L).when(accountPrincipal).getAccountNo();
 			
-			Integer actual = sessionHelper.getAccountNo();
+			Long actual = sessionHelper.getAccountNo();
 			assertEquals(Integer.valueOf(1), actual);
 		}
 		
@@ -58,7 +58,7 @@ public class SessionHelperTest {
 		void getAccountNo_not_found() {
 			doReturn(null).when(authentication).getPrincipal();
 			
-			Integer actual = sessionHelper.getAccountNo();
+			Long actual = sessionHelper.getAccountNo();
 			assertNull(actual);
 			verify(accountPrincipal, times(0)).getAccountNo();
 		}

--- a/backend/src/test/java/com/web/gallery/helper/SessionHelperTest.java
+++ b/backend/src/test/java/com/web/gallery/helper/SessionHelperTest.java
@@ -49,7 +49,7 @@ public class SessionHelperTest {
 			doReturn(1L).when(accountPrincipal).getAccountNo();
 			
 			Long actual = sessionHelper.getAccountNo();
-			assertEquals(Integer.valueOf(1), actual);
+			assertEquals(Long.valueOf(1L), actual);
 		}
 		
 		@Test

--- a/backend/src/test/java/com/web/gallery/mapper/AccountMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/AccountMapperTest.java
@@ -45,14 +45,14 @@ public class AccountMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのselectで1件の場合")
 		void select_by_accountNo() {
-			Account account = Account.builder().accountNo(1).build();
+			Account account = Account.builder().accountNo(1L).build();
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
-					.accountNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(1)
+					.updatedBy(1L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("aaaaaaaa")
@@ -83,10 +83,10 @@ public class AccountMapperTest {
 			List<Account> actual = accountMapper.select(account);
 		
 			Account expectedAccount = Account.builder()
-					.accountNo(9)
-					.createdBy(9)
+					.accountNo(9L)
+					.createdBy(9L)
 					.createdAt(OffsetDateTime.of(2000, 1, 9, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(9)
+					.updatedBy(9L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 9, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(true)
 					.accountId("iiiiiiii")
@@ -117,10 +117,10 @@ public class AccountMapperTest {
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
-					.accountNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(1)
+					.updatedBy(1L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("aaaaaaaa")
@@ -151,10 +151,10 @@ public class AccountMapperTest {
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
-					.accountNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(1)
+					.updatedBy(1L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("aaaaaaaa")
@@ -185,10 +185,10 @@ public class AccountMapperTest {
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
-					.accountNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(1)
+					.updatedBy(1L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("aaaaaaaa")
@@ -219,10 +219,10 @@ public class AccountMapperTest {
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
-					.accountNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(1)
+					.updatedBy(1L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("aaaaaaaa")
@@ -253,10 +253,10 @@ public class AccountMapperTest {
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
-					.accountNo(2)
-					.createdBy(2)
+					.accountNo(2L)
+					.createdBy(2L)
 					.createdAt(OffsetDateTime.of(2000, 1, 2, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(2)
+					.updatedBy(2L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 2, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("bbbbbbbb")
@@ -287,10 +287,10 @@ public class AccountMapperTest {
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
-					.accountNo(3)
-					.createdBy(3)
+					.accountNo(3L)
+					.createdBy(3L)
 					.createdAt(OffsetDateTime.of(2000, 1, 3, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(3)
+					.updatedBy(3L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 3, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("cccccccc")
@@ -321,10 +321,10 @@ public class AccountMapperTest {
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
-					.accountNo(4)
-					.createdBy(4)
+					.accountNo(4L)
+					.createdBy(4L)
 					.createdAt(OffsetDateTime.of(2000, 1, 4, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(4)
+					.updatedBy(4L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 4, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("dddddddd")
@@ -355,10 +355,10 @@ public class AccountMapperTest {
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
-					.accountNo(5)
-					.createdBy(5)
+					.accountNo(5L)
+					.createdBy(5L)
 					.createdAt(OffsetDateTime.of(2000, 1, 5, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(5)
+					.updatedBy(5L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 5, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("eeeeeeee")
@@ -389,10 +389,10 @@ public class AccountMapperTest {
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
-					.accountNo(6)
-					.createdBy(6)
+					.accountNo(6L)
+					.createdBy(6L)
 					.createdAt(OffsetDateTime.of(2000, 1, 6, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(6)
+					.updatedBy(6L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 6, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("ffffffff")
@@ -423,10 +423,10 @@ public class AccountMapperTest {
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
-					.accountNo(7)
-					.createdBy(7)
+					.accountNo(7L)
+					.createdBy(7L)
 					.createdAt(OffsetDateTime.of(2000, 1, 7, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(7)
+					.updatedBy(7L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 7, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("gggggggg")
@@ -457,10 +457,10 @@ public class AccountMapperTest {
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
-					.accountNo(8)
-					.createdBy(8)
+					.accountNo(8L)
+					.createdBy(8L)
 					.createdAt(OffsetDateTime.of(2000, 1, 8, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(8)
+					.updatedBy(8L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 8, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("hhhhhhhh")
@@ -487,7 +487,7 @@ public class AccountMapperTest {
 		@Order(14)
 		@DisplayName("正常系：selectで0件の場合")
 		void select_not_found() {
-			Account account = Account.builder().accountNo(99).build();
+			Account account = Account.builder().accountNo(99L).build();
 			List<Account> actual = accountMapper.select(account);
 			List<Account> expected = new ArrayList<Account>();
 			
@@ -503,10 +503,10 @@ public class AccountMapperTest {
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount1 = Account.builder()
-					.accountNo(9)
-					.createdBy(9)
+					.accountNo(9L)
+					.createdBy(9L)
 					.createdAt(OffsetDateTime.of(2000, 1, 9, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(9)
+					.updatedBy(9L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 9, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(true)
 					.accountId("iiiiiiii")
@@ -523,10 +523,10 @@ public class AccountMapperTest {
 					.build();
 			
 			Account expectedAccount2 = Account.builder()
-					.accountNo(10)
-					.createdBy(10)
+					.accountNo(10L)
+					.createdBy(10L)
 					.createdAt(OffsetDateTime.of(2000, 1, 10, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(10)
+					.updatedBy(10L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 10, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("jjjjjjjj")
@@ -564,10 +564,10 @@ public class AccountMapperTest {
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount1 = Account.builder()
-					.accountNo(12)
-					.createdBy(12)
+					.accountNo(12L)
+					.createdBy(12L)
 					.createdAt(OffsetDateTime.of(2000, 1, 12, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(12)
+					.updatedBy(12L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 12, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("llllllll")
@@ -601,7 +601,7 @@ public class AccountMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのcount")
 		void count_by_accountNo() {
-			Account account = Account.builder().accountNo(1).build();
+			Account account = Account.builder().accountNo(1L).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(1, actual);
 		}
@@ -720,7 +720,7 @@ public class AccountMapperTest {
 		@Order(14)
 		@DisplayName("正常系：countで0件の場合")
 		void count_not_found() {
-			Account account = Account.builder().accountNo(99).build();
+			Account account = Account.builder().accountNo(99L).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(0, actual);
 		}
@@ -761,10 +761,10 @@ public class AccountMapperTest {
 		@DisplayName("正常系：登録成功")
 		void insert_success() {
 			Account insertAccount = Account.builder()
-					.accountNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9)))
-					.updatedBy(1)
+					.updatedBy(1L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9)))
 					.isDeleted(false)
 					.accountId("aaaaaaaa")
@@ -786,10 +786,10 @@ public class AccountMapperTest {
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account", (rs, rowNum) ->
 						Account.builder()
-							.accountNo(rs.getInt("account_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.accountId(rs.getString("account_id"))
@@ -806,9 +806,9 @@ public class AccountMapperTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("aaaaaaaa", actualData.getFirst().getAccountId());
 			assertEquals("AAAAAAAA", actualData.getFirst().getAccountName());
@@ -834,10 +834,10 @@ public class AccountMapperTest {
 			return jdbcTemplate.query(
 					"SELECT * FROM common.account WHERE " + condition, (rs, rowNum) ->
 						Account.builder()
-							.accountNo(rs.getInt("account_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.accountId(rs.getString("account_id"))
@@ -858,17 +858,17 @@ public class AccountMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのupdate")
 		void update_by_accountNo() {
-			Account conditionAccount = Account.builder().accountNo(1).build();
+			Account conditionAccount = Account.builder().accountNo(1L).build();
 			Account targetAccount = Account.builder().loginFailureCount(1).build();
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
 			
 			List<Account> actualData = getAccountList("account_no=1");
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("aaaaaaaa", actualData.getFirst().getAccountId());
 			assertEquals("AAAAAAAA", actualData.getFirst().getAccountName());
@@ -894,10 +894,10 @@ public class AccountMapperTest {
 			
 			List<Account> actualData = getAccountList("is_deleted=true");
 			assertEquals(1, actualData.size());
-			assertEquals(9, actualData.getFirst().getAccountNo());
-			assertEquals(9, actualData.getFirst().getCreatedBy());
+			assertEquals(9L, actualData.getFirst().getAccountNo());
+			assertEquals(9L, actualData.getFirst().getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 9, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt());
-			assertEquals(9, actualData.getFirst().getUpdatedBy());
+			assertEquals(9L, actualData.getFirst().getUpdatedBy());
 			assertTrue(actualData.getFirst().getIsDeleted());
 			assertEquals("iiiiiiii", actualData.getFirst().getAccountId());
 			assertEquals("IIIIIIII", actualData.getFirst().getAccountName());
@@ -923,10 +923,10 @@ public class AccountMapperTest {
 			
 			List<Account> actualData = getAccountList("account_id='aaaaaaaa'");
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("aaaaaaaa", actualData.getFirst().getAccountId());
 			assertEquals("AAAAAAAA", actualData.getFirst().getAccountName());
@@ -952,10 +952,10 @@ public class AccountMapperTest {
 			
 			List<Account> actualData = getAccountList("account_name='AAAAAAAA'");
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("aaaaaaaa", actualData.getFirst().getAccountId());
 			assertEquals("AAAAAAAA", actualData.getFirst().getAccountName());
@@ -981,10 +981,10 @@ public class AccountMapperTest {
 			
 			List<Account> actualData = getAccountList("password='$2a$10$password1'");
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("aaaaaaaa", actualData.getFirst().getAccountId());
 			assertEquals("AAAAAAAA", actualData.getFirst().getAccountName());
@@ -1010,10 +1010,10 @@ public class AccountMapperTest {
 			
 			List<Account> actualData = getAccountList("birthdate='1991-02-14'");
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("aaaaaaaa", actualData.getFirst().getAccountId());
 			assertEquals("AAAAAAAA", actualData.getFirst().getAccountName());
@@ -1039,10 +1039,10 @@ public class AccountMapperTest {
 			
 			List<Account> actualData = getAccountList("sex_kbn='man'");
 			assertEquals(1, actualData.size());
-			assertEquals(2, actualData.getFirst().getAccountNo());
-			assertEquals(2, actualData.getFirst().getCreatedBy());
+			assertEquals(2L, actualData.getFirst().getAccountNo());
+			assertEquals(2L, actualData.getFirst().getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 2, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt());
-			assertEquals(2, actualData.getFirst().getUpdatedBy());
+			assertEquals(2L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("bbbbbbbb", actualData.getFirst().getAccountId());
 			assertEquals("BBBBBBBB", actualData.getFirst().getAccountName());
@@ -1068,10 +1068,10 @@ public class AccountMapperTest {
 			
 			List<Account> actualData = getAccountList("birthplace_prefecture_kbn_code='Hokkaido'");
 			assertEquals(1, actualData.size());
-			assertEquals(3, actualData.getFirst().getAccountNo());
-			assertEquals(3, actualData.getFirst().getCreatedBy());
+			assertEquals(3L, actualData.getFirst().getAccountNo());
+			assertEquals(3L, actualData.getFirst().getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 3, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt());
-			assertEquals(3, actualData.getFirst().getUpdatedBy());
+			assertEquals(3L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("cccccccc", actualData.getFirst().getAccountId());
 			assertEquals("CCCCCCCC", actualData.getFirst().getAccountName());
@@ -1097,10 +1097,10 @@ public class AccountMapperTest {
 			
 			List<Account> actualData = getAccountList("resident_prefecture_kbn_code='Okinawa'");
 			assertEquals(1, actualData.size());
-			assertEquals(4, actualData.getFirst().getAccountNo());
-			assertEquals(4, actualData.getFirst().getCreatedBy());
+			assertEquals(4L, actualData.getFirst().getAccountNo());
+			assertEquals(4L, actualData.getFirst().getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 4, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt());
-			assertEquals(4, actualData.getFirst().getUpdatedBy());
+			assertEquals(4L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("dddddddd", actualData.getFirst().getAccountId());
 			assertEquals("DDDDDDDD", actualData.getFirst().getAccountName());
@@ -1126,10 +1126,10 @@ public class AccountMapperTest {
 			
 			List<Account> actualData = getAccountList("free_memo='フリーメモ'");
 			assertEquals(1, actualData.size());
-			assertEquals(5, actualData.getFirst().getAccountNo());
-			assertEquals(5, actualData.getFirst().getCreatedBy());
+			assertEquals(5L, actualData.getFirst().getAccountNo());
+			assertEquals(5L, actualData.getFirst().getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 5, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt());
-			assertEquals(5, actualData.getFirst().getUpdatedBy());
+			assertEquals(5L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("eeeeeeee", actualData.getFirst().getAccountId());
 			assertEquals("EEEEEEEE", actualData.getFirst().getAccountName());
@@ -1155,10 +1155,10 @@ public class AccountMapperTest {
 			
 			List<Account> actualData = getAccountList("authority_kbn='mini-user'");
 			assertEquals(1, actualData.size());
-			assertEquals(6, actualData.getFirst().getAccountNo());
-			assertEquals(6, actualData.getFirst().getCreatedBy());
+			assertEquals(6L, actualData.getFirst().getAccountNo());
+			assertEquals(6L, actualData.getFirst().getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 6, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt());
-			assertEquals(6, actualData.getFirst().getUpdatedBy());
+			assertEquals(6L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("ffffffff", actualData.getFirst().getAccountId());
 			assertEquals("FFFFFFFF", actualData.getFirst().getAccountName());
@@ -1186,10 +1186,10 @@ public class AccountMapperTest {
 			
 			List<Account> actualData = getAccountList("last_login_datetime='2024-01-01 00:00:00.000 +0000'");
 			assertEquals(1, actualData.size());
-			assertEquals(7, actualData.getFirst().getAccountNo());
-			assertEquals(7, actualData.getFirst().getCreatedBy());
+			assertEquals(7L, actualData.getFirst().getAccountNo());
+			assertEquals(7L, actualData.getFirst().getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 7, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt());
-			assertEquals(7, actualData.getFirst().getUpdatedBy());
+			assertEquals(7L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("gggggggg", actualData.getFirst().getAccountId());
 			assertEquals("GGGGGGGG", actualData.getFirst().getAccountName());
@@ -1215,10 +1215,10 @@ public class AccountMapperTest {
 			
 			List<Account> actualData = getAccountList("account_no=8");
 			assertEquals(1, actualData.size());
-			assertEquals(8, actualData.getFirst().getAccountNo());
-			assertEquals(8, actualData.getFirst().getCreatedBy());
+			assertEquals(8L, actualData.getFirst().getAccountNo());
+			assertEquals(8L, actualData.getFirst().getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 8, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt());
-			assertEquals(8, actualData.getFirst().getUpdatedBy());
+			assertEquals(8L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("hhhhhhhh", actualData.getFirst().getAccountId());
 			assertEquals("HHHHHHHH", actualData.getFirst().getAccountName());
@@ -1237,7 +1237,7 @@ public class AccountMapperTest {
 		@Order(14)
 		@DisplayName("正常系：更新対象のレコードなし")
 		void update_not_found() {
-			Account conditionAccount = Account.builder().accountNo(99).build();
+			Account conditionAccount = Account.builder().accountNo(99L).build();
 			Account targetAccount = Account.builder().loginFailureCount(0).build();
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(0, actual);
@@ -1257,10 +1257,10 @@ public class AccountMapperTest {
 			
 			List<Account> actualData = getAccountList("authority_kbn='special-user' order by account_no");
 			assertEquals(2, actualData.size());
-			assertEquals(9, actualData.get(0).getAccountNo());
-			assertEquals(9, actualData.get(0).getCreatedBy());
+			assertEquals(9L, actualData.get(0).getAccountNo());
+			assertEquals(9L, actualData.get(0).getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 9, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt());
-			assertEquals(9, actualData.get(0).getUpdatedBy());
+			assertEquals(9L, actualData.get(0).getUpdatedBy());
 			assertTrue(actualData.get(0).getIsDeleted());
 			assertEquals("iiiiiiii", actualData.get(0).getAccountId());
 			assertEquals("IIIIIIII", actualData.get(0).getAccountName());
@@ -1274,10 +1274,10 @@ public class AccountMapperTest {
 			assertEquals(OffsetDateTime.of(2002, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getLastLoginDatetime());
 			assertEquals(1, actualData.get(0).getLoginFailureCount());
 			
-			assertEquals(10, actualData.get(1).getAccountNo());
-			assertEquals(10, actualData.get(1).getCreatedBy());
+			assertEquals(10L, actualData.get(1).getAccountNo());
+			assertEquals(10L, actualData.get(1).getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 10, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(1).getCreatedAt());
-			assertEquals(10, actualData.get(1).getUpdatedBy());
+			assertEquals(10L, actualData.get(1).getUpdatedBy());
 			assertFalse(actualData.get(1).getIsDeleted());
 			assertEquals("jjjjjjjj", actualData.get(1).getAccountId());
 			assertEquals("JJJJJJJJ", actualData.get(1).getAccountName());
@@ -1309,10 +1309,10 @@ public class AccountMapperTest {
 			
 			List<Account> actualData = getAccountList("account_id='llllllll'");
 			assertEquals(1, actualData.size());
-			assertEquals(12, actualData.getFirst().getAccountNo());
-			assertEquals(12, actualData.getFirst().getCreatedBy());
+			assertEquals(12L, actualData.getFirst().getAccountNo());
+			assertEquals(12L, actualData.getFirst().getCreatedBy());
 			assertEquals(OffsetDateTime.of(2000, 1, 12, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt());
-			assertEquals(12, actualData.getFirst().getUpdatedBy());
+			assertEquals(12L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("llllllll", actualData.getFirst().getAccountId());
 			assertEquals("LLLLLLLL", actualData.getFirst().getAccountName());
@@ -1338,10 +1338,10 @@ public class AccountMapperTest {
 			return jdbcTemplate.query(
 					"SELECT * FROM common.account WHERE " + condition, (rs, rowNum) ->
 						Account.builder()
-							.accountNo(rs.getInt("account_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.accountId(rs.getString("account_id"))
@@ -1362,7 +1362,7 @@ public class AccountMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのdelete")
 		void delete_by_accountNo() {
-			Account deleteAccount = Account.builder().accountNo(1).build();
+			Account deleteAccount = Account.builder().accountNo(1L).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(1, actual);
 			
@@ -1559,7 +1559,7 @@ public class AccountMapperTest {
 		@Order(14)
 		@DisplayName("正常系：削除対象のレコードなし")
 		void delete_not_found() {
-			Account deleteAccount = Account.builder().accountNo(99).build();
+			Account deleteAccount = Account.builder().accountNo(99L).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(0, actual);
 			
@@ -1646,7 +1646,7 @@ public class AccountMapperTest {
 		@DisplayName("正常系：アカウント番号以外で、アカウントIDが一致するアカウントが存在しない")
 		void isExistAccount_by_accountId_and_accountNo_exists() {
 			Account account = Account.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.build();
 			Boolean isExist = accountMapper.isExistAccount(account);
@@ -1657,7 +1657,7 @@ public class AccountMapperTest {
 		@DisplayName("正常系：アカウント番号以外で、アカウントIDが一致するアカウントが存在する")
 		void isExistAccount_by_accountId_and_accountNo_not_exist() {
 			Account account = Account.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("bbbbbbbb")
 					.build();
 			Boolean isExist = accountMapper.isExistAccount(account);

--- a/backend/src/test/java/com/web/gallery/mapper/PhotoDetailMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/PhotoDetailMapperTest.java
@@ -45,14 +45,14 @@ public class PhotoDetailMapperTest {
 		@DisplayName("正常系：selectで1件以上の場合")
 		void getPhotoList_some_photos() {
 			PhotoListGetDto photoSelectDto = new PhotoListGetDto();
-			photoSelectDto.setAccountNo(1);
-			photoSelectDto.setPhotoAccountNo(1);
+			photoSelectDto.setAccountNo(1L);
+			photoSelectDto.setPhotoAccountNo(1L);
 			
 			List<PhotoDto> actual = photoDetailMapper.getPhotoList(photoSelectDto);
 			
 			PhotoDto actualPhotoDto1 = actual.stream().sorted(Comparator.comparing(PhotoDto::getPhotoNo)).toList().getFirst();
-			assertEquals(1, actualPhotoDto1.getAccountNo());
-			assertEquals(1, actualPhotoDto1.getPhotoNo());
+			assertEquals(1L, actualPhotoDto1.getAccountNo());
+			assertEquals(1L, actualPhotoDto1.getPhotoNo());
 			assertEquals(2, actualPhotoDto1.getFavoriteCount());
 			assertEquals(true, actualPhotoDto1.getIsFavorite());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualPhotoDto1.getPhotoAt());
@@ -61,8 +61,8 @@ public class PhotoDetailMapperTest {
 			assertEquals(DirectionEnum.VERTICAL, actualPhotoDto1.getDirectionKbn());
 			
 			PhotoDto actualPhotoDto2 = actual.stream().sorted(Comparator.comparing(PhotoDto::getPhotoNo)).toList().getLast();
-			assertEquals(1, actualPhotoDto2.getAccountNo());
-			assertEquals(2, actualPhotoDto2.getPhotoNo());
+			assertEquals(1L, actualPhotoDto2.getAccountNo());
+			assertEquals(2L, actualPhotoDto2.getPhotoNo());
 			assertEquals(1, actualPhotoDto2.getFavoriteCount());
 			assertEquals(false, actualPhotoDto2.getIsFavorite());
 			assertEquals(OffsetDateTime.of(2021, 2, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualPhotoDto2.getPhotoAt());
@@ -76,8 +76,8 @@ public class PhotoDetailMapperTest {
 		@DisplayName("正常系：selectで0件の場合")
 		void getPhotoList_not_found() {
 			PhotoListGetDto photoSelectDto = new PhotoListGetDto();
-			photoSelectDto.setAccountNo(1);
-			photoSelectDto.setPhotoAccountNo(3);
+			photoSelectDto.setAccountNo(1L);
+			photoSelectDto.setPhotoAccountNo(3L);
 			
 			List<PhotoDto> actual = photoDetailMapper.getPhotoList(photoSelectDto);
 			assertEquals(new ArrayList<PhotoDto>(), actual);
@@ -95,16 +95,16 @@ public class PhotoDetailMapperTest {
 		@DisplayName("正常系：selectで1件の場合")
 		void getPhotoDetail_found() {
 			PhotoDetailGetDto photoGetDto = new PhotoDetailGetDto();
-			photoGetDto.setAccountNo(1);
-			photoGetDto.setPhotoAccountNo(1);
-			photoGetDto.setPhotoNo(1);
+			photoGetDto.setAccountNo(1L);
+			photoGetDto.setPhotoAccountNo(1L);
+			photoGetDto.setPhotoNo(1L);
 			
 			PhotoDetailDto actual = photoDetailMapper.getPhotoDetail(photoGetDto);
-			assertEquals(1, actual.getAccountNo());
-			assertEquals(1, actual.getPhotoNo());
+			assertEquals(1L, actual.getAccountNo());
+			assertEquals(1L, actual.getPhotoNo());
 			assertEquals(true, actual.getIsFavorite());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getPhotoAt());
-			assertEquals(1, actual.getLocationNo());
+			assertEquals(1L, actual.getLocationNo());
 			assertEquals("住所1", actual.getAddress());
 			assertEquals(0, BigDecimal.valueOf(38.1).compareTo(actual.getLatitude()));
 			assertEquals(0, BigDecimal.valueOf(115.1).compareTo(actual.getLongitude()));
@@ -125,9 +125,9 @@ public class PhotoDetailMapperTest {
 		@DisplayName("正常系：selectで0件の場合")
 		void getPhotoDetail_not_found() {
 			PhotoDetailGetDto photoGetDto = new PhotoDetailGetDto();
-			photoGetDto.setAccountNo(1);
-			photoGetDto.setPhotoAccountNo(3);
-			photoGetDto.setPhotoNo(1);
+			photoGetDto.setAccountNo(1L);
+			photoGetDto.setPhotoAccountNo(3L);
+			photoGetDto.setPhotoNo(1L);
 			
 			PhotoDetailDto actual = photoDetailMapper.getPhotoDetail(photoGetDto);
 			assertNull(actual);

--- a/backend/src/test/java/com/web/gallery/mapper/PhotoFavoriteMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/PhotoFavoriteMapperTest.java
@@ -41,10 +41,10 @@ public class PhotoFavoriteMapperTest {
 		@DisplayName("正常系：登録成功")
 		void insert_success() {
 			PhotoFavorite insertPhotoFavorite = PhotoFavorite.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(2)
-					.favoritePhotoNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(2L)
+					.favoritePhotoNo(1L)
+					.createdBy(1L)
 					.build();
 			
 			Integer actualCount = photoFavoriteMapper.insert(insertPhotoFavorite);
@@ -53,17 +53,17 @@ public class PhotoFavoriteMapperTest {
 			List<PhotoFavorite> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite WHERE account_no=1 and favorite_photo_account_no=2 and favorite_photo_no=1", (rs, rowNum) ->
 						PhotoFavorite.builder()
-							.accountNo(rs.getInt("account_no"))
-							.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-							.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+							.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.build());
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(2, actualData.getFirst().getFavoritePhotoAccountNo());
-			assertEquals(1, actualData.getFirst().getFavoritePhotoNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(2L, actualData.getFirst().getFavoritePhotoAccountNo());
+			assertEquals(1L, actualData.getFirst().getFavoritePhotoNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
 		}
 	}
 	
@@ -77,10 +77,10 @@ public class PhotoFavoriteMapperTest {
 			return jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite WHERE " + condition, (rs, rowNum) ->
 						PhotoFavorite.builder()
-							.accountNo(rs.getInt("account_no"))
-							.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-							.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+							.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.build());
 		}
@@ -89,7 +89,7 @@ public class PhotoFavoriteMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのdelete")
 		void delete_by_accountNo() {
-			PhotoFavorite deletePhotoFavorite = PhotoFavorite.builder().accountNo(1).build();
+			PhotoFavorite deletePhotoFavorite = PhotoFavorite.builder().accountNo(1L).build();
 			Integer actual = photoFavoriteMapper.delete(deletePhotoFavorite);
 			assertEquals(2, actual);
 			
@@ -104,7 +104,7 @@ public class PhotoFavoriteMapperTest {
 		@Order(2)
 		@DisplayName("正常系：お気に入り写真アカウント番号でのdelete")
 		void delete_by_favoritePhotoAccountNo() {
-			PhotoFavorite deletePhotoFavorite = PhotoFavorite.builder().favoritePhotoAccountNo(1).build();
+			PhotoFavorite deletePhotoFavorite = PhotoFavorite.builder().favoritePhotoAccountNo(1L).build();
 			Integer actual = photoFavoriteMapper.delete(deletePhotoFavorite);
 			assertEquals(3, actual);
 			
@@ -119,7 +119,7 @@ public class PhotoFavoriteMapperTest {
 		@Order(3)
 		@DisplayName("正常系：お気に入り写真番号でのdelete")
 		void delete_by_favoritePhotoNo() {
-			PhotoFavorite deletePhotoFavorite = PhotoFavorite.builder().favoritePhotoNo(1).build();
+			PhotoFavorite deletePhotoFavorite = PhotoFavorite.builder().favoritePhotoNo(1L).build();
 			Integer actual = photoFavoriteMapper.delete(deletePhotoFavorite);
 			assertEquals(2, actual);
 			
@@ -134,7 +134,7 @@ public class PhotoFavoriteMapperTest {
 		@Order(4)
 		@DisplayName("正常系：削除対象のレコードなし")
 		void delete_not_found() {
-			PhotoFavorite deletePhotoFavorite = PhotoFavorite.builder().accountNo(3).build();
+			PhotoFavorite deletePhotoFavorite = PhotoFavorite.builder().accountNo(3L).build();
 			Integer actual = photoFavoriteMapper.delete(deletePhotoFavorite);
 			assertEquals(0, actual);
 			
@@ -150,9 +150,9 @@ public class PhotoFavoriteMapperTest {
 		@DisplayName("正常系：複数の条件でdeleteする場合")
 		void delete_some_conditions() {
 			PhotoFavorite deletePhotoFavorite = PhotoFavorite.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			Integer actual = photoFavoriteMapper.delete(deletePhotoFavorite);
 			assertEquals(1, actual);

--- a/backend/src/test/java/com/web/gallery/mapper/PhotoMstMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/PhotoMstMapperTest.java
@@ -44,7 +44,7 @@ public class PhotoMstMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのcountで1件の場合")
 		void count_by_accountNo() {
-			PhotoMst photoMst = PhotoMst.builder().accountNo(1).build();
+			PhotoMst photoMst = PhotoMst.builder().accountNo(1L).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(3, actual);
 		}
@@ -53,7 +53,7 @@ public class PhotoMstMapperTest {
 		@Order(2)
 		@DisplayName("正常系：写真番号でのcountで1件の場合")
 		void count_by_photoNo() {
-			PhotoMst photoMst = PhotoMst.builder().photoNo(1).build();
+			PhotoMst photoMst = PhotoMst.builder().photoNo(1L).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(2, actual);
 		}
@@ -81,7 +81,7 @@ public class PhotoMstMapperTest {
 		@Order(5)
 		@DisplayName("正常系：ロケーション番号でのcountで1件の場合")
 		void count_by_locationNo() {
-			PhotoMst photoMst = PhotoMst.builder().locationNo(1).build();
+			PhotoMst photoMst = PhotoMst.builder().locationNo(1L).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(1, actual);
 		}
@@ -171,7 +171,7 @@ public class PhotoMstMapperTest {
 		@Order(15)
 		@DisplayName("正常系：countで0件の場合")
 		void count_not_found() {
-			PhotoMst photoMst = PhotoMst.builder().accountNo(100).build();
+			PhotoMst photoMst = PhotoMst.builder().accountNo(100L).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(0, actual);
 		}
@@ -180,7 +180,7 @@ public class PhotoMstMapperTest {
 		@Order(16)
 		@DisplayName("正常系：複数の条件でcountする場合")
 		void count_some_conditions() {
-			PhotoMst photoMst = PhotoMst.builder().accountNo(1).photoNo(1).build();
+			PhotoMst photoMst = PhotoMst.builder().accountNo(1L).photoNo(1L).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(1, actual);
 		}
@@ -197,15 +197,15 @@ public class PhotoMstMapperTest {
 		@DisplayName("正常系：登録成功")
 		void insert_success() {
 			PhotoMst insertPhotoMst = PhotoMst.builder()
-					.accountNo(1)
-					.photoNo(4)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(4L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9)))
-					.updatedBy(1)
+					.updatedBy(1L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9)))
 					.isDeleted(false)
 					.photoAt(OffsetDateTime.of(2000, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(9)))
-					.locationNo(6)
+					.locationNo(6L)
 					.imageFilePath("https://www.xxx.com/DSC666.jpg")
 					.photoJapaneseTitle("")
 					.photoEnglishTitle("")
@@ -223,15 +223,15 @@ public class PhotoMstMapperTest {
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst WHERE account_no=1 and photo_no=4", (rs, rowNum) ->
 						PhotoMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.photoAt(rs.getObject("photo_at", OffsetDateTime.class))
-							.locationNo(rs.getInt("location_no"))
+							.locationNo(rs.getLong("location_no"))
 							.imageFilePath(rs.getString("image_file_path"))
 							.photoJapaneseTitle(rs.getString("photo_japanese_title"))
 							.photoEnglishTitle(rs.getString("photo_english_title"))
@@ -244,13 +244,13 @@ public class PhotoMstMapperTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(4, actualData.getFirst().getPhotoNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(4L, actualData.getFirst().getPhotoNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getPhotoAt());
-			assertEquals(6, actualData.getFirst().getLocationNo());
+			assertEquals(6L, actualData.getFirst().getLocationNo());
 			assertEquals("https://www.xxx.com/DSC666.jpg", actualData.getFirst().getImageFilePath());
 			assertEquals("", actualData.getFirst().getPhotoJapaneseTitle());
 			assertEquals("", actualData.getFirst().getPhotoEnglishTitle());
@@ -273,15 +273,15 @@ public class PhotoMstMapperTest {
 			return jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst WHERE " + condition, (rs, rowNum) ->
 						PhotoMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.photoAt(rs.getObject("photo_at", OffsetDateTime.class))
-							.locationNo(rs.getInt("location_no"))
+							.locationNo(rs.getLong("location_no"))
 							.imageFilePath(rs.getString("image_file_path"))
 							.photoJapaneseTitle(rs.getString("photo_japanese_title"))
 							.photoEnglishTitle(rs.getString("photo_english_title"))
@@ -298,20 +298,20 @@ public class PhotoMstMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのupdate")
 		void update_by_accountNo() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().accountNo(1).build();
+			PhotoMst conditionPhotoMst = PhotoMst.builder().accountNo(1L).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(1000).build();
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(3, actual);
 			
 			List<PhotoMst> actualData = getPhotoMstList("account_no=1");
 			assertEquals(3, actualData.size());
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(1, actualData.get(0).getPhotoNo());
-			assertEquals(1, actualData.get(0).getCreatedBy());
-			assertEquals(1, actualData.get(0).getUpdatedBy());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(1L, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getCreatedBy());
+			assertEquals(1L, actualData.get(0).getUpdatedBy());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
-			assertEquals(1, actualData.get(0).getLocationNo());
+			assertEquals(1L, actualData.get(0).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.get(0).getImageFilePath());
 			assertEquals("タイトル11", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title11", actualData.get(0).getPhotoEnglishTitle());
@@ -327,7 +327,7 @@ public class PhotoMstMapperTest {
 		@Order(2)
 		@DisplayName("正常系：写真番号でのupdate")
 		void update_by_photoNo() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().photoNo(1).build();
+			PhotoMst conditionPhotoMst = PhotoMst.builder().photoNo(1L).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(1000).build();
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(2, actual);
@@ -336,13 +336,13 @@ public class PhotoMstMapperTest {
 					.stream().sorted(Comparator.comparing(PhotoMst::getAccountNo)).toList();
 			assertEquals(2, actualData.size());
 			
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(1, actualData.get(0).getPhotoNo());
-			assertEquals(1, actualData.get(0).getCreatedBy());
-			assertEquals(1, actualData.get(0).getUpdatedBy());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(1L, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getCreatedBy());
+			assertEquals(1L, actualData.get(0).getUpdatedBy());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
-			assertEquals(1, actualData.get(0).getLocationNo());
+			assertEquals(1L, actualData.get(0).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.get(0).getImageFilePath());
 			assertEquals("タイトル11", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title11", actualData.get(0).getPhotoEnglishTitle());
@@ -353,13 +353,13 @@ public class PhotoMstMapperTest {
 			assertEquals(0, BigDecimal.valueOf(1).compareTo(actualData.get(0).getShutterSpeed()));
 			assertEquals(1000, actualData.get(0).getIso());
 			
-			assertEquals(2, actualData.get(1).getAccountNo());
-			assertEquals(1, actualData.get(1).getPhotoNo());
-			assertEquals(1, actualData.get(1).getCreatedBy());
-			assertEquals(1, actualData.get(1).getUpdatedBy());
+			assertEquals(2L, actualData.get(1).getAccountNo());
+			assertEquals(1L, actualData.get(1).getPhotoNo());
+			assertEquals(1L, actualData.get(1).getCreatedBy());
+			assertEquals(1L, actualData.get(1).getUpdatedBy());
 			assertFalse(actualData.get(1).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2022, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(1).getPhotoAt());
-			assertEquals(4, actualData.get(1).getLocationNo());
+			assertEquals(4L, actualData.get(1).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC444.jpg", actualData.get(1).getImageFilePath());
 			assertEquals("タイトル21", actualData.get(1).getPhotoJapaneseTitle());
 			assertEquals("title21", actualData.get(1).getPhotoEnglishTitle());
@@ -384,13 +384,13 @@ public class PhotoMstMapperTest {
 			assertEquals(3, actualData.size());
 			
 			actualData = actualData.stream().filter(photoMst -> photoMst.getAccountNo() == 2).toList();
-			assertEquals(2, actualData.get(0).getAccountNo());
-			assertEquals(3, actualData.get(0).getPhotoNo());
-			assertEquals(1, actualData.get(0).getCreatedBy());
-			assertEquals(1, actualData.get(0).getUpdatedBy());
+			assertEquals(2L, actualData.get(0).getAccountNo());
+			assertEquals(3L, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getCreatedBy());
+			assertEquals(1L, actualData.get(0).getUpdatedBy());
 			assertTrue(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2022, 3, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
-			assertEquals(6, actualData.get(0).getLocationNo());
+			assertEquals(6L, actualData.get(0).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC555.jpg", actualData.get(0).getImageFilePath());
 			assertEquals("タイトル23", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title23", actualData.get(0).getPhotoEnglishTitle());
@@ -415,13 +415,13 @@ public class PhotoMstMapperTest {
 			List<PhotoMst> actualData = getPhotoMstList("photo_at='2021-01-01 00:00:00.000 +0000'");
 			assertEquals(1, actualData.size());
 			
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(1, actualData.get(0).getPhotoNo());
-			assertEquals(1, actualData.get(0).getCreatedBy());
-			assertEquals(1, actualData.get(0).getUpdatedBy());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(1L, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getCreatedBy());
+			assertEquals(1L, actualData.get(0).getUpdatedBy());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
-			assertEquals(1, actualData.get(0).getLocationNo());
+			assertEquals(1L, actualData.get(0).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.get(0).getImageFilePath());
 			assertEquals("タイトル11", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title11", actualData.get(0).getPhotoEnglishTitle());
@@ -437,7 +437,7 @@ public class PhotoMstMapperTest {
 		@Order(5)
 		@DisplayName("正常系：ロケーション番号でのupdate")
 		void update_by_locationNo() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().locationNo(1).build();
+			PhotoMst conditionPhotoMst = PhotoMst.builder().locationNo(1L).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(1000).build();
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
@@ -445,13 +445,13 @@ public class PhotoMstMapperTest {
 			List<PhotoMst> actualData = getPhotoMstList("location_no=1");
 			assertEquals(1, actualData.size());
 			
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(1, actualData.get(0).getPhotoNo());
-			assertEquals(1, actualData.get(0).getCreatedBy());
-			assertEquals(1, actualData.get(0).getUpdatedBy());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(1L, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getCreatedBy());
+			assertEquals(1L, actualData.get(0).getUpdatedBy());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
-			assertEquals(1, actualData.get(0).getLocationNo());
+			assertEquals(1L, actualData.get(0).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.get(0).getImageFilePath());
 			assertEquals("タイトル11", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title11", actualData.get(0).getPhotoEnglishTitle());
@@ -475,13 +475,13 @@ public class PhotoMstMapperTest {
 			List<PhotoMst> actualData = getPhotoMstList("image_file_path='https://www.xxx.com/DSC111.jpg'");
 			assertEquals(1, actualData.size());
 			
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(1, actualData.get(0).getPhotoNo());
-			assertEquals(1, actualData.get(0).getCreatedBy());
-			assertEquals(1, actualData.get(0).getUpdatedBy());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(1L, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getCreatedBy());
+			assertEquals(1L, actualData.get(0).getUpdatedBy());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
-			assertEquals(1, actualData.get(0).getLocationNo());
+			assertEquals(1L, actualData.get(0).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.get(0).getImageFilePath());
 			assertEquals("タイトル11", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title11", actualData.get(0).getPhotoEnglishTitle());
@@ -505,13 +505,13 @@ public class PhotoMstMapperTest {
 			List<PhotoMst> actualData = getPhotoMstList("photo_japanese_title='タイトル11'");
 			assertEquals(1, actualData.size());
 			
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(1, actualData.get(0).getPhotoNo());
-			assertEquals(1, actualData.get(0).getCreatedBy());
-			assertEquals(1, actualData.get(0).getUpdatedBy());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(1L, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getCreatedBy());
+			assertEquals(1L, actualData.get(0).getUpdatedBy());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
-			assertEquals(1, actualData.get(0).getLocationNo());
+			assertEquals(1L, actualData.get(0).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.get(0).getImageFilePath());
 			assertEquals("タイトル11", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title11", actualData.get(0).getPhotoEnglishTitle());
@@ -535,13 +535,13 @@ public class PhotoMstMapperTest {
 			List<PhotoMst> actualData = getPhotoMstList("photo_english_title='title11'");
 			assertEquals(1, actualData.size());
 			
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(1, actualData.get(0).getPhotoNo());
-			assertEquals(1, actualData.get(0).getCreatedBy());
-			assertEquals(1, actualData.get(0).getUpdatedBy());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(1L, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getCreatedBy());
+			assertEquals(1L, actualData.get(0).getUpdatedBy());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
-			assertEquals(1, actualData.get(0).getLocationNo());
+			assertEquals(1L, actualData.get(0).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.get(0).getImageFilePath());
 			assertEquals("タイトル11", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title11", actualData.get(0).getPhotoEnglishTitle());
@@ -565,13 +565,13 @@ public class PhotoMstMapperTest {
 			List<PhotoMst> actualData = getPhotoMstList("caption='キャプション11'");
 			assertEquals(1, actualData.size());
 			
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(1, actualData.get(0).getPhotoNo());
-			assertEquals(1, actualData.get(0).getCreatedBy());
-			assertEquals(1, actualData.get(0).getUpdatedBy());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(1L, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getCreatedBy());
+			assertEquals(1L, actualData.get(0).getUpdatedBy());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
-			assertEquals(1, actualData.get(0).getLocationNo());
+			assertEquals(1L, actualData.get(0).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.get(0).getImageFilePath());
 			assertEquals("タイトル11", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title11", actualData.get(0).getPhotoEnglishTitle());
@@ -595,13 +595,13 @@ public class PhotoMstMapperTest {
 			List<PhotoMst> actualData = getPhotoMstList("direction_kbn='vertical'");
 			assertEquals(1, actualData.size());
 			
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(1, actualData.get(0).getPhotoNo());
-			assertEquals(1, actualData.get(0).getCreatedBy());
-			assertEquals(1, actualData.get(0).getUpdatedBy());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(1L, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getCreatedBy());
+			assertEquals(1L, actualData.get(0).getUpdatedBy());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
-			assertEquals(1, actualData.get(0).getLocationNo());
+			assertEquals(1L, actualData.get(0).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.get(0).getImageFilePath());
 			assertEquals("タイトル11", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title11", actualData.get(0).getPhotoEnglishTitle());
@@ -625,13 +625,13 @@ public class PhotoMstMapperTest {
 			List<PhotoMst> actualData = getPhotoMstList("focal_length=24");
 			assertEquals(1, actualData.size());
 			
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(1, actualData.get(0).getPhotoNo());
-			assertEquals(1, actualData.get(0).getCreatedBy());
-			assertEquals(1, actualData.get(0).getUpdatedBy());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(1L, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getCreatedBy());
+			assertEquals(1L, actualData.get(0).getUpdatedBy());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
-			assertEquals(1, actualData.get(0).getLocationNo());
+			assertEquals(1L, actualData.get(0).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.get(0).getImageFilePath());
 			assertEquals("タイトル11", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title11", actualData.get(0).getPhotoEnglishTitle());
@@ -655,13 +655,13 @@ public class PhotoMstMapperTest {
 			List<PhotoMst> actualData = getPhotoMstList("f_value=8.0");
 			assertEquals(1, actualData.size());
 			
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(1, actualData.get(0).getPhotoNo());
-			assertEquals(1, actualData.get(0).getCreatedBy());
-			assertEquals(1, actualData.get(0).getUpdatedBy());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(1L, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getCreatedBy());
+			assertEquals(1L, actualData.get(0).getUpdatedBy());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
-			assertEquals(1, actualData.get(0).getLocationNo());
+			assertEquals(1L, actualData.get(0).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.get(0).getImageFilePath());
 			assertEquals("タイトル11", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title11", actualData.get(0).getPhotoEnglishTitle());
@@ -685,13 +685,13 @@ public class PhotoMstMapperTest {
 			List<PhotoMst> actualData = getPhotoMstList("shutter_speed=1");
 			assertEquals(1, actualData.size());
 			
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(1, actualData.get(0).getPhotoNo());
-			assertEquals(1, actualData.get(0).getCreatedBy());
-			assertEquals(1, actualData.get(0).getUpdatedBy());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(1L, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getCreatedBy());
+			assertEquals(1L, actualData.get(0).getUpdatedBy());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
-			assertEquals(1, actualData.get(0).getLocationNo());
+			assertEquals(1L, actualData.get(0).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.get(0).getImageFilePath());
 			assertEquals("タイトル11", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title11", actualData.get(0).getPhotoEnglishTitle());
@@ -715,13 +715,13 @@ public class PhotoMstMapperTest {
 			List<PhotoMst> actualData = getPhotoMstList("iso=1000");
 			assertEquals(1, actualData.size());
 			
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(1, actualData.get(0).getPhotoNo());
-			assertEquals(1, actualData.get(0).getCreatedBy());
-			assertEquals(1, actualData.get(0).getUpdatedBy());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(1L, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getCreatedBy());
+			assertEquals(1L, actualData.get(0).getUpdatedBy());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
-			assertEquals(1, actualData.get(0).getLocationNo());
+			assertEquals(1L, actualData.get(0).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.get(0).getImageFilePath());
 			assertEquals("タイトル11", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title11", actualData.get(0).getPhotoEnglishTitle());
@@ -737,7 +737,7 @@ public class PhotoMstMapperTest {
 		@Order(15)
 		@DisplayName("正常系：updateで0件の場合")
 		void update_not_found() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().accountNo(100).build();
+			PhotoMst conditionPhotoMst = PhotoMst.builder().accountNo(100L).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(1000).build();
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(0, actual);
@@ -750,7 +750,7 @@ public class PhotoMstMapperTest {
 		@Order(16)
 		@DisplayName("正常系：複数の条件でupdateする場合")
 		void update_some_conditions() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().accountNo(1).photoNo(1).build();
+			PhotoMst conditionPhotoMst = PhotoMst.builder().accountNo(1L).photoNo(1L).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(1000).build();
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
@@ -758,13 +758,13 @@ public class PhotoMstMapperTest {
 			List<PhotoMst> actualData = getPhotoMstList("account_no=1 and photo_no=1");
 			assertEquals(1, actualData.size());
 			
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(1, actualData.get(0).getPhotoNo());
-			assertEquals(1, actualData.get(0).getCreatedBy());
-			assertEquals(1, actualData.get(0).getUpdatedBy());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(1L, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getCreatedBy());
+			assertEquals(1L, actualData.get(0).getUpdatedBy());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
-			assertEquals(1, actualData.get(0).getLocationNo());
+			assertEquals(1L, actualData.get(0).getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.get(0).getImageFilePath());
 			assertEquals("タイトル11", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title11", actualData.get(0).getPhotoEnglishTitle());
@@ -787,7 +787,7 @@ public class PhotoMstMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号に該当する写真がある場合")
 		void getMaxPhotoNo_found() {
-			Integer actual = photoMstMapper.getMaxPhotoNo(1);
+			Long actual = photoMstMapper.getMaxPhotoNo(1L);
 			assertEquals(3, actual);
 		}
 		
@@ -795,7 +795,7 @@ public class PhotoMstMapperTest {
 		@Order(2)
 		@DisplayName("正常系：アカウント番号に該当する写真がない場合")
 		void getMaxPhotoNo_not_found() {
-			Integer actual = photoMstMapper.getMaxPhotoNo(3);
+			Long actual = photoMstMapper.getMaxPhotoNo(3L);
 			assertNull(actual);
 		}
 	}
@@ -811,7 +811,7 @@ public class PhotoMstMapperTest {
 		@DisplayName("正常系：画像ファイルパスに該当する写真が1つある場合")
 		void isExistPhoto_photo_found() {
 			PhotoMst photoMst = PhotoMst.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.imageFilePath("DSC111.jpg")
 					.build();
 			assertTrue(photoMstMapper.isExistPhoto(photoMst));
@@ -822,7 +822,7 @@ public class PhotoMstMapperTest {
 		@DisplayName("正常系：画像ファイルパスに該当する写真が複数ある場合")
 		void isExistPhoto_photos_found() {
 			PhotoMst photoMst = PhotoMst.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.imageFilePath("DSC555.jpg")
 					.build();
 			assertTrue(photoMstMapper.isExistPhoto(photoMst));
@@ -833,7 +833,7 @@ public class PhotoMstMapperTest {
 		@DisplayName("正常系：画像ファイルパスに該当する写真があるが、削除済みの場合")
 		void isExistPhoto_found_is_deleted() {
 			PhotoMst photoMst = PhotoMst.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.imageFilePath("DSC333.jpg")
 					.build();
 			assertFalse(photoMstMapper.isExistPhoto(photoMst));
@@ -844,7 +844,7 @@ public class PhotoMstMapperTest {
 		@DisplayName("正常系：画像ファイルパスに該当する写真がない場合")
 		void isExistPhoto_not_found() {
 			PhotoMst photoMst = PhotoMst.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.imageFilePath("DSC999.jpg")
 					.build();
 			assertFalse(photoMstMapper.isExistPhoto(photoMst));

--- a/backend/src/test/java/com/web/gallery/mapper/PhotoTagMstMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/PhotoTagMstMapperTest.java
@@ -43,51 +43,51 @@ public class PhotoTagMstMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのselectで1件以上の場合")
 		void select_by_accountNo() {
-			PhotoTagMst photoTagMst = PhotoTagMst.builder().accountNo(1).build();
+			PhotoTagMst photoTagMst = PhotoTagMst.builder().accountNo(1L).build();
 			List<PhotoTagMst> actual = photoTagMstMapper.select(photoTagMst);
 			actual.forEach(e -> e.setId(null));
 
 			PhotoTagMst expectedPhotoTagMst1 = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build();
 			PhotoTagMst expectedPhotoTagMst2 = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(2)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(2L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 2, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.tagJapaneseName("青空")
 					.tagEnglishName("bluesky")
 					.build();
 			PhotoTagMst expectedPhotoTagMst3 = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(2)
-					.tagNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(2L)
+					.tagNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 2, 1, 1, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build();
 			PhotoTagMst expectedPhotoTagMst4 = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(2)
-					.tagNo(2)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(2L)
+					.tagNo(2L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 2, 1, 2, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.tagJapaneseName("曇天")
 					.tagEnglishName("cloudy")
 					.build();
 			PhotoTagMst expectedPhotoTagMst5 = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(2)
-					.tagNo(3)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(2L)
+					.tagNo(3L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 2, 1, 3, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.tagJapaneseName("花")
 					.tagEnglishName("flower")
@@ -108,24 +108,24 @@ public class PhotoTagMstMapperTest {
 		@Order(2)
 		@DisplayName("正常系：写真番号でのselectで1件の場合")
 		void select_by_photoNo() {
-			PhotoTagMst photoTagMst = PhotoTagMst.builder().photoNo(1).build();
+			PhotoTagMst photoTagMst = PhotoTagMst.builder().photoNo(1L).build();
 			List<PhotoTagMst> actual = photoTagMstMapper.select(photoTagMst);
 			actual.forEach(e -> e.setId(null));
 
 			PhotoTagMst expectedPhotoTagMst1 = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build();
 			PhotoTagMst expectedPhotoTagMst2 = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(2)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(2L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 2, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.tagJapaneseName("青空")
 					.tagEnglishName("bluesky")
@@ -143,24 +143,24 @@ public class PhotoTagMstMapperTest {
 		@Order(3)
 		@DisplayName("正常系：タグ番号でのselectで1件の場合")
 		void select_by_tagNo() {
-			PhotoTagMst photoTagMst = PhotoTagMst.builder().tagNo(1).build();
+			PhotoTagMst photoTagMst = PhotoTagMst.builder().tagNo(1L).build();
 			List<PhotoTagMst> actual = photoTagMstMapper.select(photoTagMst);
 			actual.forEach(e -> e.setId(null));
 
 			PhotoTagMst expectedPhotoTagMst1 = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build();
 			PhotoTagMst expectedPhotoTagMst2 = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(2)
-					.tagNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(2L)
+					.tagNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 2, 1, 1, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
@@ -183,19 +183,19 @@ public class PhotoTagMstMapperTest {
 			actual.forEach(e -> e.setId(null));
 
 			PhotoTagMst expectedPhotoTagMst1 = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build();
 			PhotoTagMst expectedPhotoTagMst2 = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(2)
-					.tagNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(2L)
+					.tagNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 2, 1, 1, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
@@ -218,19 +218,19 @@ public class PhotoTagMstMapperTest {
 			actual.forEach(e -> e.setId(null));
 
 			PhotoTagMst expectedPhotoTagMst1 = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build();
 			PhotoTagMst expectedPhotoTagMst2 = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(2)
-					.tagNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(2L)
+					.tagNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 2, 1, 1, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
@@ -248,7 +248,7 @@ public class PhotoTagMstMapperTest {
 		@Order(6)
 		@DisplayName("正常系：selectで0件の場合")
 		void select_not_found() {
-			PhotoTagMst photoTagMst = PhotoTagMst.builder().accountNo(3).build();
+			PhotoTagMst photoTagMst = PhotoTagMst.builder().accountNo(3L).build();
 			List<PhotoTagMst> actual = photoTagMstMapper.select(photoTagMst);
 			List<PhotoTagMst> expected = new ArrayList<PhotoTagMst>();
 			assertEquals(0, actual.size());
@@ -260,18 +260,18 @@ public class PhotoTagMstMapperTest {
 		@DisplayName("正常系：複数の条件でselectする場合")
 		void select_some_conditions() {
 			PhotoTagMst photoTagMst = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.build();
 			List<PhotoTagMst> actual = photoTagMstMapper.select(photoTagMst);
 			actual.forEach(e -> e.setId(null));
 
 			PhotoTagMst expectedPhotoTagMst1 = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
@@ -296,10 +296,10 @@ public class PhotoTagMstMapperTest {
 		@DisplayName("正常系：登録成功")
 		void insert_success() {
 			PhotoTagMst photoTagMst = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(3)
-					.createdBy(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(3L)
+					.createdBy(1L)
 					.tagJapaneseName("春")
 					.tagEnglishName("spring")
 					.build();
@@ -310,19 +310,19 @@ public class PhotoTagMstMapperTest {
 			List<PhotoTagMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_tag_mst WHERE account_no=1 and photo_no=1 and tag_no=3", (rs, rowNum) ->
 						PhotoTagMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.tagNo(rs.getInt("tag_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.tagNo(rs.getLong("tag_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.tagJapaneseName(rs.getObject("tag_japanese_name").toString())
 							.tagEnglishName(rs.getObject("tag_english_name").toString())
 							.build());
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getPhotoNo());
-			assertEquals(3, actualData.getFirst().getTagNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getPhotoNo());
+			assertEquals(3L, actualData.getFirst().getTagNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
 			assertEquals("春", actualData.getFirst().getTagJapaneseName());
 			assertEquals("spring", actualData.getFirst().getTagEnglishName());
 		}
@@ -338,10 +338,10 @@ public class PhotoTagMstMapperTest {
 			return jdbcTemplate.query(
 					"SELECT * FROM photo.photo_tag_mst WHERE " + condition, (rs, rowNum) ->
 						PhotoTagMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.tagNo(rs.getInt("tag_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.tagNo(rs.getLong("tag_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.tagJapaneseName(rs.getObject("tag_japanese_name").toString())
 							.tagEnglishName(rs.getObject("tag_english_name").toString())
@@ -352,7 +352,7 @@ public class PhotoTagMstMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのdelete")
 		void delete_by_accountNo() {
-			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder().accountNo(1).build();
+			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder().accountNo(1L).build();
 			Integer deleteCount = photoTagMstMapper.delete(deletePhotoTagMst);
 			assertEquals(deleteCount, 5);
 			
@@ -367,7 +367,7 @@ public class PhotoTagMstMapperTest {
 		@Order(2)
 		@DisplayName("正常系：写真番号でのdelete")
 		void delete_by_photoNo() {
-			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder().photoNo(1).build();
+			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder().photoNo(1L).build();
 			Integer deleteCount = photoTagMstMapper.delete(deletePhotoTagMst);
 			assertEquals(deleteCount, 2);
 			
@@ -382,7 +382,7 @@ public class PhotoTagMstMapperTest {
 		@Order(3)
 		@DisplayName("正常系：タグ番号でのdelete")
 		void delete_by_tagNo() {
-			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder().tagNo(1).build();
+			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder().tagNo(1L).build();
 			Integer actual = photoTagMstMapper.delete(deletePhotoTagMst);
 			assertEquals(2, actual);
 			
@@ -427,7 +427,7 @@ public class PhotoTagMstMapperTest {
 		@Order(6)
 		@DisplayName("正常系：deleteで0件の場合")
 		void delete_not_found() {
-			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder().accountNo(3).build();
+			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder().accountNo(3L).build();
 			Integer actual = photoTagMstMapper.delete(deletePhotoTagMst);
 			assertEquals(0, actual);
 			
@@ -443,9 +443,9 @@ public class PhotoTagMstMapperTest {
 		@DisplayName("正常系：複数の条件でdeleteする場合")
 		void delete_some_conditions() {
 			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.build();
 			Integer actual = photoTagMstMapper.delete(deletePhotoTagMst);
 			assertEquals(1, actual);

--- a/backend/src/test/java/com/web/gallery/repository/impl/AccountRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/AccountRepositoryImplTest.java
@@ -55,10 +55,10 @@ public class AccountRepositoryImplTest {
 		@DisplayName("正常系：アカウントが取得できた場合")
 		void getByAccountNo_found() {
 			Account account = Account.builder()
-					.accountNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(1)
+					.updatedBy(1L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("aaaaaaaa")
@@ -80,11 +80,11 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(accountList).when(accountMapper).select(accountCaptor.capture());
 			
-			AccountModel actual = accountRepositoryImpl.getByAccountNo(1);
+			AccountModel actual = accountRepositoryImpl.getByAccountNo(1L);
 
 			verify(accountMapper).select(any(Account.class));
 			Account accountCapture = accountCaptor.getValue();
-			assertEquals(1, accountCapture.getAccountNo());
+			assertEquals(1L, accountCapture.getAccountNo());
 
 			assertNotNull(actual);
 			assertEquals(account.getAccountNo(), actual.getAccountNo());
@@ -108,11 +108,11 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(new ArrayList<Account>()).when(accountMapper).select(accountCaptor.capture());
 			
-			AccountModel actual = accountRepositoryImpl.getByAccountNo(1);
+			AccountModel actual = accountRepositoryImpl.getByAccountNo(1L);
 			
 			verify(accountMapper).select(any(Account.class));
 			Account accountCapture = accountCaptor.getValue();
-			assertEquals(1, accountCapture.getAccountNo());
+			assertEquals(1L, accountCapture.getAccountNo());
 			
 			assertNull(actual);
 		}
@@ -127,10 +127,10 @@ public class AccountRepositoryImplTest {
 		@DisplayName("正常系：アカウントが取得できた場合")
 		void getByAccountId_found() {
 			Account account = Account.builder()
-					.accountNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(1)
+					.updatedBy(1L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("aaaaaaaa")
@@ -213,9 +213,9 @@ public class AccountRepositoryImplTest {
 			verify(accountMapper).insert(any(Account.class));
 			Account accountCapture = accountCaptor.getValue();
 			assertEquals(null, accountCapture.getAccountNo());
-			assertEquals(0, accountCapture.getCreatedBy());
+			assertEquals(0L, accountCapture.getCreatedBy());
 			assertEquals(null, accountCapture.getCreatedAt());
-			assertEquals(0, accountCapture.getUpdatedBy());
+			assertEquals(0L, accountCapture.getUpdatedBy());
 			assertEquals(null, accountCapture.getUpdatedAt());
 			assertEquals(null, accountCapture.getIsDeleted());
 			assertEquals("aaaaaaaa", accountCapture.getAccountId());
@@ -255,9 +255,9 @@ public class AccountRepositoryImplTest {
 			verify(accountMapper).insert(any(Account.class));
 			Account accountCapture = accountCaptor.getValue();
 			assertEquals(null, accountCapture.getAccountNo());
-			assertEquals(0, accountCapture.getCreatedBy());
+			assertEquals(0L, accountCapture.getCreatedBy());
 			assertEquals(null, accountCapture.getCreatedAt());
-			assertEquals(0, accountCapture.getUpdatedBy());
+			assertEquals(0L, accountCapture.getUpdatedBy());
 			assertEquals(null, accountCapture.getUpdatedAt());
 			assertEquals(null, accountCapture.getIsDeleted());
 			assertEquals("aaaaaaaa", accountCapture.getAccountId());
@@ -292,9 +292,9 @@ public class AccountRepositoryImplTest {
 			verify(accountMapper).insert(any(Account.class));
 			Account accountCapture = accountCaptor.getValue();
 			assertEquals(null, accountCapture.getAccountNo());
-			assertEquals(0, accountCapture.getCreatedBy());
+			assertEquals(0L, accountCapture.getCreatedBy());
 			assertEquals(null, accountCapture.getCreatedAt());
-			assertEquals(0, accountCapture.getUpdatedBy());
+			assertEquals(0L, accountCapture.getUpdatedBy());
 			assertEquals(null, accountCapture.getUpdatedAt());
 			assertEquals(null, accountCapture.getIsDeleted());
 			assertEquals("aaaaaaaa", accountCapture.getAccountId());
@@ -320,7 +320,7 @@ public class AccountRepositoryImplTest {
 		@DisplayName("正常系：Nullのパラメータを含むAccountModelでの更新")
 		void update_contain_null_parameter() throws UpdateFailureException {
 			AccountModel accountModel = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.accountName("AAAAAAAA")
 					.build();
@@ -333,7 +333,7 @@ public class AccountRepositoryImplTest {
 			
 			verify(accountMapper).update(any(Account.class), any(Account.class));
 			Account cndAccountCapture = cndAccountCaptor.getValue();
-			assertEquals(1, cndAccountCapture.getAccountNo());
+			assertEquals(1L, cndAccountCapture.getAccountNo());
 			
 			Account targetAccountCapture = targetAccountCaptor.getValue();
 			assertEquals(null, targetAccountCapture.getCreatedBy());
@@ -359,7 +359,7 @@ public class AccountRepositoryImplTest {
 		@DisplayName("正常系：Nullのパラメータを含まないAccountModelでの更新")
 		void update_not_contain_null_parameter() throws UpdateFailureException {
 			AccountModel accountModel = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.accountName("AAAAAAAA")
 					.password("aaaaaaaa")
@@ -381,7 +381,7 @@ public class AccountRepositoryImplTest {
 			
 			verify(accountMapper).update(any(Account.class), any(Account.class));
 			Account cndAccountCapture = cndAccountCaptor.getValue();
-			assertEquals(1, cndAccountCapture.getAccountNo());
+			assertEquals(1L, cndAccountCapture.getAccountNo());
 			
 			Account targetAccountCapture = targetAccountCaptor.getValue();
 			assertEquals(null, targetAccountCapture.getCreatedBy());
@@ -407,7 +407,7 @@ public class AccountRepositoryImplTest {
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
 		void update_UpdateFailureException() {
 			AccountModel accountModel = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.accountName("AAAAAAAA")
 					.build();
@@ -420,7 +420,7 @@ public class AccountRepositoryImplTest {
 			
 			verify(accountMapper).update(any(Account.class), any(Account.class));
 			Account cndAccountCapture = cndAccountCaptor.getValue();
-			assertEquals(1, cndAccountCapture.getAccountNo());
+			assertEquals(1L, cndAccountCapture.getAccountNo());
 			
 			Account targetAccountCapture = targetAccountCaptor.getValue();
 			assertEquals(null, targetAccountCapture.getCreatedBy());
@@ -451,7 +451,7 @@ public class AccountRepositoryImplTest {
 		@DisplayName("正常系：Nullのパラメータを含むAccountModelでの更新")
 		void updateLoginFailureCount_contain_null_parameter() throws UpdateFailureException {
 			AccountModel accountModel = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.build();
 			
 			ArgumentCaptor<Account> cndAccountCaptor = ArgumentCaptor.forClass(Account.class);
@@ -462,7 +462,7 @@ public class AccountRepositoryImplTest {
 			
 			verify(accountMapper).update(any(Account.class), any(Account.class));
 			Account cndAccountCapture = cndAccountCaptor.getValue();
-			assertEquals(cndAccountCapture.getAccountNo(), 1);
+			assertEquals(cndAccountCapture.getAccountNo(), 1L);
 			
 			Account targetAccountCapture = targetAccountCaptor.getValue();
 			assertEquals(null, targetAccountCapture.getCreatedBy());
@@ -488,7 +488,7 @@ public class AccountRepositoryImplTest {
 		@DisplayName("正常系：Nullのパラメータを含まないAccountModelでの更新")
 		void updateLoginFailureCount_not_contain_null_parameter() throws UpdateFailureException {
 			AccountModel accountModel = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.lastLoginDatetime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9)))
 					.loginFailureCount(2)
 					.build();
@@ -501,7 +501,7 @@ public class AccountRepositoryImplTest {
 			
 			verify(accountMapper).update(any(Account.class), any(Account.class));
 			Account cndAccountCapture = cndAccountCaptor.getValue();
-			assertEquals(cndAccountCapture.getAccountNo(), 1);
+			assertEquals(cndAccountCapture.getAccountNo(), 1L);
 			
 			Account targetAccountCapture = targetAccountCaptor.getValue();
 			assertEquals(null, targetAccountCapture.getCreatedBy());
@@ -527,7 +527,7 @@ public class AccountRepositoryImplTest {
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
 		void updateLoginFailureCount_UpdateFailureException() {
 			AccountModel accountModel = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.build();
 			
 			ArgumentCaptor<Account> cndAccountCaptor = ArgumentCaptor.forClass(Account.class);
@@ -538,7 +538,7 @@ public class AccountRepositoryImplTest {
 			
 			verify(accountMapper).update(any(Account.class), any(Account.class));
 			Account cndAccountCapture = cndAccountCaptor.getValue();
-			assertEquals(cndAccountCapture.getAccountNo(), 1);
+			assertEquals(cndAccountCapture.getAccountNo(), 1L);
 			
 			Account targetAccountCapture = targetAccountCaptor.getValue();
 			assertEquals(null, targetAccountCapture.getCreatedBy());
@@ -571,11 +571,11 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(true).when(accountMapper).isExistAccount(accountCaptor.capture());
 			
-			assertTrue(accountRepositoryImpl.isExistAccount(1, "aaaaaaaa"));
+			assertTrue(accountRepositoryImpl.isExistAccount(1L, "aaaaaaaa"));
 			verify(accountMapper, times(1)).isExistAccount(any(Account.class));
 			
 			Account accountCapture = accountCaptor.getValue();
-			assertEquals(1, accountCapture.getAccountNo());
+			assertEquals(1L, accountCapture.getAccountNo());
 			assertEquals("aaaaaaaa", accountCapture.getAccountId());
 		}
 		
@@ -586,11 +586,11 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(false).when(accountMapper).isExistAccount(accountCaptor.capture());
 			
-			assertFalse(accountRepositoryImpl.isExistAccount(1, "aaaaaaaa"));
+			assertFalse(accountRepositoryImpl.isExistAccount(1L, "aaaaaaaa"));
 			verify(accountMapper, times(1)).isExistAccount(any());
 			
 			Account accountCapture = accountCaptor.getValue();
-			assertEquals(1, accountCapture.getAccountNo());
+			assertEquals(1L, accountCapture.getAccountNo());
 			assertEquals("aaaaaaaa", accountCapture.getAccountId());
 		}
 	}
@@ -604,10 +604,10 @@ public class AccountRepositoryImplTest {
 		@DisplayName("正常系：アカウントを2件以上取得")
 		void getAccountList_found_some_accounts() {
 			Account account1 = Account.builder()
-					.accountNo(1)
-					.createdBy(1)
+					.accountNo(1L)
+					.createdBy(1L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(1)
+					.updatedBy(1L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("aaaaaaaa")
@@ -623,10 +623,10 @@ public class AccountRepositoryImplTest {
 					.loginFailureCount(0)
 					.build();
 			Account account2 = Account.builder()
-					.accountNo(2)
-					.createdBy(2)
+					.accountNo(2L)
+					.createdBy(2L)
 					.createdAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.updatedBy(2)
+					.updatedBy(2L)
 					.updatedAt(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.isDeleted(false)
 					.accountId("bbbbbbbb")
@@ -655,7 +655,7 @@ public class AccountRepositoryImplTest {
 			assertFalse(account.getIsDeleted());
 			
 			AccountModel actualAccountModel1 = actual.stream().sorted(Comparator.comparing(AccountModel::getAccountNo)).toList().getFirst();
-			assertEquals(1, actualAccountModel1.getAccountNo());
+			assertEquals(1L, actualAccountModel1.getAccountNo());
 			assertEquals("aaaaaaaa", actualAccountModel1.getAccountId());
 			assertEquals("AAAAAAAA", actualAccountModel1.getAccountName());
 			assertEquals("$2a$10$password1", actualAccountModel1.getPassword());
@@ -669,7 +669,7 @@ public class AccountRepositoryImplTest {
 			assertEquals(0, actualAccountModel1.getLoginFailureCount());
 			
 			AccountModel actualAccountModel2 = actual.stream().sorted(Comparator.comparing(AccountModel::getAccountNo)).toList().getLast();
-			assertEquals(2, actualAccountModel2.getAccountNo());
+			assertEquals(2L, actualAccountModel2.getAccountNo());
 			assertEquals("bbbbbbbb", actualAccountModel2.getAccountId());
 			assertEquals("BBBBBBBB", actualAccountModel2.getAccountName());
 			assertEquals("$2a$10$password2", actualAccountModel2.getPassword());

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImplTest.java
@@ -58,8 +58,8 @@ public class PhotoDetailRepositoryImplTest {
 		@DisplayName("正常系：写真が0件の場合")
 		void getPhotoList_photo_not_found() {
 			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(1)
+					.accountNo(1L)
+					.photoAccountNo(1L)
 					.build();
 			
 			List<PhotoDto> photoDtoList = new ArrayList<PhotoDto>();
@@ -79,11 +79,11 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals(expected, actual);
 			
 			PhotoListGetDto photoListGetDtoCapture = photoListGetDtoCaptor.getValue();
-			assertEquals(1, photoListGetDtoCapture.getAccountNo());
-			assertEquals(1, photoListGetDtoCapture.getPhotoAccountNo());
+			assertEquals(1L, photoListGetDtoCapture.getAccountNo());
+			assertEquals(1L, photoListGetDtoCapture.getPhotoAccountNo());
 			
 			PhotoTagMst photoTagMstCapture = photoTagMstCaptor.getValue();
-			assertEquals(1, photoTagMstCapture.getAccountNo());
+			assertEquals(1L, photoTagMstCapture.getAccountNo());
 		}
 		
 		@Test
@@ -91,14 +91,14 @@ public class PhotoDetailRepositoryImplTest {
 		@DisplayName("正常系：写真が1件以上、写真タグが0件の場合")
 		void getPhotoList_photoTag_not_found() {
 			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(1)
+					.accountNo(1L)
+					.photoAccountNo(1L)
 					.build();
 			
 			List<PhotoDto> photoDtoList = new ArrayList<PhotoDto>();
 			PhotoDto photoDto1 = new PhotoDto();
-			photoDto1.setAccountNo(1);
-			photoDto1.setPhotoNo(1);
+			photoDto1.setAccountNo(1L);
+			photoDto1.setPhotoNo(1L);
 			photoDto1.setFavoriteCount(1);
 			photoDto1.setIsFavorite(false);
 			photoDto1.setPhotoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)));
@@ -108,8 +108,8 @@ public class PhotoDetailRepositoryImplTest {
 			photoDtoList.add(photoDto1);
 			
 			PhotoDto photoDto2 = new PhotoDto();
-			photoDto2.setAccountNo(1);
-			photoDto2.setPhotoNo(2);
+			photoDto2.setAccountNo(1L);
+			photoDto2.setPhotoNo(2L);
 			photoDto2.setFavoriteCount(2);
 			photoDto2.setIsFavorite(true);
 			photoDto2.setPhotoAt(OffsetDateTime.of(2000, 2, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)));
@@ -128,8 +128,8 @@ public class PhotoDetailRepositoryImplTest {
 			
 			List<PhotoModel> actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
 			
-			assertEquals(1, actual.get(0).getAccountNo());
-			assertEquals(1, actual.get(0).getPhotoNo());
+			assertEquals(1L, actual.get(0).getAccountNo());
+			assertEquals(1L, actual.get(0).getPhotoNo());
 			assertEquals(1, actual.get(0).getFavoriteCount());
 			assertFalse(actual.get(0).getIsFavorite());
 			assertEquals(OffsetDateTime.of(2000, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt());
@@ -137,8 +137,8 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals("キャプション1", actual.get(0).getCaption());
 			assertEquals(DirectionEnum.VERTICAL, actual.get(0).getDirectionKbn());
 			
-			assertEquals(1, actual.get(1).getAccountNo());
-			assertEquals(2, actual.get(1).getPhotoNo());
+			assertEquals(1L, actual.get(1).getAccountNo());
+			assertEquals(2L, actual.get(1).getPhotoNo());
 			assertEquals(2, actual.get(1).getFavoriteCount());
 			assertTrue(actual.get(1).getIsFavorite());
 			assertEquals(OffsetDateTime.of(2000, 2, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(1).getPhotoAt());
@@ -147,11 +147,11 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals(DirectionEnum.HORIZONTAL, actual.get(1).getDirectionKbn());
 			
 			PhotoListGetDto photoListGetDtoCapture = photoListGetDtoCaptor.getValue();
-			assertEquals(1, photoListGetDtoCapture.getAccountNo());
-			assertEquals(1, photoListGetDtoCapture.getPhotoAccountNo());
+			assertEquals(1L, photoListGetDtoCapture.getAccountNo());
+			assertEquals(1L, photoListGetDtoCapture.getPhotoAccountNo());
 			
 			PhotoTagMst photoTagMstCapture = photoTagMstCaptor.getValue();
-			assertEquals(1, photoTagMstCapture.getAccountNo());
+			assertEquals(1L, photoTagMstCapture.getAccountNo());
 		}
 		
 		@Test
@@ -159,14 +159,14 @@ public class PhotoDetailRepositoryImplTest {
 		@DisplayName("正常系：写真が1件以上、写真タグが1件以上の場合")
 		void getPhotoList_photoTag_found() {
 			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(1)
+					.accountNo(1L)
+					.photoAccountNo(1L)
 					.build();
 			
 			List<PhotoDto> photoDtoList = new ArrayList<PhotoDto>();
 			PhotoDto photoDto1 = new PhotoDto();
-			photoDto1.setAccountNo(1);
-			photoDto1.setPhotoNo(1);
+			photoDto1.setAccountNo(1L);
+			photoDto1.setPhotoNo(1L);
 			photoDto1.setFavoriteCount(1);
 			photoDto1.setIsFavorite(false);
 			photoDto1.setPhotoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)));
@@ -176,8 +176,8 @@ public class PhotoDetailRepositoryImplTest {
 			photoDtoList.add(photoDto1);
 			
 			PhotoDto photoDto2 = new PhotoDto();
-			photoDto2.setAccountNo(1);
-			photoDto2.setPhotoNo(2);
+			photoDto2.setAccountNo(1L);
+			photoDto2.setPhotoNo(2L);
 			photoDto2.setFavoriteCount(2);
 			photoDto2.setIsFavorite(true);
 			photoDto2.setPhotoAt(OffsetDateTime.of(2000, 2, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)));
@@ -191,16 +191,16 @@ public class PhotoDetailRepositoryImplTest {
 			
 			List<PhotoTagMst> photoTagMstList = new ArrayList<PhotoTagMst>();
 			photoTagMstList.add(PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build());
 			photoTagMstList.add(PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(2)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(2L)
+					.tagNo(1L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build());
@@ -210,8 +210,8 @@ public class PhotoDetailRepositoryImplTest {
 			
 			List<PhotoModel> actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
 			
-			assertEquals(1, actual.get(0).getAccountNo());
-			assertEquals(1, actual.get(0).getPhotoNo());
+			assertEquals(1L, actual.get(0).getAccountNo());
+			assertEquals(1L, actual.get(0).getPhotoNo());
 			assertEquals(1, actual.get(0).getFavoriteCount());
 			assertFalse(actual.get(0).getIsFavorite());
 			assertEquals(OffsetDateTime.of(2000, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt());
@@ -219,12 +219,12 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals("キャプション1", actual.get(0).getCaption());
 			assertEquals(DirectionEnum.VERTICAL, actual.get(0).getDirectionKbn());
 			assertEquals(1, actual.get(0).getPhotoTagModelList().size());
-			assertEquals(1, actual.get(0).getPhotoTagModelList().get(0).getTagNo());
+			assertEquals(1L, actual.get(0).getPhotoTagModelList().get(0).getTagNo());
 			assertEquals("太陽", actual.get(0).getPhotoTagModelList().get(0).getTagJapaneseName());
 			assertEquals("sun", actual.get(0).getPhotoTagModelList().get(0).getTagEnglishName());
 			
-			assertEquals(1, actual.get(1).getAccountNo());
-			assertEquals(2, actual.get(1).getPhotoNo());
+			assertEquals(1L, actual.get(1).getAccountNo());
+			assertEquals(2L, actual.get(1).getPhotoNo());
 			assertEquals(2, actual.get(1).getFavoriteCount());
 			assertTrue(actual.get(1).getIsFavorite());
 			assertEquals(OffsetDateTime.of(2000, 2, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(1).getPhotoAt());
@@ -232,16 +232,16 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals("キャプション2", actual.get(1).getCaption());
 			assertEquals(DirectionEnum.HORIZONTAL, actual.get(1).getDirectionKbn());
 			assertEquals(1, actual.get(1).getPhotoTagModelList().size());
-			assertEquals(1, actual.get(1).getPhotoTagModelList().get(0).getTagNo());
+			assertEquals(1L, actual.get(1).getPhotoTagModelList().get(0).getTagNo());
 			assertEquals("海", actual.get(1).getPhotoTagModelList().get(0).getTagJapaneseName());
 			assertEquals("sea", actual.get(1).getPhotoTagModelList().get(0).getTagEnglishName());
 			
 			PhotoListGetDto photoListGetDtoCapture = photoListGetDtoCaptor.getValue();
-			assertEquals(1, photoListGetDtoCapture.getAccountNo());
-			assertEquals(1, photoListGetDtoCapture.getPhotoAccountNo());
+			assertEquals(1L, photoListGetDtoCapture.getAccountNo());
+			assertEquals(1L, photoListGetDtoCapture.getPhotoAccountNo());
 			
 			PhotoTagMst photoTagMstCapture = photoTagMstCaptor.getValue();
-			assertEquals(1, photoTagMstCapture.getAccountNo());
+			assertEquals(1L, photoTagMstCapture.getAccountNo());
 		}
 	}
 	
@@ -254,14 +254,14 @@ public class PhotoDetailRepositoryImplTest {
 		@DisplayName("正常系：写真のメタデータがデフォルト値、写真タグが0件の場合")
 		void getPhotoDetail_photoTag_default_value_not_found() throws PhotoNotFoundException {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoAccountNo(1L)
+					.photoNo(1L)
 					.build();
 			
 			PhotoDetailDto photoDetailDto = new PhotoDetailDto();
-			photoDetailDto.setAccountNo(1);
-			photoDetailDto.setPhotoNo(1);
+			photoDetailDto.setAccountNo(1L);
+			photoDetailDto.setPhotoNo(1L);
 			photoDetailDto.setIsFavorite(false);
 			photoDetailDto.setPhotoAt(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9)));
 			photoDetailDto.setLocationNo(null);
@@ -289,8 +289,8 @@ public class PhotoDetailRepositoryImplTest {
 			
 			PhotoDetailModel actual = photoDetailRepositoryImpl.getPhotoDetail(photoDetailGetModel);
 			
-			assertEquals(1, actual.getAccountNo());
-			assertEquals(1, actual.getPhotoNo());
+			assertEquals(1L, actual.getAccountNo());
+			assertEquals(1L, actual.getPhotoNo());
 			assertFalse(actual.getIsFavorite());
 			assertNull(actual.getPhotoAt());
 			assertNull(actual.getLocationNo());
@@ -310,13 +310,13 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals(0, actual.getPhotoTagModelList().size());
 			
 			PhotoDetailGetDto photoDetailGetDtoCapture = photoDetailGetDtoCaptor.getValue();
-			assertEquals(1, photoDetailGetDtoCapture.getAccountNo());
-			assertEquals(1, photoDetailGetDtoCapture.getPhotoAccountNo());
-			assertEquals(1, photoDetailGetDtoCapture.getPhotoNo());
+			assertEquals(1L, photoDetailGetDtoCapture.getAccountNo());
+			assertEquals(1L, photoDetailGetDtoCapture.getPhotoAccountNo());
+			assertEquals(1L, photoDetailGetDtoCapture.getPhotoNo());
 			
 			PhotoTagMst photoTagMstCapture = photoTagMstCaptor.getValue();
-			assertEquals(1, photoTagMstCapture.getAccountNo());
-			assertEquals(1, photoTagMstCapture.getPhotoNo());
+			assertEquals(1L, photoTagMstCapture.getAccountNo());
+			assertEquals(1L, photoTagMstCapture.getPhotoNo());
 			assertNull(photoTagMstCapture.getTagNo());
 			assertNull(photoTagMstCapture.getTagJapaneseName());
 			assertNull(photoTagMstCapture.getTagEnglishName());
@@ -327,17 +327,17 @@ public class PhotoDetailRepositoryImplTest {
 		@DisplayName("正常系：写真のメタデータがデフォルト値でない場、写真タグが1件以上の場合")
 		void getPhotoDetail_not_default_value_photoTag_found() throws PhotoNotFoundException {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoAccountNo(1L)
+					.photoNo(1L)
 					.build();
 			
 			PhotoDetailDto photoDetailDto = new PhotoDetailDto();
-			photoDetailDto.setAccountNo(1);
-			photoDetailDto.setPhotoNo(1);
+			photoDetailDto.setAccountNo(1L);
+			photoDetailDto.setPhotoNo(1L);
 			photoDetailDto.setIsFavorite(false);
 			photoDetailDto.setPhotoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)));
-			photoDetailDto.setLocationNo(1);
+			photoDetailDto.setLocationNo(1L);
 			photoDetailDto.setAddress("住所");
 			photoDetailDto.setLatitude(BigDecimal.valueOf(38.000));
 			photoDetailDto.setLongitude(BigDecimal.valueOf(115.000));
@@ -357,16 +357,16 @@ public class PhotoDetailRepositoryImplTest {
 			
 			List<PhotoTagMst> photoTagMstList = new ArrayList<PhotoTagMst>();
 			photoTagMstList.add(PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build());
 			photoTagMstList.add(PhotoTagMst.builder()
-					.accountNo(1)
-					.photoNo(2)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(2L)
+					.tagNo(1L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build());
@@ -376,11 +376,11 @@ public class PhotoDetailRepositoryImplTest {
 			
 			PhotoDetailModel actual = photoDetailRepositoryImpl.getPhotoDetail(photoDetailGetModel);
 			
-			assertEquals(1, actual.getAccountNo());
-			assertEquals(1, actual.getPhotoNo());
+			assertEquals(1L, actual.getAccountNo());
+			assertEquals(1L, actual.getPhotoNo());
 			assertFalse(actual.getIsFavorite());
 			assertEquals(OffsetDateTime.of(2000, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getPhotoAt());
-			assertEquals(1, actual.getLocationNo());
+			assertEquals(1L, actual.getLocationNo());
 			assertEquals("住所", actual.getAddress());
 			assertEquals(0, BigDecimal.valueOf(38.000).compareTo(actual.getLatitude()));
 			assertEquals(0, BigDecimal.valueOf(115.000).compareTo(actual.getLongitude()));
@@ -391,20 +391,20 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals("キャプション", actual.getCaption());
 			assertEquals(DirectionEnum.VERTICAL, actual.getDirectionKbn());
 			assertEquals(2, actual.getPhotoTagModelList().size());
-			assertEquals(1, actual.getPhotoTagModelList().get(0).getTagNo());
+			assertEquals(1L, actual.getPhotoTagModelList().get(0).getTagNo());
 			assertEquals("太陽", actual.getPhotoTagModelList().get(0).getTagJapaneseName());
 			assertEquals("sun", actual.getPhotoTagModelList().get(0).getTagEnglishName());
 			assertEquals("海", actual.getPhotoTagModelList().get(1).getTagJapaneseName());
 			assertEquals("sea", actual.getPhotoTagModelList().get(1).getTagEnglishName());
 			
 			PhotoDetailGetDto photoDetailGetDtoCapture = photoDetailGetDtoCaptor.getValue();
-			assertEquals(1, photoDetailGetDtoCapture.getAccountNo());
-			assertEquals(1, photoDetailGetDtoCapture.getPhotoAccountNo());
-			assertEquals(1, photoDetailGetDtoCapture.getPhotoNo());
+			assertEquals(1L, photoDetailGetDtoCapture.getAccountNo());
+			assertEquals(1L, photoDetailGetDtoCapture.getPhotoAccountNo());
+			assertEquals(1L, photoDetailGetDtoCapture.getPhotoNo());
 			
 			PhotoTagMst photoTagMstCapture = photoTagMstCaptor.getValue();
-			assertEquals(1, photoTagMstCapture.getAccountNo());
-			assertEquals(1, photoTagMstCapture.getPhotoNo());
+			assertEquals(1L, photoTagMstCapture.getAccountNo());
+			assertEquals(1L, photoTagMstCapture.getPhotoNo());
 			assertNull(photoTagMstCapture.getTagNo());
 			assertNull(photoTagMstCapture.getTagJapaneseName());
 			assertNull(photoTagMstCapture.getTagEnglishName());
@@ -415,9 +415,9 @@ public class PhotoDetailRepositoryImplTest {
 		@DisplayName("異常系：PhotoNotFoundExceptionをthrowする")
 		void getPhotoDetail_PhotoNotFoundException() {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoAccountNo(1L)
+					.photoNo(1L)
 					.build();
 			
 			ArgumentCaptor<PhotoDetailGetDto> photoDetailGetDtoCaptor = ArgumentCaptor.forClass(PhotoDetailGetDto.class);

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoFavoriteRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoFavoriteRepositoryImplTest.java
@@ -43,9 +43,9 @@ public class PhotoFavoriteRepositoryImplTest {
 		@DisplayName("正常系")
 		void regist_contain_null_parameter() throws RegistFailureException {
 			PhotoFavoriteModel favoriteModel = PhotoFavoriteModel.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			
 			ArgumentCaptor<PhotoFavorite> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavorite.class);
@@ -55,10 +55,10 @@ public class PhotoFavoriteRepositoryImplTest {
 			
 			verify(photoFavoriteMapper).insert(any(PhotoFavorite.class));
 			PhotoFavorite photoFavorite = photoFavoriteCaptor.getValue();
-			assertEquals(1, photoFavorite.getAccountNo());
-			assertEquals(1, photoFavorite.getFavoritePhotoAccountNo());
-			assertEquals(1, photoFavorite.getFavoritePhotoNo());
-			assertEquals(1, photoFavorite.getCreatedBy());
+			assertEquals(1L, photoFavorite.getAccountNo());
+			assertEquals(1L, photoFavorite.getFavoritePhotoAccountNo());
+			assertEquals(1L, photoFavorite.getFavoritePhotoNo());
+			assertEquals(1L, photoFavorite.getCreatedBy());
 			assertNull(photoFavorite.getCreatedAt());
 		}
 		
@@ -67,9 +67,9 @@ public class PhotoFavoriteRepositoryImplTest {
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
 		void regist_RegistFailureException() {
 			PhotoFavoriteModel favoriteModel = PhotoFavoriteModel.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			
 			ArgumentCaptor<PhotoFavorite> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavorite.class);
@@ -79,10 +79,10 @@ public class PhotoFavoriteRepositoryImplTest {
 			
 			verify(photoFavoriteMapper).insert(any(PhotoFavorite.class));
 			PhotoFavorite photoFavorite = photoFavoriteCaptor.getValue();
-			assertEquals(1, photoFavorite.getAccountNo());
-			assertEquals(1, photoFavorite.getFavoritePhotoAccountNo());
-			assertEquals(1, photoFavorite.getFavoritePhotoNo());
-			assertEquals(1, photoFavorite.getCreatedBy());
+			assertEquals(1L, photoFavorite.getAccountNo());
+			assertEquals(1L, photoFavorite.getFavoritePhotoAccountNo());
+			assertEquals(1L, photoFavorite.getFavoritePhotoNo());
+			assertEquals(1L, photoFavorite.getCreatedBy());
 			assertNull(photoFavorite.getCreatedAt());
 		}
 	}
@@ -96,9 +96,9 @@ public class PhotoFavoriteRepositoryImplTest {
 		@DisplayName("正常系")
 		void delete_contain_null_parameter() throws UpdateFailureException {
 			PhotoFavoriteDeleteModel favoriteDeleteModel = PhotoFavoriteDeleteModel.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			
 			ArgumentCaptor<PhotoFavorite> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavorite.class);
@@ -108,9 +108,9 @@ public class PhotoFavoriteRepositoryImplTest {
 			
 			verify(photoFavoriteMapper).delete(any(PhotoFavorite.class));
 			PhotoFavorite photoFavorite = photoFavoriteCaptor.getValue();
-			assertEquals(1, photoFavorite.getAccountNo());
-			assertEquals(1, photoFavorite.getFavoritePhotoAccountNo());
-			assertEquals(1, photoFavorite.getFavoritePhotoNo());
+			assertEquals(1L, photoFavorite.getAccountNo());
+			assertEquals(1L, photoFavorite.getFavoritePhotoAccountNo());
+			assertEquals(1L, photoFavorite.getFavoritePhotoNo());
 			assertNull(photoFavorite.getCreatedBy());
 			assertNull(photoFavorite.getCreatedAt());
 		}
@@ -120,9 +120,9 @@ public class PhotoFavoriteRepositoryImplTest {
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
 		void delete_UpdateFailureException() throws UpdateFailureException {
 			PhotoFavoriteDeleteModel favoriteDeleteModel = PhotoFavoriteDeleteModel.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			
 			ArgumentCaptor<PhotoFavorite> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavorite.class);
@@ -132,9 +132,9 @@ public class PhotoFavoriteRepositoryImplTest {
 			
 			verify(photoFavoriteMapper).delete(any(PhotoFavorite.class));
 			PhotoFavorite photoFavorite = photoFavoriteCaptor.getValue();
-			assertEquals(1, photoFavorite.getAccountNo());
-			assertEquals(1, photoFavorite.getFavoritePhotoAccountNo());
-			assertEquals(1, photoFavorite.getFavoritePhotoNo());
+			assertEquals(1L, photoFavorite.getAccountNo());
+			assertEquals(1L, photoFavorite.getFavoritePhotoAccountNo());
+			assertEquals(1L, photoFavorite.getFavoritePhotoNo());
 			assertNull(photoFavorite.getCreatedBy());
 			assertNull(photoFavorite.getCreatedAt());
 		}
@@ -149,8 +149,8 @@ public class PhotoFavoriteRepositoryImplTest {
 		@DisplayName("正常系：")
 		void clear_success() {
 			PhotoFavoriteDeleteModel favoriteDeleteModel = PhotoFavoriteDeleteModel.builder()
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			
 			ArgumentCaptor<PhotoFavorite> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavorite.class);
@@ -161,8 +161,8 @@ public class PhotoFavoriteRepositoryImplTest {
 			verify(photoFavoriteMapper).delete(any(PhotoFavorite.class));
 			PhotoFavorite photoFavorite = photoFavoriteCaptor.getValue();
 			assertNull(photoFavorite.getAccountNo());
-			assertEquals(1, photoFavorite.getFavoritePhotoAccountNo());
-			assertEquals(1, photoFavorite.getFavoritePhotoNo());
+			assertEquals(1L, photoFavorite.getFavoritePhotoAccountNo());
+			assertEquals(1L, photoFavorite.getFavoritePhotoNo());
 			assertNull(photoFavorite.getCreatedBy());
 			assertNull(photoFavorite.getCreatedAt());
 		}

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoMstRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoMstRepositoryImplTest.java
@@ -52,27 +52,27 @@ public class PhotoMstRepositoryImplTest {
 			String imageFilePath = "https://localhost:8080/image/aaaaaaaa/DSC111.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.imageFilePath(imageFilePath)
 					.build();
 			
 			ArgumentCaptor<PhotoMst> photoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
 			doReturn(1).when(photoMstMapper).insert(photoMstCaptor.capture());
 			
-			photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 1);
+			photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 1L);
 			
 			verify(photoMstMapper).insert(any(PhotoMst.class));
 			PhotoMst photoMst = photoMstCaptor.getValue();
-			assertEquals(1, photoMst.getAccountNo());
-			assertEquals(1, photoMst.getPhotoNo());
-			assertEquals(1, photoMst.getCreatedBy());
+			assertEquals(1L, photoMst.getAccountNo());
+			assertEquals(1L, photoMst.getPhotoNo());
+			assertEquals(1L, photoMst.getCreatedBy());
 			assertNull(photoMst.getCreatedAt());
-			assertEquals(1, photoMst.getUpdatedBy());
+			assertEquals(1L, photoMst.getUpdatedBy());
 			assertNull(photoMst.getUpdatedAt());
 			assertNull(photoMst.getIsDeleted());
 			assertEquals(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9)), photoMst.getPhotoAt());
-			assertEquals(0, photoMst.getLocationNo());
+			assertEquals(0L, photoMst.getLocationNo());
 			assertEquals(imageFilePath, photoMst.getImageFilePath());
 			assertEquals("", photoMst.getPhotoJapaneseTitle());
 			assertEquals("", photoMst.getPhotoEnglishTitle());
@@ -91,10 +91,10 @@ public class PhotoMstRepositoryImplTest {
 			String imageFilePath = "https://localhost:8080/image/aaaaaaaa/DSC111.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.photoAt(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.locationNo(1)
+					.locationNo(1L)
 					.imageFilePath("https://localhost:8080/image/aaaaaaaa/DSC111.jpg")
 					.photoJapaneseTitle("タイトル1")
 					.photoEnglishTitle("title1")
@@ -109,19 +109,19 @@ public class PhotoMstRepositoryImplTest {
 			ArgumentCaptor<PhotoMst> photoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
 			doReturn(1).when(photoMstMapper).insert(photoMstCaptor.capture());
 			
-			photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 1);
+			photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 1L);
 			
 			verify(photoMstMapper).insert(any(PhotoMst.class));
 			PhotoMst photoMst = photoMstCaptor.getValue();
-			assertEquals(1, photoMst.getAccountNo());
-			assertEquals(1, photoMst.getPhotoNo());
-			assertEquals(1, photoMst.getCreatedBy());
+			assertEquals(1L, photoMst.getAccountNo());
+			assertEquals(1L, photoMst.getPhotoNo());
+			assertEquals(1L, photoMst.getCreatedBy());
 			assertNull(photoMst.getCreatedAt());
-			assertEquals(1, photoMst.getUpdatedBy());
+			assertEquals(1L, photoMst.getUpdatedBy());
 			assertNull(photoMst.getUpdatedAt());
 			assertNull(photoMst.getIsDeleted());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), photoMst.getPhotoAt());
-			assertEquals(1, photoMst.getLocationNo());
+			assertEquals(1L, photoMst.getLocationNo());
 			assertEquals(imageFilePath, photoMst.getImageFilePath());
 			assertEquals("タイトル1", photoMst.getPhotoJapaneseTitle());
 			assertEquals("title1", photoMst.getPhotoEnglishTitle());
@@ -140,27 +140,27 @@ public class PhotoMstRepositoryImplTest {
 			String imageFilePath = "https://localhost:8080/image/aaaaaaaa/DSC111.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.imageFilePath(imageFilePath)
 					.build();
 			
 			ArgumentCaptor<PhotoMst> photoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
 			doThrow(DuplicateKeyException.class).when(photoMstMapper).insert(photoMstCaptor.capture());
 			
-			assertThrows(RegistFailureException.class, () -> photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 1));
+			assertThrows(RegistFailureException.class, () -> photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 1L));
 			
 			verify(photoMstMapper).insert(any(PhotoMst.class));
 			PhotoMst photoMst = photoMstCaptor.getValue();
-			assertEquals(1, photoMst.getAccountNo());
-			assertEquals(1, photoMst.getPhotoNo());
-			assertEquals(1, photoMst.getCreatedBy());
+			assertEquals(1L, photoMst.getAccountNo());
+			assertEquals(1L, photoMst.getPhotoNo());
+			assertEquals(1L, photoMst.getCreatedBy());
 			assertNull(photoMst.getCreatedAt());
-			assertEquals(1, photoMst.getUpdatedBy());
+			assertEquals(1L, photoMst.getUpdatedBy());
 			assertNull(photoMst.getUpdatedAt());
 			assertNull(photoMst.getIsDeleted());
 			assertEquals(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9)), photoMst.getPhotoAt());
-			assertEquals(0, photoMst.getLocationNo());
+			assertEquals(0L, photoMst.getLocationNo());
 			assertEquals(imageFilePath, photoMst.getImageFilePath());
 			assertEquals("", photoMst.getPhotoJapaneseTitle());
 			assertEquals("", photoMst.getPhotoEnglishTitle());
@@ -184,8 +184,8 @@ public class PhotoMstRepositoryImplTest {
 			String imageFilePath = "https://localhost:8080/image/aaaaaaaa/DSC111.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.imageFilePath(imageFilePath)
 					.build();
 			
@@ -198,8 +198,8 @@ public class PhotoMstRepositoryImplTest {
 			
 			verify(photoMstMapper).update(any(PhotoMst.class), any(PhotoMst.class));
 			PhotoMst cndPhotoMst = cndPhotoMstCaptor.getValue();
-			assertEquals(1, cndPhotoMst.getAccountNo());
-			assertEquals(1, cndPhotoMst.getPhotoNo());
+			assertEquals(1L, cndPhotoMst.getAccountNo());
+			assertEquals(1L, cndPhotoMst.getPhotoNo());
 			assertNull(cndPhotoMst.getCreatedBy());
 			assertNull(cndPhotoMst.getCreatedAt());
 			assertNull(cndPhotoMst.getUpdatedBy());
@@ -222,11 +222,11 @@ public class PhotoMstRepositoryImplTest {
 			assertNull(targetPhotoMst.getPhotoNo());
 			assertNull(targetPhotoMst.getCreatedBy());
 			assertNull(targetPhotoMst.getCreatedAt());
-			assertEquals(1, targetPhotoMst.getUpdatedBy());
+			assertEquals(1L, targetPhotoMst.getUpdatedBy());
 			assertNull(targetPhotoMst.getUpdatedAt());
 			assertFalse(targetPhotoMst.getIsDeleted());
 			assertEquals(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9)), targetPhotoMst.getPhotoAt());
-			assertEquals(0, targetPhotoMst.getLocationNo());
+			assertEquals(0L, targetPhotoMst.getLocationNo());
 			assertEquals(imageFilePath, targetPhotoMst.getImageFilePath());
 			assertEquals("", targetPhotoMst.getPhotoJapaneseTitle());
 			assertEquals("", targetPhotoMst.getPhotoEnglishTitle());
@@ -245,10 +245,10 @@ public class PhotoMstRepositoryImplTest {
 			String imageFilePath = "https://localhost:8080/image/aaaaaaaa/DSC111.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.photoAt(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.locationNo(1)
+					.locationNo(1L)
 					.imageFilePath("https://localhost:8080/image/aaaaaaaa/DSC111.jpg")
 					.photoJapaneseTitle("タイトル1")
 					.photoEnglishTitle("title1")
@@ -269,8 +269,8 @@ public class PhotoMstRepositoryImplTest {
 			
 			verify(photoMstMapper).update(any(PhotoMst.class), any(PhotoMst.class));
 			PhotoMst cndPhotoMst = cndPhotoMstCaptor.getValue();
-			assertEquals(1, cndPhotoMst.getAccountNo());
-			assertEquals(1, cndPhotoMst.getPhotoNo());
+			assertEquals(1L, cndPhotoMst.getAccountNo());
+			assertEquals(1L, cndPhotoMst.getPhotoNo());
 			assertNull(cndPhotoMst.getCreatedBy());
 			assertNull(cndPhotoMst.getCreatedAt());
 			assertNull(cndPhotoMst.getUpdatedBy());
@@ -293,11 +293,11 @@ public class PhotoMstRepositoryImplTest {
 			assertNull(targetPhotoMst.getPhotoNo());
 			assertNull(targetPhotoMst.getCreatedBy());
 			assertNull(targetPhotoMst.getCreatedAt());
-			assertEquals(1, targetPhotoMst.getUpdatedBy());
+			assertEquals(1L, targetPhotoMst.getUpdatedBy());
 			assertNull(targetPhotoMst.getUpdatedAt());
 			assertFalse(targetPhotoMst.getIsDeleted());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), targetPhotoMst.getPhotoAt());
-			assertEquals(1, targetPhotoMst.getLocationNo());
+			assertEquals(1L, targetPhotoMst.getLocationNo());
 			assertEquals(imageFilePath, targetPhotoMst.getImageFilePath());
 			assertEquals("タイトル1", targetPhotoMst.getPhotoJapaneseTitle());
 			assertEquals("title1", targetPhotoMst.getPhotoEnglishTitle());
@@ -316,8 +316,8 @@ public class PhotoMstRepositoryImplTest {
 			String imageFilePath = "https://localhost:8080/image/aaaaaaaa/DSC111.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.imageFilePath(imageFilePath)
 					.build();
 			
@@ -330,8 +330,8 @@ public class PhotoMstRepositoryImplTest {
 			
 			verify(photoMstMapper).update(any(PhotoMst.class), any(PhotoMst.class));
 			PhotoMst cndPhotoMst = cndPhotoMstCaptor.getValue();
-			assertEquals(1, cndPhotoMst.getAccountNo());
-			assertEquals(1, cndPhotoMst.getPhotoNo());
+			assertEquals(1L, cndPhotoMst.getAccountNo());
+			assertEquals(1L, cndPhotoMst.getPhotoNo());
 			assertNull(cndPhotoMst.getCreatedBy());
 			assertNull(cndPhotoMst.getCreatedAt());
 			assertNull(cndPhotoMst.getUpdatedBy());
@@ -354,11 +354,11 @@ public class PhotoMstRepositoryImplTest {
 			assertNull(targetPhotoMst.getPhotoNo());
 			assertNull(targetPhotoMst.getCreatedBy());
 			assertNull(targetPhotoMst.getCreatedAt());
-			assertEquals(1, targetPhotoMst.getUpdatedBy());
+			assertEquals(1L, targetPhotoMst.getUpdatedBy());
 			assertNull(targetPhotoMst.getUpdatedAt());
 			assertFalse(targetPhotoMst.getIsDeleted());
 			assertEquals(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9)), targetPhotoMst.getPhotoAt());
-			assertEquals(0, targetPhotoMst.getLocationNo());
+			assertEquals(0L, targetPhotoMst.getLocationNo());
 			assertEquals(imageFilePath, targetPhotoMst.getImageFilePath());
 			assertEquals("", targetPhotoMst.getPhotoJapaneseTitle());
 			assertEquals("", targetPhotoMst.getPhotoEnglishTitle());
@@ -382,8 +382,8 @@ public class PhotoMstRepositoryImplTest {
 			String imageFilePath = "https://localhost:8080/image/aaaaaaaa/DSC111.jpg";
 			
 			PhotoDeleteModel photoDeleteModel = PhotoDeleteModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.imageFilePath(imageFilePath)
 					.build();
 			
@@ -396,8 +396,8 @@ public class PhotoMstRepositoryImplTest {
 			
 			verify(photoMstMapper).update(any(PhotoMst.class), any(PhotoMst.class));
 			PhotoMst cndPhotoMst = cndPhotoMstCaptor.getValue();
-			assertEquals(1, cndPhotoMst.getAccountNo());
-			assertEquals(1, cndPhotoMst.getPhotoNo());
+			assertEquals(1L, cndPhotoMst.getAccountNo());
+			assertEquals(1L, cndPhotoMst.getPhotoNo());
 			assertNull(cndPhotoMst.getCreatedBy());
 			assertNull(cndPhotoMst.getCreatedAt());
 			assertNull(cndPhotoMst.getUpdatedBy());
@@ -420,7 +420,7 @@ public class PhotoMstRepositoryImplTest {
 			assertNull(targetPhotoMst.getPhotoNo());
 			assertNull(targetPhotoMst.getCreatedBy());
 			assertNull(targetPhotoMst.getCreatedAt());
-			assertEquals(1, targetPhotoMst.getUpdatedBy());
+			assertEquals(1L, targetPhotoMst.getUpdatedBy());
 			assertNull(targetPhotoMst.getUpdatedAt());
 			assertTrue(targetPhotoMst.getIsDeleted());
 			assertNull(targetPhotoMst.getPhotoAt());
@@ -443,8 +443,8 @@ public class PhotoMstRepositoryImplTest {
 			String imageFilePath = "https://localhost:8080/image/aaaaaaaa/DSC111.jpg";
 			
 			PhotoDeleteModel photoDeleteModel = PhotoDeleteModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.imageFilePath(imageFilePath)
 					.build();
 			
@@ -457,8 +457,8 @@ public class PhotoMstRepositoryImplTest {
 			
 			verify(photoMstMapper).update(any(PhotoMst.class), any(PhotoMst.class));
 			PhotoMst cndPhotoMst = cndPhotoMstCaptor.getValue();
-			assertEquals(1, cndPhotoMst.getAccountNo());
-			assertEquals(1, cndPhotoMst.getPhotoNo());
+			assertEquals(1L, cndPhotoMst.getAccountNo());
+			assertEquals(1L, cndPhotoMst.getPhotoNo());
 			assertNull(cndPhotoMst.getCreatedBy());
 			assertNull(cndPhotoMst.getCreatedAt());
 			assertNull(cndPhotoMst.getUpdatedBy());
@@ -481,7 +481,7 @@ public class PhotoMstRepositoryImplTest {
 			assertNull(targetPhotoMst.getPhotoNo());
 			assertNull(targetPhotoMst.getCreatedBy());
 			assertNull(targetPhotoMst.getCreatedAt());
-			assertEquals(1, targetPhotoMst.getUpdatedBy());
+			assertEquals(1L, targetPhotoMst.getUpdatedBy());
 			assertNull(targetPhotoMst.getUpdatedAt());
 			assertTrue(targetPhotoMst.getIsDeleted());
 			assertNull(targetPhotoMst.getPhotoAt());
@@ -506,16 +506,16 @@ public class PhotoMstRepositoryImplTest {
 		@Order(1)
 		@DisplayName("正常系：getMaxPhotoNoがある場合")
 		void getNewPhotoNo_getMaxPhotoNo_found() {
-			doReturn(1).when(photoMstMapper).getMaxPhotoNo(1);
-			assertEquals(2, photoMstRepositoryImpl.getNewPhotoNo(1));
+			doReturn(1L).when(photoMstMapper).getMaxPhotoNo(1L);
+			assertEquals(2L, photoMstRepositoryImpl.getNewPhotoNo(1L));
 		}
 		
 		@Test
 		@Order(2)
 		@DisplayName("正常系：getMaxPhotoNoがない場合")
 		void getNewPhotoNo_getMaxPhotoNo_not_found() {
-			doReturn(null).when(photoMstMapper).getMaxPhotoNo(1);
-			assertEquals(1, photoMstRepositoryImpl.getNewPhotoNo(1));
+			doReturn(null).when(photoMstMapper).getMaxPhotoNo(1L);
+			assertEquals(1L, photoMstRepositoryImpl.getNewPhotoNo(1L));
 		}
 	}
 	
@@ -535,7 +535,7 @@ public class PhotoMstRepositoryImplTest {
 			);
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.imageFile(multipartFile)
 					.imageFilePath("")
 					.build();
@@ -545,7 +545,7 @@ public class PhotoMstRepositoryImplTest {
 			assertFalse(photoMstRepositoryImpl.isExistPhoto(photoDetailModel));
 			
 			PhotoMst photoMst = photoMstCaptor.getValue();
-			assertEquals(1, photoMst.getAccountNo());
+			assertEquals(1L, photoMst.getAccountNo());
 			assertEquals("DSC111.jpg", photoMst.getImageFilePath());
 		}
 		
@@ -561,7 +561,7 @@ public class PhotoMstRepositoryImplTest {
 			);
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.imageFile(multipartFile)
 					.imageFilePath("")
 					.build();
@@ -571,7 +571,7 @@ public class PhotoMstRepositoryImplTest {
 			assertTrue(photoMstRepositoryImpl.isExistPhoto(photoDetailModel));
 			
 			PhotoMst photoMst = photoMstCaptor.getValue();
-			assertEquals(1, photoMst.getAccountNo());
+			assertEquals(1L, photoMst.getAccountNo());
 		}
 	}
 	
@@ -586,10 +586,10 @@ public class PhotoMstRepositoryImplTest {
 			ArgumentCaptor<PhotoMst> photoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
 			doReturn(3).when(photoMstMapper).count(photoMstCaptor.capture());
 			
-			assertEquals(3, photoMstRepositoryImpl.count(1));
+			assertEquals(3, photoMstRepositoryImpl.count(1L));
 			
 			PhotoMst photoMst = photoMstCaptor.getValue();
-			assertEquals(1, photoMst.getAccountNo());
+			assertEquals(1L, photoMst.getAccountNo());
 			assertNull(photoMst.getPhotoNo());
 			assertNull(photoMst.getCreatedBy());
 			assertNull(photoMst.getCreatedAt());

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoTagMstRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoTagMstRepositoryImplTest.java
@@ -42,9 +42,9 @@ public class PhotoTagMstRepositoryImplTest {
 		@DisplayName("正常系")
 		void regist_contain_null_parameter() throws RegistFailureException {
 			PhotoTagModel photoTagModel = PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build();
@@ -56,10 +56,10 @@ public class PhotoTagMstRepositoryImplTest {
 			
 			verify(photoTagMstMapper).insert(any(PhotoTagMst.class));
 			PhotoTagMst photoTagMst = photoTagMstCaptor.getValue();
-			assertEquals(1, photoTagMst.getAccountNo());
-			assertEquals(1, photoTagMst.getPhotoNo());
-			assertEquals(1, photoTagMst.getTagNo());
-			assertEquals(1, photoTagMst.getCreatedBy());
+			assertEquals(1L, photoTagMst.getAccountNo());
+			assertEquals(1L, photoTagMst.getPhotoNo());
+			assertEquals(1L, photoTagMst.getTagNo());
+			assertEquals(1L, photoTagMst.getCreatedBy());
 			assertNull(photoTagMst.getCreatedAt());
 			assertEquals("太陽", photoTagMst.getTagJapaneseName());
 			assertEquals("sun", photoTagMst.getTagEnglishName());
@@ -70,9 +70,9 @@ public class PhotoTagMstRepositoryImplTest {
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
 		void regist_RegistFailureException() {
 			PhotoTagModel photoTagModel = PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build();
@@ -84,10 +84,10 @@ public class PhotoTagMstRepositoryImplTest {
 			
 			verify(photoTagMstMapper).insert(any(PhotoTagMst.class));
 			PhotoTagMst photoTagMst = photoTagMstCaptor.getValue();
-			assertEquals(1, photoTagMst.getAccountNo());
-			assertEquals(1, photoTagMst.getPhotoNo());
-			assertEquals(1, photoTagMst.getTagNo());
-			assertEquals(1, photoTagMst.getCreatedBy());
+			assertEquals(1L, photoTagMst.getAccountNo());
+			assertEquals(1L, photoTagMst.getPhotoNo());
+			assertEquals(1L, photoTagMst.getTagNo());
+			assertEquals(1L, photoTagMst.getCreatedBy());
 			assertNull(photoTagMst.getCreatedAt());
 			assertEquals("太陽", photoTagMst.getTagJapaneseName());
 			assertEquals("sun", photoTagMst.getTagEnglishName());
@@ -103,8 +103,8 @@ public class PhotoTagMstRepositoryImplTest {
 		@DisplayName("正常系：")
 		void clear_success() {
 			PhotoTagDeleteModel photoTagDeleteModel = PhotoTagDeleteModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.build();
 			
 			ArgumentCaptor<PhotoTagMst> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMst.class);
@@ -114,8 +114,8 @@ public class PhotoTagMstRepositoryImplTest {
 			
 			verify(photoTagMstMapper).delete(any(PhotoTagMst.class));
 			PhotoTagMst photoTagMst = photoTagMstCaptor.getValue();
-			assertEquals(1, photoTagMst.getAccountNo());
-			assertEquals(1, photoTagMst.getPhotoNo());
+			assertEquals(1L, photoTagMst.getAccountNo());
+			assertEquals(1L, photoTagMst.getPhotoNo());
 			assertNull(photoTagMst.getTagNo());
 			assertNull(photoTagMst.getCreatedBy());
 			assertNull(photoTagMst.getCreatedAt());

--- a/backend/src/test/java/com/web/gallery/repository/impl/RefreshTokenRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/RefreshTokenRepositoryImplTest.java
@@ -40,7 +40,7 @@ public class RefreshTokenRepositoryImplTest {
 		@DisplayName("正常系：リフレッシュトークンを保存する")
 		void save_success() {
 			RefreshTokenModel refreshTokenModel = RefreshTokenModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.tokenHash("abc123hash")
 					.expiresAt(OffsetDateTime.now().plusDays(7))
 					.build();
@@ -63,8 +63,8 @@ public class RefreshTokenRepositoryImplTest {
 		void findByTokenHash_success() {
 			OffsetDateTime expiresAt = OffsetDateTime.now().plusDays(7);
 			RefreshToken mapperResult = RefreshToken.builder()
-					.tokenId(1)
-					.accountNo(1)
+					.tokenId(1L)
+					.accountNo(1L)
 					.tokenHash("abc123hash")
 					.expiresAt(expiresAt)
 					.isRevoked(false)
@@ -75,7 +75,7 @@ public class RefreshTokenRepositoryImplTest {
 			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash("abc123hash");
 
 			assertNotNull(actual);
-			assertEquals(1, actual.getAccountNo());
+			assertEquals(1L, actual.getAccountNo());
 			assertEquals("abc123hash", actual.getTokenHash());
 			assertEquals(expiresAt, actual.getExpiresAt());
 			assertFalse(actual.getIsRevoked());
@@ -103,11 +103,11 @@ public class RefreshTokenRepositoryImplTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号に該当するリフレッシュトークンをすべて無効化する")
 		void revokeAllByAccountNo_success() {
-			doReturn(2).when(refreshTokenMapper).revokeAllByAccountNo(1);
+			doReturn(2).when(refreshTokenMapper).revokeAllByAccountNo(1L);
 
-			refreshTokenRepositoryImpl.revokeAllByAccountNo(1);
+			refreshTokenRepositoryImpl.revokeAllByAccountNo(1L);
 
-			verify(refreshTokenMapper, times(1)).revokeAllByAccountNo(1);
+			verify(refreshTokenMapper, times(1)).revokeAllByAccountNo(1L);
 		}
 	}
 

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/AccountRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/AccountRepositoryImplIntegrationTest.java
@@ -49,9 +49,9 @@ public class AccountRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントが取得できた場合")
 		void getByAccountNo_found() {
-			AccountModel actual = accountRepositoryImpl.getByAccountNo(1);
+			AccountModel actual = accountRepositoryImpl.getByAccountNo(1L);
 
-			assertEquals(1, actual.getAccountNo());
+			assertEquals(1L, actual.getAccountNo());
 			assertFalse(actual.getIsDeleted());
 			assertEquals("aaaaaaaa", actual.getAccountId());
 			assertEquals("AAAAAAAA", actual.getAccountName());
@@ -70,7 +70,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが取得できなかった場合")
 		void getByAccountNo_not_found() {
-			AccountModel actual = accountRepositoryImpl.getByAccountNo(99);
+			AccountModel actual = accountRepositoryImpl.getByAccountNo(99L);
 			assertNull(actual);
 		}
 	}
@@ -87,7 +87,7 @@ public class AccountRepositoryImplIntegrationTest {
 		void getByAccountId_found() {
 			AccountModel actual = accountRepositoryImpl.getByAccountId("aaaaaaaa");
 
-			assertEquals(1, actual.getAccountNo());
+			assertEquals(1L, actual.getAccountNo());
 			assertFalse(actual.getIsDeleted());
 			assertEquals("aaaaaaaa", actual.getAccountId());
 			assertEquals("AAAAAAAA", actual.getAccountName());
@@ -132,10 +132,10 @@ public class AccountRepositoryImplIntegrationTest {
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_id='zzzzzzzz'", (rs, rowNum) ->
 						Account.builder()
-							.accountNo(rs.getInt("account_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.accountId(rs.getString("account_id"))
@@ -152,9 +152,9 @@ public class AccountRepositoryImplIntegrationTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(0, actualData.getFirst().getCreatedBy());
-			assertEquals(0, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(0L, actualData.getFirst().getCreatedBy());
+			assertEquals(0L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("zzzzzzzz", actualData.getFirst().getAccountId());
 			assertEquals("ZZZZZZZZ", actualData.getFirst().getAccountName());
@@ -190,10 +190,10 @@ public class AccountRepositoryImplIntegrationTest {
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_id='zzzzzzzz'", (rs, rowNum) ->
 						Account.builder()
-							.accountNo(rs.getInt("account_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.accountId(rs.getString("account_id"))
@@ -210,9 +210,9 @@ public class AccountRepositoryImplIntegrationTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(0, actualData.getFirst().getCreatedBy());
-			assertEquals(0, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(0L, actualData.getFirst().getCreatedBy());
+			assertEquals(0L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("zzzzzzzz", actualData.getFirst().getAccountId());
 			assertEquals("ZZZZZZZZ", actualData.getFirst().getAccountName());
@@ -253,7 +253,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@DisplayName("正常系：Nullのパラメータを含むAccountModelでの更新")
 		void update_contain_null_parameter() throws UpdateFailureException {
 			AccountModel accountModel = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.accountName("AAAAAAAA")
 					.build();
@@ -263,10 +263,10 @@ public class AccountRepositoryImplIntegrationTest {
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_id='aaaaaaaa'", (rs, rowNum) ->
 						Account.builder()
-							.accountNo(rs.getInt("account_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.accountId(rs.getString("account_id"))
@@ -283,9 +283,9 @@ public class AccountRepositoryImplIntegrationTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("aaaaaaaa", actualData.getFirst().getAccountId());
 			assertEquals("AAAAAAAA", actualData.getFirst().getAccountName());
@@ -305,7 +305,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@DisplayName("正常系：Nullのパラメータを含まないAccountModelでの更新")
 		void update_not_contain_null_parameter() throws UpdateFailureException {
 			AccountModel accountModel = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.accountName("AAAAAAAA")
 					.password("aaaaaaaa")
@@ -323,10 +323,10 @@ public class AccountRepositoryImplIntegrationTest {
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_id='aaaaaaaa'", (rs, rowNum) ->
 						Account.builder()
-							.accountNo(rs.getInt("account_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.accountId(rs.getString("account_id"))
@@ -343,9 +343,9 @@ public class AccountRepositoryImplIntegrationTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("aaaaaaaa", actualData.getFirst().getAccountId());
 			assertEquals("AAAAAAAA", actualData.getFirst().getAccountName());
@@ -365,7 +365,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
 		void update_UpdateFailureException() {
 			AccountModel accountModel = AccountModel.builder()
-					.accountNo(13)
+					.accountNo(13L)
 					.accountId("aaaaaaaa")
 					.accountName("AAAAAAAA")
 					.build();
@@ -385,7 +385,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@DisplayName("正常系：Nullのパラメータを含むAccountModelでの更新")
 		void updateLoginFailureCount_contain_null_parameter() throws UpdateFailureException {
 			AccountModel accountModel = AccountModel.builder()
-					.accountNo(8)
+					.accountNo(8L)
 					.build();
 			
 			accountRepositoryImpl.updateLoginFailureCount(accountModel);
@@ -393,10 +393,10 @@ public class AccountRepositoryImplIntegrationTest {
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_no=8", (rs, rowNum) ->
 						Account.builder()
-							.accountNo(rs.getInt("account_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.accountId(rs.getString("account_id"))
@@ -413,9 +413,9 @@ public class AccountRepositoryImplIntegrationTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(8, actualData.getFirst().getAccountNo());
-			assertEquals(8, actualData.getFirst().getCreatedBy());
-			assertEquals(8, actualData.getFirst().getUpdatedBy());
+			assertEquals(8L, actualData.getFirst().getAccountNo());
+			assertEquals(8L, actualData.getFirst().getCreatedBy());
+			assertEquals(8L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("hhhhhhhh", actualData.getFirst().getAccountId());
 			assertEquals("HHHHHHHH", actualData.getFirst().getAccountName());
@@ -435,7 +435,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@DisplayName("正常系：Nullのパラメータを含まないAccountModelでの更新")
 		void updateLoginFailureCount_not_contain_null_parameter() throws UpdateFailureException {
 			AccountModel accountModel = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.lastLoginDatetime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9)))
 					.loginFailureCount(2)
 					.build();
@@ -445,10 +445,10 @@ public class AccountRepositoryImplIntegrationTest {
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_no=1", (rs, rowNum) ->
 						Account.builder()
-							.accountNo(rs.getInt("account_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.accountId(rs.getString("account_id"))
@@ -465,9 +465,9 @@ public class AccountRepositoryImplIntegrationTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("aaaaaaaa", actualData.getFirst().getAccountId());
 			assertEquals("AAAAAAAA", actualData.getFirst().getAccountName());
@@ -487,7 +487,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
 		void updateLoginFailureCount_UpdateFailureException() {
 			AccountModel accountModel = AccountModel.builder()
-					.accountNo(13)
+					.accountNo(13L)
 					.loginFailureCount(2)
 					.build();
 			
@@ -505,14 +505,14 @@ public class AccountRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントが存在する場合")
 		void isExistAccount_true() {
-			assertTrue(accountRepositoryImpl.isExistAccount(2, "aaaaaaaa"));
+			assertTrue(accountRepositoryImpl.isExistAccount(2L, "aaaaaaaa"));
 		}
 		
 		@Test
 		@Order(2)
 		@DisplayName("正常系：アカウントが存在しない場合")
 		void isExistAccount_false() {
-			assertFalse(accountRepositoryImpl.isExistAccount(1, "zzzzzzzz"));
+			assertFalse(accountRepositoryImpl.isExistAccount(1L, "zzzzzzzz"));
 		}
 	}
 	

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoDetailRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoDetailRepositoryImplIntegrationTest.java
@@ -46,8 +46,8 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 		@DisplayName("正常系：写真が0件の場合")
 		void getPhotoList_photo_not_found() {
 			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(3)
+					.accountNo(1L)
+					.photoAccountNo(3L)
 					.build();
 			List<PhotoModel> actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
 			assertEquals(0, actual.size());
@@ -58,18 +58,18 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 		@DisplayName("正常系：写真が1件以上、写真タグが0件の場合")
 		void getPhotoList_photoTag_not_found() {
 			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(2)
+					.accountNo(1L)
+					.photoAccountNo(2L)
 					.build();
 			
 			List<PhotoModel> actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
 			
 			assertEquals(2, actual.size());
-			assertEquals(2, actual.get(0).getAccountNo());
-			assertEquals(1, actual.get(0).getPhotoNo());
+			assertEquals(2L, actual.get(0).getAccountNo());
+			assertEquals(1L, actual.get(0).getPhotoNo());
 			assertEquals(0, actual.get(0).getPhotoTagModelList().size());
-			assertEquals(2, actual.get(1).getAccountNo());
-			assertEquals(2, actual.get(1).getPhotoNo());
+			assertEquals(2L, actual.get(1).getAccountNo());
+			assertEquals(2L, actual.get(1).getPhotoNo());
 			assertEquals(0, actual.get(1).getPhotoTagModelList().size());
 		}
 		
@@ -78,44 +78,44 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 		@DisplayName("正常系：写真が1件以上、写真タグが1件以上の場合")
 		void getPhotoList_photoTag_found() {
 			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(1)
+					.accountNo(1L)
+					.photoAccountNo(1L)
 					.build();
 			
 			List<PhotoModel> actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
 			
 			assertEquals(2, actual.size());
 			
-			assertEquals(1, actual.get(0).getAccountNo());
-			assertEquals(1, actual.get(0).getPhotoNo());
+			assertEquals(1L, actual.get(0).getAccountNo());
+			assertEquals(1L, actual.get(0).getPhotoNo());
 			assertEquals(2, actual.get(0).getPhotoTagModelList().size());
-			assertEquals(1, actual.get(0).getPhotoTagModelList().get(0).getAccountNo());
-			assertEquals(1, actual.get(0).getPhotoTagModelList().get(0).getPhotoNo());
-			assertEquals(1, actual.get(0).getPhotoTagModelList().get(0).getTagNo());
+			assertEquals(1L, actual.get(0).getPhotoTagModelList().get(0).getAccountNo());
+			assertEquals(1L, actual.get(0).getPhotoTagModelList().get(0).getPhotoNo());
+			assertEquals(1L, actual.get(0).getPhotoTagModelList().get(0).getTagNo());
 			assertEquals("太陽", actual.get(0).getPhotoTagModelList().get(0).getTagJapaneseName());
 			assertEquals("sun", actual.get(0).getPhotoTagModelList().get(0).getTagEnglishName());
-			assertEquals(1, actual.get(0).getPhotoTagModelList().get(1).getAccountNo());
-			assertEquals(1, actual.get(0).getPhotoTagModelList().get(1).getPhotoNo());
-			assertEquals(2, actual.get(0).getPhotoTagModelList().get(1).getTagNo());
+			assertEquals(1L, actual.get(0).getPhotoTagModelList().get(1).getAccountNo());
+			assertEquals(1L, actual.get(0).getPhotoTagModelList().get(1).getPhotoNo());
+			assertEquals(2L, actual.get(0).getPhotoTagModelList().get(1).getTagNo());
 			assertEquals("青空", actual.get(0).getPhotoTagModelList().get(1).getTagJapaneseName());
 			assertEquals("bluesky", actual.get(0).getPhotoTagModelList().get(1).getTagEnglishName());
 			
-			assertEquals(1, actual.get(1).getAccountNo());
-			assertEquals(2, actual.get(1).getPhotoNo());
+			assertEquals(1L, actual.get(1).getAccountNo());
+			assertEquals(2L, actual.get(1).getPhotoNo());
 			assertEquals(3, actual.get(1).getPhotoTagModelList().size());
-			assertEquals(1, actual.get(1).getPhotoTagModelList().get(0).getAccountNo());
-			assertEquals(2, actual.get(1).getPhotoTagModelList().get(0).getPhotoNo());
-			assertEquals(1, actual.get(1).getPhotoTagModelList().get(0).getTagNo());
+			assertEquals(1L, actual.get(1).getPhotoTagModelList().get(0).getAccountNo());
+			assertEquals(2L, actual.get(1).getPhotoTagModelList().get(0).getPhotoNo());
+			assertEquals(1L, actual.get(1).getPhotoTagModelList().get(0).getTagNo());
 			assertEquals("太陽", actual.get(1).getPhotoTagModelList().get(0).getTagJapaneseName());
 			assertEquals("sun", actual.get(1).getPhotoTagModelList().get(0).getTagEnglishName());
-			assertEquals(1, actual.get(1).getPhotoTagModelList().get(1).getAccountNo());
-			assertEquals(2, actual.get(1).getPhotoTagModelList().get(1).getPhotoNo());
-			assertEquals(2, actual.get(1).getPhotoTagModelList().get(1).getTagNo());
+			assertEquals(1L, actual.get(1).getPhotoTagModelList().get(1).getAccountNo());
+			assertEquals(2L, actual.get(1).getPhotoTagModelList().get(1).getPhotoNo());
+			assertEquals(2L, actual.get(1).getPhotoTagModelList().get(1).getTagNo());
 			assertEquals("曇天", actual.get(1).getPhotoTagModelList().get(1).getTagJapaneseName());
 			assertEquals("cloudy", actual.get(1).getPhotoTagModelList().get(1).getTagEnglishName());
-			assertEquals(1, actual.get(1).getPhotoTagModelList().get(2).getAccountNo());
-			assertEquals(2, actual.get(1).getPhotoTagModelList().get(2).getPhotoNo());
-			assertEquals(3, actual.get(1).getPhotoTagModelList().get(2).getTagNo());
+			assertEquals(1L, actual.get(1).getPhotoTagModelList().get(2).getAccountNo());
+			assertEquals(2L, actual.get(1).getPhotoTagModelList().get(2).getPhotoNo());
+			assertEquals(3L, actual.get(1).getPhotoTagModelList().get(2).getTagNo());
 			assertEquals("花", actual.get(1).getPhotoTagModelList().get(2).getTagJapaneseName());
 			assertEquals("flower", actual.get(1).getPhotoTagModelList().get(2).getTagEnglishName());
 		}
@@ -132,18 +132,18 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 		@DisplayName("正常系：写真のメタデータがデフォルト値、写真タグが0件の場合")
 		void getPhotoDetail_photoTag_default_value_not_found() throws PhotoNotFoundException {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(2)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoAccountNo(2L)
+					.photoNo(1L)
 					.build();
 			
 			PhotoDetailModel actual = photoDetailRepositoryImpl.getPhotoDetail(photoDetailGetModel);
 			
-			assertEquals(2, actual.getAccountNo());
-			assertEquals(1, actual.getPhotoNo());
+			assertEquals(2L, actual.getAccountNo());
+			assertEquals(1L, actual.getPhotoNo());
 			assertFalse(actual.getIsFavorite());
 			assertEquals(OffsetDateTime.of(2022, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getPhotoAt());
-			assertEquals(4, actual.getLocationNo());
+			assertEquals(4L, actual.getLocationNo());
 			assertEquals("住所4", actual.getAddress());
 			assertEquals(0, BigDecimal.valueOf(38.400).compareTo(actual.getLatitude()));
 			assertEquals(0, BigDecimal.valueOf(115.400).compareTo(actual.getLongitude()));
@@ -165,18 +165,18 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 		@DisplayName("正常系：写真のメタデータがデフォルト値でない場、写真タグが1件以上の場合")
 		void getPhotoDetail_not_default_value_photoTag_found() throws PhotoNotFoundException {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoAccountNo(1L)
+					.photoNo(1L)
 					.build();
 			
 			PhotoDetailModel actual = photoDetailRepositoryImpl.getPhotoDetail(photoDetailGetModel);
 			
-			assertEquals(1, actual.getAccountNo());
-			assertEquals(1, actual.getPhotoNo());
+			assertEquals(1L, actual.getAccountNo());
+			assertEquals(1L, actual.getPhotoNo());
 			assertTrue(actual.getIsFavorite());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getPhotoAt());
-			assertEquals(1, actual.getLocationNo());
+			assertEquals(1L, actual.getLocationNo());
 			assertEquals("住所1", actual.getAddress());
 			assertEquals(0, BigDecimal.valueOf(38.100).compareTo(actual.getLatitude()));
 			assertEquals(0, BigDecimal.valueOf(115.100).compareTo(actual.getLongitude()));
@@ -192,14 +192,14 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 			assertEquals(100, actual.getIso());
 			assertEquals(2, actual.getPhotoTagModelList().size());
 			
-			assertEquals(1, actual.getPhotoTagModelList().get(0).getAccountNo());
-			assertEquals(1, actual.getPhotoTagModelList().get(0).getPhotoNo());
-			assertEquals(1, actual.getPhotoTagModelList().get(0).getTagNo());
+			assertEquals(1L, actual.getPhotoTagModelList().get(0).getAccountNo());
+			assertEquals(1L, actual.getPhotoTagModelList().get(0).getPhotoNo());
+			assertEquals(1L, actual.getPhotoTagModelList().get(0).getTagNo());
 			assertEquals("太陽", actual.getPhotoTagModelList().get(0).getTagJapaneseName());
 			assertEquals("sun", actual.getPhotoTagModelList().get(0).getTagEnglishName());
-			assertEquals(1, actual.getPhotoTagModelList().get(1).getAccountNo());
-			assertEquals(1, actual.getPhotoTagModelList().get(1).getPhotoNo());
-			assertEquals(2, actual.getPhotoTagModelList().get(1).getTagNo());
+			assertEquals(1L, actual.getPhotoTagModelList().get(1).getAccountNo());
+			assertEquals(1L, actual.getPhotoTagModelList().get(1).getPhotoNo());
+			assertEquals(2L, actual.getPhotoTagModelList().get(1).getTagNo());
 			assertEquals("青空", actual.getPhotoTagModelList().get(1).getTagJapaneseName());
 			assertEquals("bluesky", actual.getPhotoTagModelList().get(1).getTagEnglishName());
 		}
@@ -209,9 +209,9 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 		@DisplayName("異常系：PhotoNotFoundExceptionをthrowする")
 		void getPhotoDetail_PhotoNotFoundException() {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(1)
-					.photoNo(99)
+					.accountNo(1L)
+					.photoAccountNo(1L)
+					.photoNo(99L)
 					.build();
 			
 			assertThrows(PhotoNotFoundException.class, () -> photoDetailRepositoryImpl.getPhotoDetail(photoDetailGetModel));

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoFavoriteRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoFavoriteRepositoryImplIntegrationTest.java
@@ -47,9 +47,9 @@ public class PhotoFavoriteRepositoryImplIntegrationTest {
 		@DisplayName("正常系")
 		void regist_contain_null_parameter() throws RegistFailureException {
 			PhotoFavoriteModel favoriteModel = PhotoFavoriteModel.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(2)
-					.favoritePhotoNo(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(2L)
+					.favoritePhotoNo(1L)
 					.build();
 			
 			photoFavoriteRepositoryImpl.regist(favoriteModel);
@@ -57,17 +57,17 @@ public class PhotoFavoriteRepositoryImplIntegrationTest {
 			List<PhotoFavorite> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite WHERE account_no=1 and favorite_photo_account_no=2 and favorite_photo_no=1", (rs, rowNum) ->
 						PhotoFavorite.builder()
-							.accountNo(rs.getInt("account_no"))
-							.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-							.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+							.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.build());
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(2, actualData.getFirst().getFavoritePhotoAccountNo());
-			assertEquals(1, actualData.getFirst().getFavoritePhotoNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(2L, actualData.getFirst().getFavoritePhotoAccountNo());
+			assertEquals(1L, actualData.getFirst().getFavoritePhotoNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
 		}
 		
 		@Test
@@ -75,9 +75,9 @@ public class PhotoFavoriteRepositoryImplIntegrationTest {
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
 		void regist_RegistFailureException() {
 			PhotoFavoriteModel favoriteModel = PhotoFavoriteModel.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			
 			assertThrows(RegistFailureException.class, () -> photoFavoriteRepositoryImpl.regist(favoriteModel));
@@ -95,9 +95,9 @@ public class PhotoFavoriteRepositoryImplIntegrationTest {
 		@DisplayName("正常系")
 		void delete_contain_null_parameter() throws UpdateFailureException {
 			PhotoFavoriteDeleteModel favoriteDeleteModel = PhotoFavoriteDeleteModel.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			
 			photoFavoriteRepositoryImpl.delete(favoriteDeleteModel);
@@ -105,10 +105,10 @@ public class PhotoFavoriteRepositoryImplIntegrationTest {
 			List<PhotoFavorite> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite WHERE account_no=1 and favorite_photo_account_no=1 and favorite_photo_no=1", (rs, rowNum) ->
 						PhotoFavorite.builder()
-							.accountNo(rs.getInt("account_no"))
-							.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-							.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+							.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.build());
 			assertEquals(0, actualData.size());
@@ -116,10 +116,10 @@ public class PhotoFavoriteRepositoryImplIntegrationTest {
 			List<PhotoFavorite> actualRestData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite", (rs, rowNum) ->
 						PhotoFavorite.builder()
-							.accountNo(rs.getInt("account_no"))
-							.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-							.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+							.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.build());
 			assertEquals(3, actualRestData.size());
@@ -130,9 +130,9 @@ public class PhotoFavoriteRepositoryImplIntegrationTest {
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
 		void delete_UpdateFailureException() throws UpdateFailureException {
 			PhotoFavoriteDeleteModel favoriteDeleteModel = PhotoFavoriteDeleteModel.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(3)
-					.favoritePhotoNo(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(3L)
+					.favoritePhotoNo(1L)
 					.build();
 			
 			assertThrows(UpdateFailureException.class, () -> photoFavoriteRepositoryImpl.delete(favoriteDeleteModel));
@@ -150,8 +150,8 @@ public class PhotoFavoriteRepositoryImplIntegrationTest {
 		@DisplayName("正常系：")
 		void clear_success() {
 			PhotoFavoriteDeleteModel favoriteDeleteModel = PhotoFavoriteDeleteModel.builder()
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			
 			photoFavoriteRepositoryImpl.clear(favoriteDeleteModel);
@@ -159,10 +159,10 @@ public class PhotoFavoriteRepositoryImplIntegrationTest {
 			List<PhotoFavorite> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite WHERE favorite_photo_account_no=1 and favorite_photo_no=1", (rs, rowNum) ->
 						PhotoFavorite.builder()
-							.accountNo(rs.getInt("account_no"))
-							.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-							.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+							.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.build());
 			assertEquals(0, actualData.size());
@@ -170,10 +170,10 @@ public class PhotoFavoriteRepositoryImplIntegrationTest {
 			List<PhotoFavorite> actualRestData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite", (rs, rowNum) ->
 						PhotoFavorite.builder()
-							.accountNo(rs.getInt("account_no"))
-							.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-							.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+							.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.build());
 			assertEquals(3, actualRestData.size());

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoMstRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoMstRepositoryImplIntegrationTest.java
@@ -54,25 +54,25 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			String imageFilePath = "https://www.xxx.com/DSC14.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(4)
+					.accountNo(1L)
+					.photoNo(4L)
 					.imageFilePath(imageFilePath)
 					.build();
 			
-			photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 4);
+			photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 4L);
 			
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst WHERE account_no=1 and photo_no=4", (rs, rowNum) ->
 						PhotoMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.photoAt(rs.getObject("photo_at", OffsetDateTime.class))
-							.locationNo(rs.getInt("location_no"))
+							.locationNo(rs.getLong("location_no"))
 							.imageFilePath(rs.getString("image_file_path"))
 							.photoJapaneseTitle(rs.getString("photo_japanese_title"))
 							.photoEnglishTitle(rs.getString("photo_english_title"))
@@ -85,13 +85,13 @@ public class PhotoMstRepositoryImplIntegrationTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(4, actualData.getFirst().getPhotoNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(4L, actualData.getFirst().getPhotoNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getPhotoAt().plusHours(9));
-			assertEquals(0, actualData.getFirst().getLocationNo());
+			assertEquals(0L, actualData.getFirst().getLocationNo());
 			assertEquals("https://www.xxx.com/DSC14.jpg", actualData.getFirst().getImageFilePath());
 			assertEquals("", actualData.getFirst().getPhotoJapaneseTitle());
 			assertEquals("", actualData.getFirst().getPhotoEnglishTitle());
@@ -110,10 +110,10 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			String imageFilePath = "https://www.xxx.com/DSC14.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(4)
+					.accountNo(1L)
+					.photoNo(4L)
 					.photoAt(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.locationNo(1)
+					.locationNo(1L)
 					.imageFilePath(imageFilePath)
 					.photoJapaneseTitle("タイトル14")
 					.photoEnglishTitle("title14")
@@ -125,20 +125,20 @@ public class PhotoMstRepositoryImplIntegrationTest {
 					.iso(100)
 					.build();
 			
-			photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 4);
+			photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 4L);
 			
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst WHERE account_no=1 and photo_no=4", (rs, rowNum) ->
 						PhotoMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.photoAt(rs.getObject("photo_at", OffsetDateTime.class))
-							.locationNo(rs.getInt("location_no"))
+							.locationNo(rs.getLong("location_no"))
 							.imageFilePath(rs.getString("image_file_path"))
 							.photoJapaneseTitle(rs.getString("photo_japanese_title"))
 							.photoEnglishTitle(rs.getString("photo_english_title"))
@@ -151,13 +151,13 @@ public class PhotoMstRepositoryImplIntegrationTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(4, actualData.getFirst().getPhotoNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(4L, actualData.getFirst().getPhotoNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getPhotoAt().plusHours(9));
-			assertEquals(1, actualData.getFirst().getLocationNo());
+			assertEquals(1L, actualData.getFirst().getLocationNo());
 			assertEquals("https://www.xxx.com/DSC14.jpg", actualData.getFirst().getImageFilePath());
 			assertEquals("タイトル14", actualData.getFirst().getPhotoJapaneseTitle());
 			assertEquals("title14", actualData.getFirst().getPhotoEnglishTitle());
@@ -176,12 +176,12 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			String imageFilePath = "https://www.xxx.com/DSC11.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.imageFilePath(imageFilePath)
 					.build();
 			
-			assertThrows(RegistFailureException.class , () -> photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 1));
+			assertThrows(RegistFailureException.class , () -> photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 1L));
 		}
 	}
 	
@@ -198,8 +198,8 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			String imageFilePath = "https://www.xxx.com/DSC111.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.imageFilePath(imageFilePath)
 					.build();
 			
@@ -208,15 +208,15 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst WHERE account_no=1 and photo_no=1", (rs, rowNum) ->
 						PhotoMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.photoAt(rs.getObject("photo_at", OffsetDateTime.class))
-							.locationNo(rs.getInt("location_no"))
+							.locationNo(rs.getLong("location_no"))
 							.imageFilePath(rs.getString("image_file_path"))
 							.photoJapaneseTitle(rs.getString("photo_japanese_title"))
 							.photoEnglishTitle(rs.getString("photo_english_title"))
@@ -229,13 +229,13 @@ public class PhotoMstRepositoryImplIntegrationTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getPhotoNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getPhotoNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getPhotoAt().plusHours(9));
-			assertEquals(0, actualData.getFirst().getLocationNo());
+			assertEquals(0L, actualData.getFirst().getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.getFirst().getImageFilePath());
 			assertEquals("", actualData.getFirst().getPhotoJapaneseTitle());
 			assertEquals("", actualData.getFirst().getPhotoEnglishTitle());
@@ -254,10 +254,10 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			String imageFilePath = "https://www.xxx.com/DSC111.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.photoAt(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
-					.locationNo(1)
+					.locationNo(1L)
 					.imageFilePath(imageFilePath)
 					.photoJapaneseTitle("タイトル111")
 					.photoEnglishTitle("title111")
@@ -274,15 +274,15 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst WHERE account_no=1 and photo_no=1", (rs, rowNum) ->
 						PhotoMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.photoAt(rs.getObject("photo_at", OffsetDateTime.class))
-							.locationNo(rs.getInt("location_no"))
+							.locationNo(rs.getLong("location_no"))
 							.imageFilePath(rs.getString("image_file_path"))
 							.photoJapaneseTitle(rs.getString("photo_japanese_title"))
 							.photoEnglishTitle(rs.getString("photo_english_title"))
@@ -295,13 +295,13 @@ public class PhotoMstRepositoryImplIntegrationTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getPhotoNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getPhotoNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getPhotoAt().plusHours(9));
-			assertEquals(1, actualData.getFirst().getLocationNo());
+			assertEquals(1L, actualData.getFirst().getLocationNo());
 			assertEquals("https://www.xxx.com/DSC111.jpg", actualData.getFirst().getImageFilePath());
 			assertEquals("タイトル111", actualData.getFirst().getPhotoJapaneseTitle());
 			assertEquals("title111", actualData.getFirst().getPhotoEnglishTitle());
@@ -320,8 +320,8 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			String imageFilePath = "https://www.xxx.com/DSC999.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(9)
+					.accountNo(1L)
+					.photoNo(9L)
 					.imageFilePath(imageFilePath)
 					.build();
 			
@@ -342,8 +342,8 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			String imageFilePath = "https://www.xxx.com/DSC11.jpg";
 			
 			PhotoDeleteModel photoDeleteModel = PhotoDeleteModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.imageFilePath(imageFilePath)
 					.build();
 			
@@ -352,15 +352,15 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst WHERE account_no=1 and photo_no=1", (rs, rowNum) ->
 						PhotoMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.photoAt(rs.getObject("photo_at", OffsetDateTime.class))
-							.locationNo(rs.getInt("location_no"))
+							.locationNo(rs.getLong("location_no"))
 							.imageFilePath(rs.getString("image_file_path"))
 							.photoJapaneseTitle(rs.getString("photo_japanese_title"))
 							.photoEnglishTitle(rs.getString("photo_english_title"))
@@ -374,13 +374,13 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			
 			assertEquals(1, actualData.size());
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getPhotoNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getPhotoNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertTrue(actualData.getFirst().getIsDeleted());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getPhotoAt().plusHours(9));
-			assertEquals(1, actualData.getFirst().getLocationNo());
+			assertEquals(1L, actualData.getFirst().getLocationNo());
 			assertEquals("https://www.xxx.com/DSC11.jpg", actualData.getFirst().getImageFilePath());
 			assertEquals("タイトル11", actualData.getFirst().getPhotoJapaneseTitle());
 			assertEquals("title11", actualData.getFirst().getPhotoEnglishTitle());
@@ -399,8 +399,8 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			String imageFilePath = "https://www.xxx.com/DSC11.jpg";
 			
 			PhotoDeleteModel photoDeleteModel = PhotoDeleteModel.builder()
-					.accountNo(1)
-					.photoNo(9)
+					.accountNo(1L)
+					.photoNo(9L)
 					.imageFilePath(imageFilePath)
 					.build();
 			
@@ -418,14 +418,14 @@ public class PhotoMstRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：getMaxPhotoNoがある場合")
 		void getNewPhotoNo_getMaxPhotoNo_found() {
-			assertEquals(4, photoMstRepositoryImpl.getNewPhotoNo(1));
+			assertEquals(4L, photoMstRepositoryImpl.getNewPhotoNo(1L));
 		}
 		
 		@Test
 		@Order(2)
 		@DisplayName("正常系：getMaxPhotoNoがない場合")
 		void getNewPhotoNo_getMaxPhotoNo_not_found() {
-			assertEquals(1, photoMstRepositoryImpl.getNewPhotoNo(9));
+			assertEquals(1L, photoMstRepositoryImpl.getNewPhotoNo(9L));
 		}
 	}
 	
@@ -447,7 +447,7 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			);
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.imageFile(multipartFile)
 					.imageFilePath("")
 					.build();
@@ -467,7 +467,7 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			);
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.imageFile(multipartFile)
 					.imageFilePath("")
 					.build();
@@ -487,7 +487,7 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			);
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.imageFile(multipartFile)
 					.imageFilePath("")
 					.build();
@@ -507,7 +507,7 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			);
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.imageFile(multipartFile)
 					.imageFilePath("")
 					.build();
@@ -527,7 +527,7 @@ public class PhotoMstRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系")
 		void count_success() {
-			assertEquals(2, photoMstRepositoryImpl.count(1));
+			assertEquals(2, photoMstRepositoryImpl.count(1L));
 		}
 	}
 }

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoTagMstRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoTagMstRepositoryImplIntegrationTest.java
@@ -46,9 +46,9 @@ public class PhotoTagMstRepositoryImplIntegrationTest {
 		@DisplayName("正常系")
 		void regist_contain_null_parameter() throws RegistFailureException {
 			PhotoTagModel photoTagModel = PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(3)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(3L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build();
@@ -58,19 +58,19 @@ public class PhotoTagMstRepositoryImplIntegrationTest {
 			List<PhotoTagMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_tag_mst WHERE account_no=1 and photo_no=1 and tag_no=3", (rs, rowNum) ->
 						PhotoTagMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.tagNo(rs.getInt("tag_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.tagNo(rs.getLong("tag_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.tagJapaneseName(rs.getObject("tag_japanese_name").toString())
 							.tagEnglishName(rs.getObject("tag_english_name").toString())
 							.build());
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getPhotoNo());
-			assertEquals(3, actualData.getFirst().getTagNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getPhotoNo());
+			assertEquals(3L, actualData.getFirst().getTagNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
 			assertEquals("海", actualData.getFirst().getTagJapaneseName());
 			assertEquals("sea", actualData.getFirst().getTagEnglishName());
 		}
@@ -80,9 +80,9 @@ public class PhotoTagMstRepositoryImplIntegrationTest {
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
 		void regist_RegistFailureException() {
 			PhotoTagModel photoTagModel = PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build();
@@ -102,8 +102,8 @@ public class PhotoTagMstRepositoryImplIntegrationTest {
 		@DisplayName("正常系：")
 		void clear_success() {
 			PhotoTagDeleteModel photoTagDeleteModel = PhotoTagDeleteModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.build();
 			
 			photoTagMstRepositoryImpl.clear(photoTagDeleteModel);
@@ -111,10 +111,10 @@ public class PhotoTagMstRepositoryImplIntegrationTest {
 			List<PhotoTagMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_tag_mst WHERE account_no=1 and photo_no=1", (rs, rowNum) ->
 						PhotoTagMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.tagNo(rs.getInt("tag_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.tagNo(rs.getLong("tag_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.tagJapaneseName(rs.getObject("tag_japanese_name").toString())
 							.tagEnglishName(rs.getObject("tag_english_name").toString())
@@ -124,10 +124,10 @@ public class PhotoTagMstRepositoryImplIntegrationTest {
 			List<PhotoTagMst> actualRestData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_tag_mst", (rs, rowNum) ->
 						PhotoTagMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.tagNo(rs.getInt("tag_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.tagNo(rs.getLong("tag_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.tagJapaneseName(rs.getObject("tag_japanese_name").toString())
 							.tagEnglishName(rs.getObject("tag_english_name").toString())

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/RefreshTokenRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/RefreshTokenRepositoryImplIntegrationTest.java
@@ -37,8 +37,8 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		return jdbcTemplate.query(
 			"SELECT * FROM common.refresh_token WHERE token_hash = ?",
 			(rs, rowNum) -> RefreshToken.builder()
-				.tokenId(rs.getInt("token_id"))
-				.accountNo(rs.getInt("account_no"))
+				.tokenId(rs.getLong("token_id"))
+				.accountNo(rs.getLong("account_no"))
 				.tokenHash(rs.getString("token_hash"))
 				.expiresAt(rs.getObject("expires_at", OffsetDateTime.class))
 				.createdAt(rs.getObject("created_at", OffsetDateTime.class))
@@ -48,12 +48,12 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		);
 	}
 
-	private List<RefreshToken> getRefreshTokensByAccountNo(Integer accountNo) {
+	private List<RefreshToken> getRefreshTokensByAccountNo(Long accountNo) {
 		return jdbcTemplate.query(
 			"SELECT * FROM common.refresh_token WHERE account_no = ?",
 			(rs, rowNum) -> RefreshToken.builder()
-				.tokenId(rs.getInt("token_id"))
-				.accountNo(rs.getInt("account_no"))
+				.tokenId(rs.getLong("token_id"))
+				.accountNo(rs.getLong("account_no"))
 				.tokenHash(rs.getString("token_hash"))
 				.expiresAt(rs.getObject("expires_at", OffsetDateTime.class))
 				.createdAt(rs.getObject("created_at", OffsetDateTime.class))
@@ -78,7 +78,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@DisplayName("正常系：リフレッシュトークンを保存する")
 		void save_success() {
 			RefreshTokenModel refreshToken = RefreshTokenModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.tokenHash("new_token_hash")
 					.expiresAt(OffsetDateTime.now().plusDays(7))
 					.build();
@@ -87,7 +87,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 
 			List<RefreshToken> actualData = getRefreshTokenData("new_token_hash");
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
 			assertEquals("new_token_hash", actualData.getFirst().getTokenHash());
 			assertFalse(actualData.getFirst().getIsRevoked());
 			assertNotNull(actualData.getFirst().getCreatedAt());
@@ -108,7 +108,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1");
 
 			assertNotNull(actual);
-			assertEquals(1, actual.getAccountNo());
+			assertEquals(1L, actual.getAccountNo());
 			assertEquals("valid_token_hash_1", actual.getTokenHash());
 			assertFalse(actual.getIsRevoked());
 		}
@@ -144,9 +144,9 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@DisplayName("正常系：アカウント番号に該当する有効なリフレッシュトークンをすべて無効化する")
 		void revokeAllByAccountNo_success() {
 			// アカウント1の有効なトークンが2件（token_id=1,5）、無効化済み1件（token_id=2）、期限切れ1件（token_id=3）
-			refreshTokenRepositoryImpl.revokeAllByAccountNo(1);
+			refreshTokenRepositoryImpl.revokeAllByAccountNo(1L);
 
-			List<RefreshToken> account1Tokens = getRefreshTokensByAccountNo(1);
+			List<RefreshToken> account1Tokens = getRefreshTokensByAccountNo(1L);
 			// アカウント1のトークンはすべて無効化されている
 			for (RefreshToken token : account1Tokens) {
 				assertTrue(token.getIsRevoked());
@@ -162,7 +162,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：該当するトークンが存在しない場合もエラーにならない")
 		void revokeAllByAccountNo_no_tokens() {
-			assertDoesNotThrow(() -> refreshTokenRepositoryImpl.revokeAllByAccountNo(999));
+			assertDoesNotThrow(() -> refreshTokenRepositoryImpl.revokeAllByAccountNo(999L));
 		}
 	}
 

--- a/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
@@ -62,7 +62,7 @@ public class AccountServiceImplTest {
 			String accountId = "aaaaaaaa";
 			String password = "AAAAAAAA";
 			AccountModel account = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId(accountId)
 					.loginFailureCount(0)
 					.password(password)
@@ -128,8 +128,8 @@ public class AccountServiceImplTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントを更新")
 		void updateAccount_success() throws UpdateFailureException {
-			AccountModel accountModel = AccountModel.builder().accountNo(1).accountId("aaaaaaaa").build();
-			doReturn(false).when(accountRepositoryImpl).isExistAccount(1, "aaaaaaaa");
+			AccountModel accountModel = AccountModel.builder().accountNo(1L).accountId("aaaaaaaa").build();
+			doReturn(false).when(accountRepositoryImpl).isExistAccount(1L, "aaaaaaaa");
 			doNothing().when(accountRepositoryImpl).update(accountModel);
 			assertFalse(accountServiceImpl.updateAccount(accountModel));
 		}
@@ -138,8 +138,8 @@ public class AccountServiceImplTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが既に存在する")
 		void updateAccount_account_already_exist() throws UpdateFailureException {
-			AccountModel accountModel = AccountModel.builder().accountNo(1).accountId("aaaaaaaa").build();
-			doReturn(true).when(accountRepositoryImpl).isExistAccount(1, "aaaaaaaa");
+			AccountModel accountModel = AccountModel.builder().accountNo(1L).accountId("aaaaaaaa").build();
+			doReturn(true).when(accountRepositoryImpl).isExistAccount(1L, "aaaaaaaa");
 			verify(accountRepositoryImpl,times(0)).update(accountModel);
 			assertTrue(accountServiceImpl.updateAccount(accountModel));
 		}
@@ -148,8 +148,8 @@ public class AccountServiceImplTest {
 		@Order(3)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
 		void updateAccount_UpdateFailureException() throws UpdateFailureException {
-			AccountModel accountModel = AccountModel.builder().accountNo(1).accountId("aaaaaaaa").build();
-			doReturn(false).when(accountRepositoryImpl).isExistAccount(1, "aaaaaaaa");
+			AccountModel accountModel = AccountModel.builder().accountNo(1L).accountId("aaaaaaaa").build();
+			doReturn(false).when(accountRepositoryImpl).isExistAccount(1L, "aaaaaaaa");
 			doThrow(UpdateFailureException.class).when(accountRepositoryImpl).update(accountModel);
 			assertThrows(UpdateFailureException.class, () -> accountServiceImpl.updateAccount(accountModel));
 		}
@@ -164,7 +164,7 @@ public class AccountServiceImplTest {
 		@DisplayName("正常系：アカウントが存在する場合")
 		void getAccountById_found() {
 			AccountModel account = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("aaaaaaaa")
 					.accountName("AAAAAAAA")
 					.password("password")
@@ -181,7 +181,7 @@ public class AccountServiceImplTest {
 
 			AccountModel actual = accountServiceImpl.getAccountById("aaaaaaaa");
 
-			assertEquals(1, actual.getAccountNo());
+			assertEquals(1L, actual.getAccountNo());
 			assertEquals("aaaaaaaa", actual.getAccountId());
 			assertEquals("AAAAAAAA", actual.getAccountName());
 			assertEquals("password", actual.getPassword());
@@ -252,7 +252,7 @@ public class AccountServiceImplTest {
 			Authentication authentication = new UsernamePasswordAuthenticationToken(username, password, authorities);
 			AuthenticationSuccessEvent event = new AuthenticationSuccessEvent(authentication);
 			
-			AccountModel account = AccountModel.builder().accountNo(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1L).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(username);
 			
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
@@ -261,7 +261,7 @@ public class AccountServiceImplTest {
 			accountServiceImpl.handle(event);
 			
 			AccountModel accountModel = accountModelCaptor.getValue();
-			assertEquals(1, accountModel.getAccountNo());
+			assertEquals(1L, accountModel.getAccountNo());
 			assertNull(accountModel.getAccountId());
 			assertNull(accountModel.getAccountName());
 			assertNull(accountModel.getPassword());
@@ -288,7 +288,7 @@ public class AccountServiceImplTest {
 			Authentication authentication = new UsernamePasswordAuthenticationToken(username, password, authorities);
 			AuthenticationSuccessEvent event = new AuthenticationSuccessEvent(authentication);
 			
-			AccountModel account = AccountModel.builder().accountNo(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1L).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(username);
 			
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
@@ -297,7 +297,7 @@ public class AccountServiceImplTest {
 			assertThrows(UpdateFailureException.class, () -> accountServiceImpl.handle(event));
 			
 			AccountModel accountModel = accountModelCaptor.getValue();
-			assertEquals(1, accountModel.getAccountNo());
+			assertEquals(1L, accountModel.getAccountNo());
 			assertNull(accountModel.getAccountId());
 			assertNull(accountModel.getAccountName());
 			assertNull(accountModel.getPassword());
@@ -332,7 +332,7 @@ public class AccountServiceImplTest {
 			
 			AuthenticationFailureBadCredentialsEvent event = new AuthenticationFailureBadCredentialsEvent(authentication, exception);
 			
-			AccountModel account = AccountModel.builder().accountNo(1).loginFailureCount(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1L).loginFailureCount(1).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(username);
 			
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
@@ -341,7 +341,7 @@ public class AccountServiceImplTest {
 			accountServiceImpl.handle(event);
 			
 			AccountModel accountModel = accountModelCaptor.getValue();
-			assertEquals(1, accountModel.getAccountNo());
+			assertEquals(1L, accountModel.getAccountNo());
 			assertNull(accountModel.getAccountId());
 			assertNull(accountModel.getAccountName());
 			assertNull(accountModel.getPassword());
@@ -393,7 +393,7 @@ public class AccountServiceImplTest {
 			
 			AuthenticationFailureBadCredentialsEvent event = new AuthenticationFailureBadCredentialsEvent(authentication, exception);
 			
-			AccountModel account = AccountModel.builder().accountNo(1).loginFailureCount(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1L).loginFailureCount(1).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(username);
 			
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
@@ -402,7 +402,7 @@ public class AccountServiceImplTest {
 			assertThrows(UpdateFailureException.class, () ->accountServiceImpl.handle(event));
 			
 			AccountModel accountModel = accountModelCaptor.getValue();
-			assertEquals(1, accountModel.getAccountNo());
+			assertEquals(1L, accountModel.getAccountNo());
 			assertNull(accountModel.getAccountId());
 			assertNull(accountModel.getAccountName());
 			assertNull(accountModel.getPassword());

--- a/backend/src/test/java/com/web/gallery/service/impl/AuthServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AuthServiceImplTest.java
@@ -66,7 +66,7 @@ class AuthServiceImplTest {
 			String password = "password1";
 
 			AccountPrincipal principal = mock(AccountPrincipal.class);
-			when(principal.getAccountNo()).thenReturn(1);
+			when(principal.getAccountNo()).thenReturn(1L);
 
 			Authentication authentication = mock(Authentication.class);
 			when(authentication.getPrincipal()).thenReturn(principal);
@@ -85,7 +85,7 @@ class AuthServiceImplTest {
 			assertEquals("refresh-token", result.getRefreshToken());
 			assertEquals(900L, result.getExpiresIn());
 
-			verify(refreshTokenRepository).revokeAllByAccountNo(1);
+			verify(refreshTokenRepository).revokeAllByAccountNo(1L);
 			verify(refreshTokenRepository).save(any(RefreshTokenModel.class));
 		}
 
@@ -121,7 +121,7 @@ class AuthServiceImplTest {
 		void refresh_success() {
 			String refreshToken = "valid-refresh-token";
 			RefreshTokenModel storedToken = RefreshTokenModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.tokenHash("hashed-token")
 					.expiresAt(OffsetDateTime.now().plusDays(7))
 					.isRevoked(false)
@@ -130,10 +130,10 @@ class AuthServiceImplTest {
 			when(refreshTokenRepository.findByTokenHash(anyString())).thenReturn(storedToken);
 
 			AccountModel account = AccountModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.accountId("testuser1")
 					.build();
-			when(accountRepository.getByAccountNo(1)).thenReturn(account);
+			when(accountRepository.getByAccountNo(1L)).thenReturn(account);
 
 			AccountPrincipal principal = mock(AccountPrincipal.class);
 			when(accountServiceImpl.loadUserByUsername("testuser1")).thenReturn(principal);
@@ -151,7 +151,7 @@ class AuthServiceImplTest {
 		@DisplayName("異常系: リフレッシュトークンが無効化されている場合は例外がスローされること")
 		void refresh_revokedToken() {
 			RefreshTokenModel storedToken = RefreshTokenModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.tokenHash("hashed-token")
 					.expiresAt(OffsetDateTime.now().plusDays(7))
 					.isRevoked(true)
@@ -168,7 +168,7 @@ class AuthServiceImplTest {
 		@DisplayName("異常系: リフレッシュトークンの有効期限が切れている場合は例外がスローされること")
 		void refresh_expiredToken() {
 			RefreshTokenModel storedToken = RefreshTokenModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.tokenHash("hashed-token")
 					.expiresAt(OffsetDateTime.now().minusDays(1))
 					.isRevoked(false)

--- a/backend/src/test/java/com/web/gallery/service/impl/PhotoFavoriteServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/PhotoFavoriteServiceImplTest.java
@@ -40,9 +40,9 @@ public class PhotoFavoriteServiceImplTest {
 		@DisplayName("正常系")
 		void addFavorite_success() throws RegistFailureException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			doNothing().when(photoFavoriteRepositoryImpl).regist(photoFavoriteModel);
 			photoFavoriteServiceImpl.addFavorite(photoFavoriteModel);
@@ -53,9 +53,9 @@ public class PhotoFavoriteServiceImplTest {
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
 		void addFavorite_RegistFailureException() throws RegistFailureException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			doThrow(RegistFailureException.class).when(photoFavoriteRepositoryImpl).regist(photoFavoriteModel);
 			assertThrows(RegistFailureException.class, () -> photoFavoriteServiceImpl.addFavorite(photoFavoriteModel));
@@ -71,9 +71,9 @@ public class PhotoFavoriteServiceImplTest {
 		@DisplayName("正常系")
 		void deleteFavorite_success() throws UpdateFailureException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			ArgumentCaptor<PhotoFavoriteDeleteModel> photoFavoriteDeleteModelCaptor = ArgumentCaptor.forClass(PhotoFavoriteDeleteModel.class);
 			doNothing().when(photoFavoriteRepositoryImpl).delete(photoFavoriteDeleteModelCaptor.capture());
@@ -81,9 +81,9 @@ public class PhotoFavoriteServiceImplTest {
 			photoFavoriteServiceImpl.deleteFavorite(photoFavoriteModel);
 			
 			PhotoFavoriteDeleteModel photoFavoriteDeleteModel = photoFavoriteDeleteModelCaptor.getValue();
-			assertEquals(1, photoFavoriteDeleteModel.getAccountNo());
-			assertEquals(1, photoFavoriteDeleteModel.getFavoritePhotoAccountNo());
-			assertEquals(1, photoFavoriteDeleteModel.getFavoritePhotoNo());
+			assertEquals(1L, photoFavoriteDeleteModel.getAccountNo());
+			assertEquals(1L, photoFavoriteDeleteModel.getFavoritePhotoAccountNo());
+			assertEquals(1L, photoFavoriteDeleteModel.getFavoritePhotoNo());
 		}
 		
 		@Test
@@ -91,9 +91,9 @@ public class PhotoFavoriteServiceImplTest {
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
 		void deleteFavorite_UpdateFailureException() throws UpdateFailureException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			ArgumentCaptor<PhotoFavoriteDeleteModel> photoFavoriteDeleteModelCaptor = ArgumentCaptor.forClass(PhotoFavoriteDeleteModel.class);
 			doThrow(UpdateFailureException.class).when(photoFavoriteRepositoryImpl).delete(photoFavoriteDeleteModelCaptor.capture());
@@ -101,9 +101,9 @@ public class PhotoFavoriteServiceImplTest {
 			assertThrows(UpdateFailureException.class, () ->photoFavoriteServiceImpl.deleteFavorite(photoFavoriteModel));
 			
 			PhotoFavoriteDeleteModel photoFavoriteDeleteModel = photoFavoriteDeleteModelCaptor.getValue();
-			assertEquals(1, photoFavoriteDeleteModel.getAccountNo());
-			assertEquals(1, photoFavoriteDeleteModel.getFavoritePhotoAccountNo());
-			assertEquals(1, photoFavoriteDeleteModel.getFavoritePhotoNo());
+			assertEquals(1L, photoFavoriteDeleteModel.getAccountNo());
+			assertEquals(1L, photoFavoriteDeleteModel.getFavoritePhotoAccountNo());
+			assertEquals(1L, photoFavoriteDeleteModel.getFavoritePhotoNo());
 		}
 	}
 }

--- a/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
@@ -92,22 +92,22 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoTagModel> photoTagModelList1 = new ArrayList<PhotoTagModel>();
 			photoTagModelList1.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build());
 			photoTagModelList1.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(2)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(2L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build());
 			PhotoModel photoModel1 = PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.favoriteCount(1)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -120,22 +120,22 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoTagModel> photoTagModelList2 = new ArrayList<PhotoTagModel>();
 			photoTagModelList2.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(2)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(2L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build());
 			photoTagModelList2.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(2)
-					.tagNo(2)
+					.accountNo(1L)
+					.photoNo(2L)
+					.tagNo(2L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build());
 			PhotoModel photoModel2 = PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(2)
+					.accountNo(1L)
+					.photoNo(2L)
 					.favoriteCount(3)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2001, 6, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -148,22 +148,22 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoTagModel> photoTagModelList3 = new ArrayList<PhotoTagModel>();
 			photoTagModelList3.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(3)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(3L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build());
 			photoTagModelList3.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(3)
-					.tagNo(2)
+					.accountNo(1L)
+					.photoNo(3L)
+					.tagNo(2L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build());
 			PhotoModel photoModel3 = PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(3)
+					.accountNo(1L)
+					.photoNo(3L)
 					.favoriteCount(2)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2002, 3, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -176,15 +176,15 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoTagModel> photoTagModelList4 = new ArrayList<PhotoTagModel>();
 			photoTagModelList4.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(4)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(4L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build());
 			PhotoModel photoModel4 = PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(4)
+					.accountNo(1L)
+					.photoNo(4L)
 					.favoriteCount(4)
 					.isFavorite(true)
 					.photoAt(OffsetDateTime.of(2001, 4, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -197,15 +197,15 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoTagModel> photoTagModelList5 = new ArrayList<PhotoTagModel>();
 			photoTagModelList5.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(5)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(5L)
+					.tagNo(1L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build());
 			PhotoModel photoModel5 = PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(5)
+					.accountNo(1L)
+					.photoNo(5L)
 					.favoriteCount(10)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2001, 5, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -217,8 +217,8 @@ public class PhotoServiceImplTest {
 			photoModelList.add(photoModel5);
 			
 			PhotoModel photoModel6 = PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(6)
+					.accountNo(1L)
+					.photoNo(6L)
 					.favoriteCount(0)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2001, 6, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -239,14 +239,14 @@ public class PhotoServiceImplTest {
 			String accountId = "aaaaaaaa";
 			List<String> tags = new ArrayList<String>();
 			
-			AccountModel account = AccountModel.builder().accountNo(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1L).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(accountId);
 			
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
 			doReturn(new ArrayList<PhotoModel>()).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
 			
 			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.photoAccountId(accountId)
 					.directionKbn(DirectionEnum.NONE)
 					.isFavoriteOnly(false)
@@ -260,8 +260,8 @@ public class PhotoServiceImplTest {
 			verify(photoDetailRepositoryImpl).getPhotoList(any(PhotoGetModel.class));
 			
 			PhotoGetModel photoGetModel = photoGetModelCaptor.getValue();
-			assertEquals(2, photoGetModel.getAccountNo());
-			assertEquals(1, photoGetModel.getPhotoAccountNo());
+			assertEquals(2L, photoGetModel.getAccountNo());
+			assertEquals(1L, photoGetModel.getPhotoAccountNo());
 		}
 		
 		@Test
@@ -271,14 +271,14 @@ public class PhotoServiceImplTest {
 			String accountId = "aaaaaaaa";
 			List<String> tags = Arrays.asList("太陽", "海");
 			
-			AccountModel account = AccountModel.builder().accountNo(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1L).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(accountId);
 			
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
 			doReturn(createPhotoModelList()).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
 			
 			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.photoAccountId(accountId)
 					.directionKbn(DirectionEnum.VERTICAL)
 					.isFavoriteOnly(false)
@@ -288,16 +288,16 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoModel> actual = photoServiceImpl.getPhotoList(photoListGetModel);
 			assertEquals(3, actual.size());
-			assertEquals(3, actual.get(0).getPhotoNo());
-			assertEquals(2, actual.get(1).getPhotoNo());
-			assertEquals(1, actual.get(2).getPhotoNo());
+			assertEquals(3L, actual.get(0).getPhotoNo());
+			assertEquals(2L, actual.get(1).getPhotoNo());
+			assertEquals(1L, actual.get(2).getPhotoNo());
 			
 			verify(accountRepositoryImpl).getByAccountId(accountId);
 			verify(photoDetailRepositoryImpl).getPhotoList(any(PhotoGetModel.class));
 			
 			PhotoGetModel photoGetModel = photoGetModelCaptor.getValue();
-			assertEquals(2, photoGetModel.getAccountNo());
-			assertEquals(1, photoGetModel.getPhotoAccountNo());
+			assertEquals(2L, photoGetModel.getAccountNo());
+			assertEquals(1L, photoGetModel.getPhotoAccountNo());
 		}
 		
 		@Test
@@ -307,14 +307,14 @@ public class PhotoServiceImplTest {
 			String accountId = "aaaaaaaa";
 			List<String> tags = Arrays.asList("太陽", "海");
 			
-			AccountModel account = AccountModel.builder().accountNo(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1L).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(accountId);
 			
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
 			doReturn(createPhotoModelList()).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
 			
 			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.photoAccountId(accountId)
 					.directionKbn(DirectionEnum.VERTICAL)
 					.isFavoriteOnly(false)
@@ -324,16 +324,16 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoModel> actual = photoServiceImpl.getPhotoList(photoListGetModel);
 			assertEquals(3, actual.size());
-			assertEquals(2, actual.get(0).getPhotoNo());
-			assertEquals(3, actual.get(1).getPhotoNo());
-			assertEquals(1, actual.get(2).getPhotoNo());
+			assertEquals(2L, actual.get(0).getPhotoNo());
+			assertEquals(3L, actual.get(1).getPhotoNo());
+			assertEquals(1L, actual.get(2).getPhotoNo());
 			
 			verify(accountRepositoryImpl).getByAccountId(accountId);
 			verify(photoDetailRepositoryImpl).getPhotoList(any(PhotoGetModel.class));
 			
 			PhotoGetModel photoGetModel = photoGetModelCaptor.getValue();
-			assertEquals(2, photoGetModel.getAccountNo());
-			assertEquals(1, photoGetModel.getPhotoAccountNo());
+			assertEquals(2L, photoGetModel.getAccountNo());
+			assertEquals(1L, photoGetModel.getPhotoAccountNo());
 		}
 		
 		@Test
@@ -343,14 +343,14 @@ public class PhotoServiceImplTest {
 			String accountId = "aaaaaaaa";
 			List<String> tags = Arrays.asList("太陽", "海");
 			
-			AccountModel account = AccountModel.builder().accountNo(1).build();
+			AccountModel account = AccountModel.builder().accountNo(1L).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(accountId);
 			
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
 			doReturn(createPhotoModelList()).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
 			
 			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
-					.accountNo(2)
+					.accountNo(2L)
 					.photoAccountId(accountId)
 					.directionKbn(DirectionEnum.VERTICAL)
 					.isFavoriteOnly(false)
@@ -360,16 +360,16 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoModel> actual = photoServiceImpl.getPhotoList(photoListGetModel);
 			assertEquals(3, actual.size());
-			assertEquals(1, actual.get(0).getPhotoNo());
-			assertEquals(2, actual.get(1).getPhotoNo());
-			assertEquals(3, actual.get(2).getPhotoNo());
+			assertEquals(1L, actual.get(0).getPhotoNo());
+			assertEquals(2L, actual.get(1).getPhotoNo());
+			assertEquals(3L, actual.get(2).getPhotoNo());
 			
 			verify(accountRepositoryImpl).getByAccountId(accountId);
 			verify(photoDetailRepositoryImpl).getPhotoList(any(PhotoGetModel.class));
 			
 			PhotoGetModel photoGetModel = photoGetModelCaptor.getValue();
-			assertEquals(2, photoGetModel.getAccountNo());
-			assertEquals(1, photoGetModel.getPhotoAccountNo());
+			assertEquals(2L, photoGetModel.getAccountNo());
+			assertEquals(1L, photoGetModel.getPhotoAccountNo());
 		}
 	}
 	
@@ -382,13 +382,13 @@ public class PhotoServiceImplTest {
 		@DisplayName("正常系")
 		void getPhotoDetail_success() throws PhotoNotFoundException {
 			PhotoDetailModel actual = PhotoDetailModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.imageFilePath("https://www.xxx.com/DSC111.jpg")
 					.build();
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoAccountNo(1L)
+					.photoNo(1L)
 					.build();
 			
 			doReturn(actual).when(photoDetailRepositoryImpl).getPhotoDetail(photoDetailGetModel);
@@ -400,9 +400,9 @@ public class PhotoServiceImplTest {
 		@DisplayName("異常系：PhotoNotFoundExceptionをthrowする")
 		void getPhotoDetail_PhotoNotFoundException() throws PhotoNotFoundException {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoAccountNo(1L)
+					.photoNo(1L)
 					.build();
 			
 			doThrow(PhotoNotFoundException.class).when(photoDetailRepositoryImpl).getPhotoDetail(photoDetailGetModel);
@@ -418,16 +418,16 @@ public class PhotoServiceImplTest {
 		PhotoDetailModel createNewPhotoWithTag() {
 			List<PhotoTagModel> photoTagModelList = new ArrayList<PhotoTagModel>();
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(5)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(5L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build());
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(5)
-					.tagNo(2)
+					.accountNo(1L)
+					.photoNo(5L)
+					.tagNo(2L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build());
@@ -438,7 +438,7 @@ public class PhotoServiceImplTest {
 					"sample image".getBytes()
 			);
 			return PhotoDetailModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.photoAt(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.imageFile(multipartFile)
 					.imageFilePath("")
@@ -461,7 +461,7 @@ public class PhotoServiceImplTest {
 					"sample image".getBytes()
 				);
 			return PhotoDetailModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.imageFile(multipartFile)
 					.imageFilePath("")
 					.build();
@@ -470,16 +470,16 @@ public class PhotoServiceImplTest {
 		PhotoDetailModel createUpdatePhotoWithTag() {
 			List<PhotoTagModel> photoTagModelList = new ArrayList<PhotoTagModel>();
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(2)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(2L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build());
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(2)
-					.tagNo(2)
+					.accountNo(1L)
+					.photoNo(2L)
+					.tagNo(2L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build());
@@ -490,8 +490,8 @@ public class PhotoServiceImplTest {
 					"sample image".getBytes()
 			);
 			return PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(2)
+					.accountNo(1L)
+					.photoNo(2L)
 					.photoAt(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.imageFile(multipartFile)
 					.imageFilePath("https://localhost:8080/image/DSC222.jpg")
@@ -514,8 +514,8 @@ public class PhotoServiceImplTest {
 					"sample image".getBytes()
 			);
 			return PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(3)
+					.accountNo(1L)
+					.photoNo(3L)
 					.photoAt(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.imageFile(multipartFile)
 					.imageFilePath("https://localhost:8080/image/DSC333.jpg")
@@ -533,11 +533,11 @@ public class PhotoServiceImplTest {
 		@Order(1)
 		@DisplayName("正常系：photoDetailModelListがnullの場合、終了")
 		void savePhotos_photoDetailModelList_is_null() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
-			Integer actual = photoServiceImpl.savePhotos("aaaaaaaa", null);
+			Long actual = photoServiceImpl.savePhotos("aaaaaaaa", null);
 			assertNull(actual);
-			verify(photoMstRepositoryImpl, times(0)).getNewPhotoNo(any(Integer.class));
+			verify(photoMstRepositoryImpl, times(0)).getNewPhotoNo(any(Long.class));
 			verify(photoMstRepositoryImpl, times(0)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Integer.class));
+			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
 			verify(photoMstRepositoryImpl, times(0)).update(any(PhotoDetailModel.class));
 		}
 		
@@ -546,11 +546,11 @@ public class PhotoServiceImplTest {
 		@DisplayName("正常系：photoDetailModelListがemptyの場合、終了")
 		void savePhotos_photoDetailModelList_is_empty() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
-			Integer actual = photoServiceImpl.savePhotos("aaaaaaaa", photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos("aaaaaaaa", photoDetailModelList);
 			assertNull(actual);
-			verify(photoMstRepositoryImpl, times(0)).getNewPhotoNo(any(Integer.class));
+			verify(photoMstRepositoryImpl, times(0)).getNewPhotoNo(any(Long.class));
 			verify(photoMstRepositoryImpl, times(0)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Integer.class));
+			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
 			verify(photoMstRepositoryImpl, times(0)).update(any(PhotoDetailModel.class));
 		}
 		
@@ -562,7 +562,7 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5).when(photoMstRepositoryImpl).getNewPhotoNo(1);
+			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			ArgumentCaptor<PhotoTagModel> photoTagModelCaptor = ArgumentCaptor.forClass(PhotoTagModel.class);
@@ -575,33 +575,33 @@ public class PhotoServiceImplTest {
 			PhotoDetailModel photoDetailModel1 = createNewPhotoWithTag();
 			photoDetailModelList.add(photoDetailModel1);
 			doReturn(false).when(photoMstRepositoryImpl).isExistPhoto(photoDetailModel1);
-			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel1, filePath + accountId + "/DSC111.jpg", 5);
+			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel1, filePath + accountId + "/DSC111.jpg", 5L);
 			
 			// 新規登録2枚目
 			PhotoDetailModel photoDetailModel2 = createNewPhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			doReturn(false).when(photoMstRepositoryImpl).isExistPhoto(photoDetailModel2);
-			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel2, filePath + accountId + "/DSC222.jpg", 6);
+			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel2, filePath + accountId + "/DSC222.jpg", 6L);
 			
-			Integer actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
 
 			assertEquals(5, actual);
 			verify(photoMstRepositoryImpl, times(2)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(2)).regist(any(PhotoDetailModel.class), any(String.class), any(Integer.class));
+			verify(photoMstRepositoryImpl, times(2)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
 			verify(photoMstRepositoryImpl, times(0)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(2)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).clear(any(PhotoTagDeleteModel.class));
 			verify(fileRepositoryImpl, times(2)).save(any(FileModel.class));
 
 			List<PhotoTagModel> photoTagModelCaptureList = photoTagModelCaptor.getAllValues();
-			assertEquals(1, photoTagModelCaptureList.get(0).getAccountNo());
-			assertEquals(5, photoTagModelCaptureList.get(0).getPhotoNo());
-			assertEquals(1, photoTagModelCaptureList.get(0).getTagNo());
+			assertEquals(1L, photoTagModelCaptureList.get(0).getAccountNo());
+			assertEquals(5L, photoTagModelCaptureList.get(0).getPhotoNo());
+			assertEquals(1L, photoTagModelCaptureList.get(0).getTagNo());
 			assertEquals("太陽", photoTagModelCaptureList.get(0).getTagJapaneseName());
 			assertEquals("sun", photoTagModelCaptureList.get(0).getTagEnglishName());
-			assertEquals(1, photoTagModelCaptureList.get(1).getAccountNo());
-			assertEquals(5, photoTagModelCaptureList.get(1).getPhotoNo());
-			assertEquals(2, photoTagModelCaptureList.get(1).getTagNo());
+			assertEquals(1L, photoTagModelCaptureList.get(1).getAccountNo());
+			assertEquals(5L, photoTagModelCaptureList.get(1).getPhotoNo());
+			assertEquals(2L, photoTagModelCaptureList.get(1).getTagNo());
 			assertEquals("海", photoTagModelCaptureList.get(1).getTagJapaneseName());
 			assertEquals("sea", photoTagModelCaptureList.get(1).getTagEnglishName());
 
@@ -620,7 +620,7 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5).when(photoMstRepositoryImpl).getNewPhotoNo(1);
+			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			ArgumentCaptor<PhotoTagDeleteModel> photoTagDeleteModelCaptor = ArgumentCaptor.forClass(PhotoTagDeleteModel.class);
@@ -639,25 +639,25 @@ public class PhotoServiceImplTest {
 			photoDetailModelList.add(photoDetailModel2);
 			doNothing().when(photoMstRepositoryImpl).update(photoDetailModel2);
 			
-			Integer actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
 
 			assertEquals(3, actual);
 			verify(photoMstRepositoryImpl, times(0)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Integer.class));
+			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
 			verify(photoMstRepositoryImpl, times(2)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(2)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(2)).clear(any(PhotoTagDeleteModel.class));
 			verify(fileRepositoryImpl, times(0)).save(any(FileModel.class));
 
 			List<PhotoTagModel> photoTagModelCaptureList = photoTagModelCaptor.getAllValues();
-			assertEquals(1, photoTagModelCaptureList.get(0).getAccountNo());
-			assertEquals(2, photoTagModelCaptureList.get(0).getPhotoNo());
-			assertEquals(1, photoTagModelCaptureList.get(0).getTagNo());
+			assertEquals(1L, photoTagModelCaptureList.get(0).getAccountNo());
+			assertEquals(2L, photoTagModelCaptureList.get(0).getPhotoNo());
+			assertEquals(1L, photoTagModelCaptureList.get(0).getTagNo());
 			assertEquals("太陽", photoTagModelCaptureList.get(0).getTagJapaneseName());
 			assertEquals("sun", photoTagModelCaptureList.get(0).getTagEnglishName());
-			assertEquals(1, photoTagModelCaptureList.get(1).getAccountNo());
-			assertEquals(2, photoTagModelCaptureList.get(1).getPhotoNo());
-			assertEquals(2, photoTagModelCaptureList.get(1).getTagNo());
+			assertEquals(1L, photoTagModelCaptureList.get(1).getAccountNo());
+			assertEquals(2L, photoTagModelCaptureList.get(1).getPhotoNo());
+			assertEquals(2L, photoTagModelCaptureList.get(1).getTagNo());
 			assertEquals("海", photoTagModelCaptureList.get(1).getTagJapaneseName());
 			assertEquals("sea", photoTagModelCaptureList.get(1).getTagEnglishName());
 		}
@@ -670,7 +670,7 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5).when(photoMstRepositoryImpl).getNewPhotoNo(1);
+			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			ArgumentCaptor<PhotoTagDeleteModel> photoTagDeleteModelCaptor = ArgumentCaptor.forClass(PhotoTagDeleteModel.class);
@@ -686,32 +686,32 @@ public class PhotoServiceImplTest {
 			PhotoDetailModel photoDetailModel1 = createNewPhotoWithTag();
 			photoDetailModelList.add(photoDetailModel1);
 			doReturn(false).when(photoMstRepositoryImpl).isExistPhoto(photoDetailModel1);
-			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel1, filePath + accountId + "/DSC111.jpg", 5);
+			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel1, filePath + accountId + "/DSC111.jpg", 5L);
 			
 			// 更新1枚目
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			doNothing().when(photoMstRepositoryImpl).update(photoDetailModel2);
 			
-			Integer actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
 
 			assertEquals(3, actual);
 			verify(photoMstRepositoryImpl, times(1)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(1)).regist(any(PhotoDetailModel.class), any(String.class), any(Integer.class));
+			verify(photoMstRepositoryImpl, times(1)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
 			verify(photoMstRepositoryImpl, times(1)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(2)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(1)).clear(any(PhotoTagDeleteModel.class));
 			verify(fileRepositoryImpl, times(1)).save(any(FileModel.class));
 
 			List<PhotoTagModel> photoTagModelCaptureList = photoTagModelCaptor.getAllValues();
-			assertEquals(1, photoTagModelCaptureList.get(0).getAccountNo());
-			assertEquals(5, photoTagModelCaptureList.get(0).getPhotoNo());
-			assertEquals(1, photoTagModelCaptureList.get(0).getTagNo());
+			assertEquals(1L, photoTagModelCaptureList.get(0).getAccountNo());
+			assertEquals(5L, photoTagModelCaptureList.get(0).getPhotoNo());
+			assertEquals(1L, photoTagModelCaptureList.get(0).getTagNo());
 			assertEquals("太陽", photoTagModelCaptureList.get(0).getTagJapaneseName());
 			assertEquals("sun", photoTagModelCaptureList.get(0).getTagEnglishName());
-			assertEquals(1, photoTagModelCaptureList.get(1).getAccountNo());
-			assertEquals(5, photoTagModelCaptureList.get(1).getPhotoNo());
-			assertEquals(2, photoTagModelCaptureList.get(1).getTagNo());
+			assertEquals(1L, photoTagModelCaptureList.get(1).getAccountNo());
+			assertEquals(5L, photoTagModelCaptureList.get(1).getPhotoNo());
+			assertEquals(2L, photoTagModelCaptureList.get(1).getTagNo());
 			assertEquals("海", photoTagModelCaptureList.get(1).getTagJapaneseName());
 			assertEquals("sea", photoTagModelCaptureList.get(1).getTagEnglishName());
 		}
@@ -724,7 +724,7 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5).when(photoMstRepositoryImpl).getNewPhotoNo(1);
+			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			// 新規登録1枚目
@@ -739,7 +739,7 @@ public class PhotoServiceImplTest {
 			assertThrows(FileDuplicateException.class, () -> photoServiceImpl.savePhotos(accountId, photoDetailModelList));
 			
 			verify(photoMstRepositoryImpl, times(1)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Integer.class));
+			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
 			verify(photoMstRepositoryImpl, times(0)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).clear(any(PhotoTagDeleteModel.class));
@@ -754,14 +754,14 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5).when(photoMstRepositoryImpl).getNewPhotoNo(1);
+			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			// 新規登録1枚目
 			PhotoDetailModel photoDetailModel1 = createNewPhotoWithTag();
 			photoDetailModelList.add(photoDetailModel1);
 			doReturn(false).when(photoMstRepositoryImpl).isExistPhoto(photoDetailModel1);
-			doThrow(RegistFailureException.class).when(photoMstRepositoryImpl).regist(photoDetailModel1, filePath + accountId + "/DSC111.jpg", 5);
+			doThrow(RegistFailureException.class).when(photoMstRepositoryImpl).regist(photoDetailModel1, filePath + accountId + "/DSC111.jpg", 5L);
 			
 			// 更新1枚目
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
@@ -770,7 +770,7 @@ public class PhotoServiceImplTest {
 			assertThrows(RegistFailureException.class, () -> photoServiceImpl.savePhotos(accountId, photoDetailModelList));
 			
 			verify(photoMstRepositoryImpl, times(1)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(1)).regist(any(PhotoDetailModel.class), any(String.class), any(Integer.class));
+			verify(photoMstRepositoryImpl, times(1)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
 			verify(photoMstRepositoryImpl, times(0)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).clear(any(PhotoTagDeleteModel.class));
@@ -785,7 +785,7 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5).when(photoMstRepositoryImpl).getNewPhotoNo(1);
+			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			ArgumentCaptor<PhotoTagModel> photoTagModelCaptor = ArgumentCaptor.forClass(PhotoTagModel.class);
@@ -795,7 +795,7 @@ public class PhotoServiceImplTest {
 			PhotoDetailModel photoDetailModel1 = createNewPhotoWithTag();
 			photoDetailModelList.add(photoDetailModel1);
 			doReturn(false).when(photoMstRepositoryImpl).isExistPhoto(photoDetailModel1);
-			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel1, filePath + accountId + "/DSC111.jpg", 5);
+			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel1, filePath + accountId + "/DSC111.jpg", 5L);
 			
 			// 更新1枚目
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
@@ -804,16 +804,16 @@ public class PhotoServiceImplTest {
 			assertThrows(RegistFailureException.class, () -> photoServiceImpl.savePhotos(accountId, photoDetailModelList));
 			
 			verify(photoMstRepositoryImpl, times(1)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(1)).regist(any(PhotoDetailModel.class), any(String.class), any(Integer.class));
+			verify(photoMstRepositoryImpl, times(1)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
 			verify(photoMstRepositoryImpl, times(0)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(1)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).clear(any(PhotoTagDeleteModel.class));
 			verify(fileRepositoryImpl, times(0)).save(any(FileModel.class));
 			
 			List<PhotoTagModel> photoTagModelCaptureList = photoTagModelCaptor.getAllValues();
-			assertEquals(1, photoTagModelCaptureList.get(0).getAccountNo());
-			assertEquals(5, photoTagModelCaptureList.get(0).getPhotoNo());
-			assertEquals(1, photoTagModelCaptureList.get(0).getTagNo());
+			assertEquals(1L, photoTagModelCaptureList.get(0).getAccountNo());
+			assertEquals(5L, photoTagModelCaptureList.get(0).getPhotoNo());
+			assertEquals(1L, photoTagModelCaptureList.get(0).getTagNo());
 			assertEquals("太陽", photoTagModelCaptureList.get(0).getTagJapaneseName());
 			assertEquals("sun", photoTagModelCaptureList.get(0).getTagEnglishName());
 		}
@@ -826,7 +826,7 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5).when(photoMstRepositoryImpl).getNewPhotoNo(1);
+			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			ArgumentCaptor<PhotoTagDeleteModel> photoTagDeleteModelCaptor = ArgumentCaptor.forClass(PhotoTagDeleteModel.class);
@@ -847,16 +847,16 @@ public class PhotoServiceImplTest {
 			assertThrows(RegistFailureException.class, () -> photoServiceImpl.savePhotos(accountId, photoDetailModelList));
 			
 			verify(photoMstRepositoryImpl, times(0)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Integer.class));
+			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
 			verify(photoMstRepositoryImpl, times(1)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(1)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(1)).clear(any(PhotoTagDeleteModel.class));
 			verify(fileRepositoryImpl, times(0)).save(any(FileModel.class));
 			
 			List<PhotoTagModel> photoTagModelCaptureList = photoTagModelCaptor.getAllValues();
-			assertEquals(1, photoTagModelCaptureList.get(0).getAccountNo());
-			assertEquals(2, photoTagModelCaptureList.get(0).getPhotoNo());
-			assertEquals(1, photoTagModelCaptureList.get(0).getTagNo());
+			assertEquals(1L, photoTagModelCaptureList.get(0).getAccountNo());
+			assertEquals(2L, photoTagModelCaptureList.get(0).getPhotoNo());
+			assertEquals(1L, photoTagModelCaptureList.get(0).getTagNo());
 			assertEquals("太陽", photoTagModelCaptureList.get(0).getTagJapaneseName());
 			assertEquals("sun", photoTagModelCaptureList.get(0).getTagEnglishName());
 		}
@@ -869,7 +869,7 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5).when(photoMstRepositoryImpl).getNewPhotoNo(1);
+			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			// 更新1枚目
@@ -884,7 +884,7 @@ public class PhotoServiceImplTest {
 			assertThrows(UpdateFailureException.class, () -> photoServiceImpl.savePhotos(accountId, photoDetailModelList));
 			
 			verify(photoMstRepositoryImpl, times(0)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Integer.class));
+			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
 			verify(photoMstRepositoryImpl, times(1)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).clear(any(PhotoTagDeleteModel.class));
@@ -929,13 +929,13 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoDeleteModel> photoDeleteModelList = new ArrayList<PhotoDeleteModel>();
 			photoDeleteModelList.add(PhotoDeleteModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.imageFilePath("DSC111.jpg")
 					.build());
 			photoDeleteModelList.add(PhotoDeleteModel.builder()
-					.accountNo(1)
-					.photoNo(2)
+					.accountNo(1L)
+					.photoNo(2L)
 					.imageFilePath("DSC222.jpg")
 					.build());
 			
@@ -947,24 +947,24 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoFavoriteDeleteModel> photoFavoriteDeleteModelCaptureList = photoFavoriteDeleteModelCaptor.getAllValues();
 			assertEquals(null, photoFavoriteDeleteModelCaptureList.get(0).getAccountNo());
-			assertEquals(1, photoFavoriteDeleteModelCaptureList.get(0).getFavoritePhotoAccountNo());
-			assertEquals(1, photoFavoriteDeleteModelCaptureList.get(0).getFavoritePhotoNo());
+			assertEquals(1L, photoFavoriteDeleteModelCaptureList.get(0).getFavoritePhotoAccountNo());
+			assertEquals(1L, photoFavoriteDeleteModelCaptureList.get(0).getFavoritePhotoNo());
 			assertEquals(null, photoFavoriteDeleteModelCaptureList.get(1).getAccountNo());
-			assertEquals(1, photoFavoriteDeleteModelCaptureList.get(1).getFavoritePhotoAccountNo());
-			assertEquals(2, photoFavoriteDeleteModelCaptureList.get(1).getFavoritePhotoNo());
+			assertEquals(1L, photoFavoriteDeleteModelCaptureList.get(1).getFavoritePhotoAccountNo());
+			assertEquals(2L, photoFavoriteDeleteModelCaptureList.get(1).getFavoritePhotoNo());
 			
 			List<PhotoTagDeleteModel> photoTagDeleteModelCaptureList = photoTagDeleteModelCaptor.getAllValues();
-			assertEquals(1, photoTagDeleteModelCaptureList.get(0).getAccountNo());
-			assertEquals(1, photoTagDeleteModelCaptureList.get(0).getPhotoNo());
-			assertEquals(1, photoTagDeleteModelCaptureList.get(1).getAccountNo());
-			assertEquals(2, photoTagDeleteModelCaptureList.get(1).getPhotoNo());
+			assertEquals(1L, photoTagDeleteModelCaptureList.get(0).getAccountNo());
+			assertEquals(1L, photoTagDeleteModelCaptureList.get(0).getPhotoNo());
+			assertEquals(1L, photoTagDeleteModelCaptureList.get(1).getAccountNo());
+			assertEquals(2L, photoTagDeleteModelCaptureList.get(1).getPhotoNo());
 			
 			List<PhotoDeleteModel> photoDeleteModelCaptureList = photoDeleteModelCaptor.getAllValues();
-			assertEquals(1, photoDeleteModelCaptureList.get(0).getAccountNo());
-			assertEquals(1, photoDeleteModelCaptureList.get(0).getPhotoNo());
+			assertEquals(1L, photoDeleteModelCaptureList.get(0).getAccountNo());
+			assertEquals(1L, photoDeleteModelCaptureList.get(0).getPhotoNo());
 			assertEquals("DSC111.jpg", photoDeleteModelCaptureList.get(0).getImageFilePath());
-			assertEquals(1, photoDeleteModelCaptureList.get(1).getAccountNo());
-			assertEquals(2, photoDeleteModelCaptureList.get(1).getPhotoNo());
+			assertEquals(1L, photoDeleteModelCaptureList.get(1).getAccountNo());
+			assertEquals(2L, photoDeleteModelCaptureList.get(1).getPhotoNo());
 			assertEquals("DSC222.jpg", photoDeleteModelCaptureList.get(1).getImageFilePath());
 			
 			List<String> fileDeleteCaptureList = fileDeleteCaptor.getAllValues();
@@ -984,8 +984,8 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoDeleteModel> photoDeleteModelList = new ArrayList<PhotoDeleteModel>();
 			photoDeleteModelList.add(PhotoDeleteModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.imageFilePath("https://www.xxx.com/DSC111.jpg")
 					.build());
 			
@@ -996,8 +996,8 @@ public class PhotoServiceImplTest {
 			verify(fileRepositoryImpl, times(0)).delete(any(String.class));
 			
 			PhotoFavoriteDeleteModel photoFavoriteDeleteModelCapture = photoFavoriteDeleteModelCaptor.getValue();
-			assertEquals(1, photoFavoriteDeleteModelCapture.getFavoritePhotoAccountNo());
-			assertEquals(1, photoFavoriteDeleteModelCapture.getFavoritePhotoNo());
+			assertEquals(1L, photoFavoriteDeleteModelCapture.getFavoritePhotoAccountNo());
+			assertEquals(1L, photoFavoriteDeleteModelCapture.getFavoritePhotoNo());
 		}
 	}
 	
@@ -1010,8 +1010,8 @@ public class PhotoServiceImplTest {
 		@DisplayName("正常系：アカウント番号がnullの場合")
 		void isReachedUpperLimit_accountNo_is_null() {
 			assertTrue(photoServiceImpl.isReachedUpperLimit(null));
-			verify(accountRepositoryImpl, times(0)).getByAccountNo(any(Integer.class));
-			verify(photoMstRepositoryImpl, times(0)).count(any(Integer.class));
+			verify(accountRepositoryImpl, times(0)).getByAccountNo(any(Long.class));
+			verify(photoMstRepositoryImpl, times(0)).count(any(Long.class));
 			verify(photoConfig, times(0)).getMiniUserUpperLimit();
 			verify(photoConfig, times(0)).getNormalUserUpperLimit();
 		}
@@ -1020,7 +1020,7 @@ public class PhotoServiceImplTest {
 		@Order(2)
 		@DisplayName("正常系：mini-userで、上限まで登録済みの場合")
 		void isReachedUpperLimit_mini_user_reached() {
-			Integer accountNo = 1;
+			Long accountNo = 1L;
 			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.MINI).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(10).when(photoMstRepositoryImpl).count(accountNo);
@@ -1032,7 +1032,7 @@ public class PhotoServiceImplTest {
 		@Order(3)
 		@DisplayName("正常系：mini-userで、上限まで未登録の場合")
 		void isReachedUpperLimit_mini_user_not_reached() {
-			Integer accountNo = 1;
+			Long accountNo = 1L;
 			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.MINI).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(9).when(photoMstRepositoryImpl).count(accountNo);
@@ -1044,7 +1044,7 @@ public class PhotoServiceImplTest {
 		@Order(4)
 		@DisplayName("正常系：normal-userで、上限まで登録済みの場合")
 		void isReachedUpperLimit_normal_user_reached() {
-			Integer accountNo = 1;
+			Long accountNo = 1L;
 			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.NORMAL).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(1000).when(photoMstRepositoryImpl).count(accountNo);
@@ -1056,7 +1056,7 @@ public class PhotoServiceImplTest {
 		@Order(5)
 		@DisplayName("正常系：normal-userで、上限まで未登録の場合")
 		void isReachedUpperLimit_normal_user_not_reached() {
-			Integer accountNo = 1;
+			Long accountNo = 1L;
 			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.NORMAL).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(999).when(photoMstRepositoryImpl).count(accountNo);
@@ -1068,7 +1068,7 @@ public class PhotoServiceImplTest {
 		@Order(6)
 		@DisplayName("正常系：special-userの場合")
 		void isReachedUpperLimit_special_user() {
-			Integer accountNo = 1;
+			Long accountNo = 1L;
 			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.SPECIAL).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(1000).when(photoMstRepositoryImpl).count(accountNo);
@@ -1079,7 +1079,7 @@ public class PhotoServiceImplTest {
 		@Order(7)
 		@DisplayName("正常系：administratorの場合")
 		void isReachedUpperLimit_administrator() {
-			Integer accountNo = 1;
+			Long accountNo = 1L;
 			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.ADMINISTRATOR).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(1000).when(photoMstRepositoryImpl).count(accountNo);
@@ -1103,8 +1103,8 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoModel> photoModelList = new ArrayList<PhotoModel>();
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.favoriteCount(1)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2002, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1114,8 +1114,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(2)
+					.accountNo(1L)
+					.photoNo(2L)
 					.favoriteCount(3)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2002, 2, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1125,8 +1125,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(3)
+					.accountNo(1L)
+					.photoNo(3L)
 					.favoriteCount(2)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2002, 3, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1136,8 +1136,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(4)
+					.accountNo(1L)
+					.photoNo(4L)
 					.favoriteCount(2)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2001, 3, 31, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1147,8 +1147,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(5)
+					.accountNo(1L)
+					.photoNo(5L)
 					.favoriteCount(3)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2003, 3, 31, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1159,11 +1159,11 @@ public class PhotoServiceImplTest {
 					.build());
 			
 			List<PhotoModel> actualData = photoModelList.stream().sorted(actual).toList();
-			assertEquals(5, actualData.get(0).getPhotoNo());
-			assertEquals(3, actualData.get(1).getPhotoNo());
-			assertEquals(2, actualData.get(2).getPhotoNo());
-			assertEquals(1, actualData.get(3).getPhotoNo());
-			assertEquals(4, actualData.get(4).getPhotoNo());
+			assertEquals(5L, actualData.get(0).getPhotoNo());
+			assertEquals(3L, actualData.get(1).getPhotoNo());
+			assertEquals(2L, actualData.get(2).getPhotoNo());
+			assertEquals(1L, actualData.get(3).getPhotoNo());
+			assertEquals(4L, actualData.get(4).getPhotoNo());
 		}
 		
 		@Test
@@ -1178,8 +1178,8 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoModel> photoModelList = new ArrayList<PhotoModel>();
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.favoriteCount(1)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2002, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1189,8 +1189,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(2)
+					.accountNo(1L)
+					.photoNo(2L)
 					.favoriteCount(3)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2002, 2, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1200,8 +1200,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(3)
+					.accountNo(1L)
+					.photoNo(3L)
 					.favoriteCount(2)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2002, 3, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1211,8 +1211,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(4)
+					.accountNo(1L)
+					.photoNo(4L)
 					.favoriteCount(2)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2001, 3, 31, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1222,8 +1222,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(5)
+					.accountNo(1L)
+					.photoNo(5L)
 					.favoriteCount(3)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2003, 3, 31, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1234,11 +1234,11 @@ public class PhotoServiceImplTest {
 					.build());
 			
 			List<PhotoModel> actualData = photoModelList.stream().sorted(actual).toList();
-			assertEquals(2, actualData.get(0).getPhotoNo());
-			assertEquals(5, actualData.get(1).getPhotoNo());
-			assertEquals(3, actualData.get(2).getPhotoNo());
-			assertEquals(4, actualData.get(3).getPhotoNo());
-			assertEquals(1, actualData.get(4).getPhotoNo());
+			assertEquals(2L, actualData.get(0).getPhotoNo());
+			assertEquals(5L, actualData.get(1).getPhotoNo());
+			assertEquals(3L, actualData.get(2).getPhotoNo());
+			assertEquals(4L, actualData.get(3).getPhotoNo());
+			assertEquals(1L, actualData.get(4).getPhotoNo());
 		}
 		
 		@Test
@@ -1253,8 +1253,8 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoModel> photoModelList = new ArrayList<PhotoModel>();
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.favoriteCount(1)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2002, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1264,8 +1264,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(2)
+					.accountNo(1L)
+					.photoNo(2L)
 					.favoriteCount(3)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2002, 2, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1275,8 +1275,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(3)
+					.accountNo(1L)
+					.photoNo(3L)
 					.favoriteCount(2)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2002, 3, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1286,8 +1286,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(4)
+					.accountNo(1L)
+					.photoNo(4L)
 					.favoriteCount(2)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2001, 3, 31, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1297,8 +1297,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(5)
+					.accountNo(1L)
+					.photoNo(5L)
 					.favoriteCount(3)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2003, 3, 31, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1309,11 +1309,11 @@ public class PhotoServiceImplTest {
 					.build());
 			
 			List<PhotoModel> actualData = photoModelList.stream().sorted(actual).toList();
-			assertEquals(4, actualData.get(0).getPhotoNo());
-			assertEquals(5, actualData.get(1).getPhotoNo());
-			assertEquals(3, actualData.get(2).getPhotoNo());
-			assertEquals(2, actualData.get(3).getPhotoNo());
-			assertEquals(1, actualData.get(4).getPhotoNo());
+			assertEquals(4L, actualData.get(0).getPhotoNo());
+			assertEquals(5L, actualData.get(1).getPhotoNo());
+			assertEquals(3L, actualData.get(2).getPhotoNo());
+			assertEquals(2L, actualData.get(3).getPhotoNo());
+			assertEquals(1L, actualData.get(4).getPhotoNo());
 		}
 		
 		@Test
@@ -1328,8 +1328,8 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoModel> photoModelList = new ArrayList<PhotoModel>();
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.favoriteCount(1)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2002, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1339,8 +1339,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(2)
+					.accountNo(1L)
+					.photoNo(2L)
 					.favoriteCount(3)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2002, 2, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1350,8 +1350,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(3)
+					.accountNo(1L)
+					.photoNo(3L)
 					.favoriteCount(2)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2002, 3, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1361,8 +1361,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(4)
+					.accountNo(1L)
+					.photoNo(4L)
 					.favoriteCount(2)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2001, 3, 31, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1372,8 +1372,8 @@ public class PhotoServiceImplTest {
 					.photoTagModelList(new ArrayList<PhotoTagModel>())
 					.build());
 			photoModelList.add(PhotoModel.builder()
-					.accountNo(1)
-					.photoNo(5)
+					.accountNo(1L)
+					.photoNo(5L)
 					.favoriteCount(3)
 					.isFavorite(false)
 					.photoAt(OffsetDateTime.of(2003, 3, 31, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
@@ -1384,11 +1384,11 @@ public class PhotoServiceImplTest {
 					.build());
 			
 			List<PhotoModel> actualData = photoModelList.stream().sorted(actual).toList();
-			assertEquals(5, actualData.get(0).getPhotoNo());
-			assertEquals(3, actualData.get(1).getPhotoNo());
-			assertEquals(2, actualData.get(2).getPhotoNo());
-			assertEquals(1, actualData.get(3).getPhotoNo());
-			assertEquals(4, actualData.get(4).getPhotoNo());
+			assertEquals(5L, actualData.get(0).getPhotoNo());
+			assertEquals(3L, actualData.get(1).getPhotoNo());
+			assertEquals(2L, actualData.get(2).getPhotoNo());
+			assertEquals(1L, actualData.get(3).getPhotoNo());
+			assertEquals(4L, actualData.get(4).getPhotoNo());
 		}
 	}
 	
@@ -1490,23 +1490,23 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoTagModel> photoTagModelList = new ArrayList<PhotoTagModel>();
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build());
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.tagJapaneseName("月")
 					.tagEnglishName("moon")
 					.build());
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build());
@@ -1528,23 +1528,23 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoTagModel> photoTagModelList = new ArrayList<PhotoTagModel>();
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build());
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.tagJapaneseName("月")
 					.tagEnglishName("moon")
 					.build());
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build());
@@ -1566,7 +1566,7 @@ public class PhotoServiceImplTest {
 		@Order(1)
 		@DisplayName("正常系：photoTagModelListがnullの場合")
 		void registPhotoTags_photoTagModelList_is_null() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, RegistFailureException {
-			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", List.class, Integer.class);
+			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", List.class, Long.class);
 			registPhotoTags.setAccessible(true);
 			
 			registPhotoTags.invoke(photoServiceImpl, null, null);
@@ -1578,7 +1578,7 @@ public class PhotoServiceImplTest {
 		@Order(2)
 		@DisplayName("正常系：photoTagModelListがemptyの場合")
 		void registPhotoTags_photoTagModelList_is_empty() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, RegistFailureException {
-			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", List.class, Integer.class);
+			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", List.class, Long.class);
 			registPhotoTags.setAccessible(true);
 			
 			registPhotoTags.invoke(photoServiceImpl, new ArrayList<PhotoTagModel>(), null);
@@ -1590,7 +1590,7 @@ public class PhotoServiceImplTest {
 		@Order(3)
 		@DisplayName("正常系：newPhotoNoがnullの場合")
 		void registPhotoTags_newPhotoNo_is_null() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, RegistFailureException {
-			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", List.class, Integer.class);
+			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", List.class, Long.class);
 			registPhotoTags.setAccessible(true);
 			
 			ArgumentCaptor<PhotoTagModel> photoTagModelCaptor = ArgumentCaptor.forClass(PhotoTagModel.class);
@@ -1598,16 +1598,16 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoTagModel> photoTagModelList = new ArrayList<PhotoTagModel>();
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build());
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(2)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(2L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build());
@@ -1617,14 +1617,14 @@ public class PhotoServiceImplTest {
 			verify(photoTagMstRepositoryImpl, times(2)).regist(any(PhotoTagModel.class));
 			
 			List<PhotoTagModel> photoTagModelCaptureList = photoTagModelCaptor.getAllValues();
-			assertEquals(1, photoTagModelCaptureList.get(0).getAccountNo());
-			assertEquals(1, photoTagModelCaptureList.get(0).getPhotoNo());
-			assertEquals(1, photoTagModelCaptureList.get(0).getTagNo());
+			assertEquals(1L, photoTagModelCaptureList.get(0).getAccountNo());
+			assertEquals(1L, photoTagModelCaptureList.get(0).getPhotoNo());
+			assertEquals(1L, photoTagModelCaptureList.get(0).getTagNo());
 			assertEquals("太陽", photoTagModelCaptureList.get(0).getTagJapaneseName());
 			assertEquals("sun", photoTagModelCaptureList.get(0).getTagEnglishName());
-			assertEquals(1, photoTagModelCaptureList.get(1).getAccountNo());
-			assertEquals(1, photoTagModelCaptureList.get(1).getPhotoNo());
-			assertEquals(2, photoTagModelCaptureList.get(1).getTagNo());
+			assertEquals(1L, photoTagModelCaptureList.get(1).getAccountNo());
+			assertEquals(1L, photoTagModelCaptureList.get(1).getPhotoNo());
+			assertEquals(2L, photoTagModelCaptureList.get(1).getTagNo());
 			assertEquals("海", photoTagModelCaptureList.get(1).getTagJapaneseName());
 			assertEquals("sea", photoTagModelCaptureList.get(1).getTagEnglishName());
 		}
@@ -1633,7 +1633,7 @@ public class PhotoServiceImplTest {
 		@Order(4)
 		@DisplayName("正常系：newPhotoNoがnullでない場合")
 		void registPhotoTags_newPhotoNo_is_not_null() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, RegistFailureException {
-			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", List.class, Integer.class);
+			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", List.class, Long.class);
 			registPhotoTags.setAccessible(true);
 			
 			ArgumentCaptor<PhotoTagModel> photoTagModelCaptor = ArgumentCaptor.forClass(PhotoTagModel.class);
@@ -1641,33 +1641,33 @@ public class PhotoServiceImplTest {
 			
 			List<PhotoTagModel> photoTagModelList = new ArrayList<PhotoTagModel>();
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build());
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(2)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(2L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build());
 			
-			registPhotoTags.invoke(photoServiceImpl, photoTagModelList, 3);
+			registPhotoTags.invoke(photoServiceImpl, photoTagModelList, 3L);
 			
 			verify(photoTagMstRepositoryImpl, times(2)).regist(any(PhotoTagModel.class));
 			
 			List<PhotoTagModel> photoTagModelCaptureList = photoTagModelCaptor.getAllValues();
-			assertEquals(1, photoTagModelCaptureList.get(0).getAccountNo());
-			assertEquals(3, photoTagModelCaptureList.get(0).getPhotoNo());
-			assertEquals(1, photoTagModelCaptureList.get(0).getTagNo());
+			assertEquals(1L, photoTagModelCaptureList.get(0).getAccountNo());
+			assertEquals(3L, photoTagModelCaptureList.get(0).getPhotoNo());
+			assertEquals(1L, photoTagModelCaptureList.get(0).getTagNo());
 			assertEquals("太陽", photoTagModelCaptureList.get(0).getTagJapaneseName());
 			assertEquals("sun", photoTagModelCaptureList.get(0).getTagEnglishName());
-			assertEquals(1, photoTagModelCaptureList.get(1).getAccountNo());
-			assertEquals(3, photoTagModelCaptureList.get(1).getPhotoNo());
-			assertEquals(2, photoTagModelCaptureList.get(1).getTagNo());
+			assertEquals(1L, photoTagModelCaptureList.get(1).getAccountNo());
+			assertEquals(3L, photoTagModelCaptureList.get(1).getPhotoNo());
+			assertEquals(2L, photoTagModelCaptureList.get(1).getTagNo());
 			assertEquals("海", photoTagModelCaptureList.get(1).getTagJapaneseName());
 			assertEquals("sea", photoTagModelCaptureList.get(1).getTagEnglishName());
 		}
@@ -1676,23 +1676,23 @@ public class PhotoServiceImplTest {
 		@Order(5)
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
 		void registPhotoTags_RegistFailureException() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, RegistFailureException {
-			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", List.class, Integer.class);
+			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", List.class, Long.class);
 			registPhotoTags.setAccessible(true);
 			
 			doThrow(new RegistFailureException(ErrorEnum.FAIL_TO_REGIST_PHOTO_TAG)).when(photoTagMstRepositoryImpl).regist(any(PhotoTagModel.class));
 			
 			List<PhotoTagModel> photoTagModelList = new ArrayList<PhotoTagModel>();
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build());
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(1)
-					.tagNo(2)
+					.accountNo(1L)
+					.photoNo(1L)
+					.tagNo(2L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build());
@@ -1748,18 +1748,18 @@ public class PhotoServiceImplTest {
 		@Order(1)
 		@DisplayName("正常系")
 		void deletePhotoTags_success() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
-			Method deletePhotoTags = PhotoServiceImpl.class.getDeclaredMethod("deletePhotoTags", Integer.class, Integer.class);
+			Method deletePhotoTags = PhotoServiceImpl.class.getDeclaredMethod("deletePhotoTags", Long.class, Long.class);
 			deletePhotoTags.setAccessible(true);
 			
 			ArgumentCaptor<PhotoTagDeleteModel> photoTagDeleteModelCaptor = ArgumentCaptor.forClass(PhotoTagDeleteModel.class);
 			doNothing().when(photoTagMstRepositoryImpl).clear(photoTagDeleteModelCaptor.capture());
 			
-			deletePhotoTags.invoke(photoServiceImpl, 1, 1);
+			deletePhotoTags.invoke(photoServiceImpl, 1L, 1L);
 			
 			verify(photoTagMstRepositoryImpl).clear(any(PhotoTagDeleteModel.class));
 			PhotoTagDeleteModel photoTagDeleteModelCapture = photoTagDeleteModelCaptor.getValue();
-			assertEquals(1, photoTagDeleteModelCapture.getAccountNo());
-			assertEquals(1, photoTagDeleteModelCapture.getPhotoNo());
+			assertEquals(1L, photoTagDeleteModelCapture.getAccountNo());
+			assertEquals(1L, photoTagDeleteModelCapture.getPhotoNo());
 		}
 	}
 }

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/AccountServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/AccountServiceImplIntegrationTest.java
@@ -92,10 +92,10 @@ public class AccountServiceImplIntegrationTest {
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_id='mmmmmmmm'", (rs, rowNum) ->
 						Account.builder()
-							.accountNo(rs.getInt("account_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.accountId(rs.getString("account_id"))
@@ -112,9 +112,9 @@ public class AccountServiceImplIntegrationTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(0, actualData.getFirst().getCreatedBy());
-			assertEquals(0, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(0L, actualData.getFirst().getCreatedBy());
+			assertEquals(0L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("mmmmmmmm", actualData.getFirst().getAccountId());
 			assertEquals("MMMMMMMM", actualData.getFirst().getAccountName());
@@ -153,16 +153,16 @@ public class AccountServiceImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントを更新")
 		void updateAccount_success() throws UpdateFailureException {
-			AccountModel accountModel = AccountModel.builder().accountNo(1).accountId("zzzzzzzz").build();
+			AccountModel accountModel = AccountModel.builder().accountNo(1L).accountId("zzzzzzzz").build();
 			assertFalse(accountServiceImpl.updateAccount(accountModel));
 			
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_no=1", (rs, rowNum) ->
 						Account.builder()
-							.accountNo(rs.getInt("account_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.accountId(rs.getString("account_id"))
@@ -179,9 +179,9 @@ public class AccountServiceImplIntegrationTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("zzzzzzzz", actualData.getFirst().getAccountId());
 			assertEquals("AAAAAAAA", actualData.getFirst().getAccountName());
@@ -200,16 +200,16 @@ public class AccountServiceImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが既に存在する")
 		void updateAccount_account_already_exist() throws UpdateFailureException {
-			AccountModel accountModel = AccountModel.builder().accountNo(1).accountId("bbbbbbbb").build();
+			AccountModel accountModel = AccountModel.builder().accountNo(1L).accountId("bbbbbbbb").build();
 			assertTrue(accountServiceImpl.updateAccount(accountModel));
 			
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_no=1", (rs, rowNum) ->
 						Account.builder()
-							.accountNo(rs.getInt("account_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.accountId(rs.getString("account_id"))
@@ -226,9 +226,9 @@ public class AccountServiceImplIntegrationTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("aaaaaaaa", actualData.getFirst().getAccountId());
 			assertEquals("AAAAAAAA", actualData.getFirst().getAccountName());
@@ -247,7 +247,7 @@ public class AccountServiceImplIntegrationTest {
 		@Order(3)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
 		void updateAccount_UpdateFailureException() throws UpdateFailureException {
-			AccountModel accountModel = AccountModel.builder().accountNo(99).accountId("zzzzzzzz").build();
+			AccountModel accountModel = AccountModel.builder().accountNo(99L).accountId("zzzzzzzz").build();
 			assertThrows(UpdateFailureException.class, () -> accountServiceImpl.updateAccount(accountModel));
 		}
 	}
@@ -264,7 +264,7 @@ public class AccountServiceImplIntegrationTest {
 		void getAccountById_found() {
 			AccountModel actual = accountServiceImpl.getAccountById("aaaaaaaa");
 
-			assertEquals(1, actual.getAccountNo());
+			assertEquals(1L, actual.getAccountNo());
 			assertEquals("aaaaaaaa", actual.getAccountId());
 			assertEquals("AAAAAAAA", actual.getAccountName());
 			assertEquals("$2a$10$password1", actual.getPassword());
@@ -345,10 +345,10 @@ public class AccountServiceImplIntegrationTest {
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_no=11", (rs, rowNum) ->
 						Account.builder()
-							.accountNo(rs.getInt("account_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.accountId(rs.getString("account_id"))
@@ -365,9 +365,9 @@ public class AccountServiceImplIntegrationTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(11, actualData.getFirst().getAccountNo());
-			assertEquals(11, actualData.getFirst().getCreatedBy());
-			assertEquals(11, actualData.getFirst().getUpdatedBy());
+			assertEquals(11L, actualData.getFirst().getAccountNo());
+			assertEquals(11L, actualData.getFirst().getCreatedBy());
+			assertEquals(11L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("kkkkkkkk", actualData.getFirst().getAccountId());
 			assertEquals("KKKKKKKK", actualData.getFirst().getAccountName());
@@ -410,10 +410,10 @@ public class AccountServiceImplIntegrationTest {
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_id='aaaaaaaa'", (rs, rowNum) ->
 						Account.builder()
-							.accountNo(rs.getInt("account_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.accountId(rs.getString("account_id"))
@@ -430,9 +430,9 @@ public class AccountServiceImplIntegrationTest {
 							.build());
 			
 			assertEquals(1, actualData.size());
-			assertEquals(1, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getCreatedBy());
-			assertEquals(1, actualData.getFirst().getUpdatedBy());
+			assertEquals(1L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getCreatedBy());
+			assertEquals(1L, actualData.getFirst().getUpdatedBy());
 			assertFalse(actualData.getFirst().getIsDeleted());
 			assertEquals("aaaaaaaa", actualData.getFirst().getAccountId());
 			assertEquals("AAAAAAAA", actualData.getFirst().getAccountName());
@@ -468,10 +468,10 @@ public class AccountServiceImplIntegrationTest {
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_id='zzzzzzzz'", (rs, rowNum) ->
 						Account.builder()
-							.accountNo(rs.getInt("account_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.accountId(rs.getString("account_id"))

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/AuthServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/AuthServiceImplIntegrationTest.java
@@ -108,7 +108,7 @@ public class AuthServiceImplIntegrationTest {
 			String tokenHash = hashToken(result.getRefreshToken());
 			RefreshTokenModel storedToken = refreshTokenRepository.findByTokenHash(tokenHash);
 			assertNotNull(storedToken);
-			assertEquals(1, storedToken.getAccountNo());
+			assertEquals(1L, storedToken.getAccountNo());
 			assertFalse(storedToken.getIsRevoked());
 			assertTrue(storedToken.getExpiresAt().isAfter(OffsetDateTime.now()));
 		}

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoFavoriteServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoFavoriteServiceImplIntegrationTest.java
@@ -46,9 +46,9 @@ public class PhotoFavoriteServiceImplIntegrationTest {
 		@DisplayName("正常系")
 		void addFavorite_success() throws RegistFailureException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
-					.accountNo(2)
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.accountNo(2L)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			
 			photoFavoriteServiceImpl.addFavorite(photoFavoriteModel);
@@ -56,17 +56,17 @@ public class PhotoFavoriteServiceImplIntegrationTest {
 			List<PhotoFavorite> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite WHERE account_no=2 and favorite_photo_account_no=1 and favorite_photo_no=1", (rs, rowNum) ->
 						PhotoFavorite.builder()
-							.accountNo(rs.getInt("account_no"))
-							.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-							.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+							.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.build());
 			assertEquals(1, actualData.size());
-			assertEquals(2, actualData.getFirst().getAccountNo());
-			assertEquals(1, actualData.getFirst().getFavoritePhotoAccountNo());
-			assertEquals(1, actualData.getFirst().getFavoritePhotoNo());
-			assertEquals(2, actualData.getFirst().getCreatedBy());
+			assertEquals(2L, actualData.getFirst().getAccountNo());
+			assertEquals(1L, actualData.getFirst().getFavoritePhotoAccountNo());
+			assertEquals(1L, actualData.getFirst().getFavoritePhotoNo());
+			assertEquals(2L, actualData.getFirst().getCreatedBy());
 		}
 		
 		@Test
@@ -74,9 +74,9 @@ public class PhotoFavoriteServiceImplIntegrationTest {
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
 		void addFavorite_RegistFailureException() throws RegistFailureException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			
 			assertThrows(RegistFailureException.class, () -> photoFavoriteServiceImpl.addFavorite(photoFavoriteModel));
@@ -94,9 +94,9 @@ public class PhotoFavoriteServiceImplIntegrationTest {
 		@DisplayName("正常系")
 		void deleteFavorite_success() throws UpdateFailureException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
-					.accountNo(1)
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.accountNo(1L)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			
 			photoFavoriteServiceImpl.deleteFavorite(photoFavoriteModel);
@@ -104,10 +104,10 @@ public class PhotoFavoriteServiceImplIntegrationTest {
 			List<PhotoFavorite> actualData = jdbcTemplate.query(
 			"SELECT * FROM photo.photo_favorite WHERE account_no=1 and favorite_photo_account_no=2 and favorite_photo_no=1", (rs, rowNum) ->
 				PhotoFavorite.builder()
-					.accountNo(rs.getInt("account_no"))
-					.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-					.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-					.createdBy(rs.getInt("created_by"))
+					.accountNo(rs.getLong("account_no"))
+					.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+					.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+					.createdBy(rs.getLong("created_by"))
 					.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 					.build());
 			assertEquals(0, actualData.size());
@@ -115,10 +115,10 @@ public class PhotoFavoriteServiceImplIntegrationTest {
 			List<PhotoFavorite> actualRestData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite", (rs, rowNum) ->
 						PhotoFavorite.builder()
-							.accountNo(rs.getInt("account_no"))
-							.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-							.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+							.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.build());
 			assertEquals(3, actualRestData.size());
@@ -129,9 +129,9 @@ public class PhotoFavoriteServiceImplIntegrationTest {
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
 		void deleteFavorite_UpdateFailureException() throws UpdateFailureException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
-					.accountNo(9)
-					.favoritePhotoAccountNo(1)
-					.favoritePhotoNo(1)
+					.accountNo(9L)
+					.favoritePhotoAccountNo(1L)
+					.favoritePhotoNo(1L)
 					.build();
 			
 			assertThrows(UpdateFailureException.class, () ->photoFavoriteServiceImpl.deleteFavorite(photoFavoriteModel));

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoServiceImplIntegrationTest.java
@@ -64,7 +64,7 @@ public class PhotoServiceImplIntegrationTest {
 			List<String> tags = new ArrayList<String>();
 			
 			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.photoAccountId("dddddddd")
 					.directionKbn(DirectionEnum.NONE)
 					.isFavoriteOnly(false)
@@ -83,7 +83,7 @@ public class PhotoServiceImplIntegrationTest {
 			List<String> tags = new ArrayList<String>();
 			
 			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.photoAccountId("aaaaaaaa")
 					.directionKbn(DirectionEnum.NONE)
 					.isFavoriteOnly(false)
@@ -97,19 +97,19 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(10, actual.size());
 			
 			// List<PhotoModel>の並び順チェック
-			assertEquals(9, actual.get(0).getPhotoNo());
-			assertEquals(8, actual.get(1).getPhotoNo());
-			assertEquals(7, actual.get(2).getPhotoNo());
-			assertEquals(6, actual.get(3).getPhotoNo());
-			assertEquals(5, actual.get(4).getPhotoNo());
-			assertEquals(4, actual.get(5).getPhotoNo());
-			assertEquals(10, actual.get(6).getPhotoNo());
-			assertEquals(3, actual.get(7).getPhotoNo());
-			assertEquals(2, actual.get(8).getPhotoNo());
-			assertEquals(1, actual.get(9).getPhotoNo());
+			assertEquals(9L, actual.get(0).getPhotoNo());
+			assertEquals(8L, actual.get(1).getPhotoNo());
+			assertEquals(7L, actual.get(2).getPhotoNo());
+			assertEquals(6L, actual.get(3).getPhotoNo());
+			assertEquals(5L, actual.get(4).getPhotoNo());
+			assertEquals(4L, actual.get(5).getPhotoNo());
+			assertEquals(10L, actual.get(6).getPhotoNo());
+			assertEquals(3L, actual.get(7).getPhotoNo());
+			assertEquals(2L, actual.get(8).getPhotoNo());
+			assertEquals(1L, actual.get(9).getPhotoNo());
 			
 			// 抜き取りで、PhotoModelのデータチェック
-			assertEquals(1, actual.get(0).getAccountNo());
+			assertEquals(1L, actual.get(0).getAccountNo());
 			assertEquals(0, actual.get(0).getFavoriteCount());
 			assertFalse(actual.get(0).getIsFavorite());
 			assertEquals(OffsetDateTime.of(2023, 9, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt());
@@ -126,7 +126,7 @@ public class PhotoServiceImplIntegrationTest {
 			List<String> tags = new ArrayList<String>();
 			
 			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.photoAccountId("aaaaaaaa")
 					.directionKbn(DirectionEnum.NONE)
 					.isFavoriteOnly(false)
@@ -140,19 +140,19 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(10, actual.size());
 			
 			// List<PhotoModel>の並び順チェック
-			assertEquals(2, actual.get(0).getPhotoNo());
-			assertEquals(1, actual.get(1).getPhotoNo());
-			assertEquals(3, actual.get(2).getPhotoNo());
-			assertEquals(4, actual.get(3).getPhotoNo());
-			assertEquals(5, actual.get(4).getPhotoNo());
-			assertEquals(6, actual.get(5).getPhotoNo());
-			assertEquals(7, actual.get(6).getPhotoNo());
-			assertEquals(8, actual.get(7).getPhotoNo());
-			assertEquals(9, actual.get(8).getPhotoNo());
-			assertEquals(10, actual.get(9).getPhotoNo());
+			assertEquals(2L, actual.get(0).getPhotoNo());
+			assertEquals(1L, actual.get(1).getPhotoNo());
+			assertEquals(3L, actual.get(2).getPhotoNo());
+			assertEquals(4L, actual.get(3).getPhotoNo());
+			assertEquals(5L, actual.get(4).getPhotoNo());
+			assertEquals(6L, actual.get(5).getPhotoNo());
+			assertEquals(7L, actual.get(6).getPhotoNo());
+			assertEquals(8L, actual.get(7).getPhotoNo());
+			assertEquals(9L, actual.get(8).getPhotoNo());
+			assertEquals(10L, actual.get(9).getPhotoNo());
 			
 			// 抜き取りで、PhotoModelのデータチェック
-			assertEquals(1, actual.get(0).getAccountNo());
+			assertEquals(1L, actual.get(0).getAccountNo());
 			assertEquals(4, actual.get(0).getFavoriteCount());
 			assertTrue(actual.get(0).getIsFavorite());
 			assertEquals(OffsetDateTime.of(2021, 2, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt());
@@ -163,9 +163,9 @@ public class PhotoServiceImplIntegrationTest {
 			
 			// 抜き取りで、PhotoTagModelのデータチェック
 			PhotoTagModel actualTag = actual.get(0).getPhotoTagModelList().stream().filter(tag -> tag.getTagNo() == 1).toList().getFirst();
-			assertEquals(1, actualTag.getAccountNo());
-			assertEquals(2, actualTag.getPhotoNo());
-			assertEquals(1, actualTag.getTagNo());
+			assertEquals(1L, actualTag.getAccountNo());
+			assertEquals(2L, actualTag.getPhotoNo());
+			assertEquals(1L, actualTag.getTagNo());
 			assertEquals("太陽", actualTag.getTagJapaneseName());
 			assertEquals("sun", actualTag.getTagEnglishName());
 		}
@@ -177,7 +177,7 @@ public class PhotoServiceImplIntegrationTest {
 			List<String> tags = new ArrayList<String>();
 			
 			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.photoAccountId("aaaaaaaa")
 					.directionKbn(DirectionEnum.NONE)
 					.isFavoriteOnly(false)
@@ -191,19 +191,19 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(10, actual.size());
 			
 			// List<PhotoModel>の並び順チェック
-			assertEquals(10, actual.get(0).getPhotoNo());
-			assertEquals(9, actual.get(1).getPhotoNo());
-			assertEquals(8, actual.get(2).getPhotoNo());
-			assertEquals(7, actual.get(3).getPhotoNo());
-			assertEquals(6, actual.get(4).getPhotoNo());
-			assertEquals(5, actual.get(5).getPhotoNo());
-			assertEquals(4, actual.get(6).getPhotoNo());
-			assertEquals(3, actual.get(7).getPhotoNo());
-			assertEquals(2, actual.get(8).getPhotoNo());
-			assertEquals(1, actual.get(9).getPhotoNo());
+			assertEquals(10L, actual.get(0).getPhotoNo());
+			assertEquals(9L, actual.get(1).getPhotoNo());
+			assertEquals(8L, actual.get(2).getPhotoNo());
+			assertEquals(7L, actual.get(3).getPhotoNo());
+			assertEquals(6L, actual.get(4).getPhotoNo());
+			assertEquals(5L, actual.get(5).getPhotoNo());
+			assertEquals(4L, actual.get(6).getPhotoNo());
+			assertEquals(3L, actual.get(7).getPhotoNo());
+			assertEquals(2L, actual.get(8).getPhotoNo());
+			assertEquals(1L, actual.get(9).getPhotoNo());
 			
 			// 抜き取りで、PhotoModelのデータチェック
-			assertEquals(1, actual.get(0).getAccountNo());
+			assertEquals(1L, actual.get(0).getAccountNo());
 			assertEquals(0, actual.get(0).getFavoriteCount());
 			assertFalse(actual.get(0).getIsFavorite());
 			assertEquals(OffsetDateTime.of(2021, 10, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt());
@@ -220,7 +220,7 @@ public class PhotoServiceImplIntegrationTest {
 			List<String> tags = new ArrayList<String>();
 			
 			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.photoAccountId("aaaaaaaa")
 					.directionKbn(DirectionEnum.VERTICAL)
 					.isFavoriteOnly(false)
@@ -234,12 +234,12 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(3, actual.size());
 			
 			// List<PhotoModel>の並び順チェック
-			assertEquals(8, actual.get(0).getPhotoNo());
-			assertEquals(7, actual.get(1).getPhotoNo());
-			assertEquals(5, actual.get(2).getPhotoNo());
+			assertEquals(8L, actual.get(0).getPhotoNo());
+			assertEquals(7L, actual.get(1).getPhotoNo());
+			assertEquals(5L, actual.get(2).getPhotoNo());
 			
 			// 抜き取りで、PhotoModelのデータチェック
-			assertEquals(1, actual.get(0).getAccountNo());
+			assertEquals(1L, actual.get(0).getAccountNo());
 			assertEquals(0, actual.get(0).getFavoriteCount());
 			assertFalse(actual.get(0).getIsFavorite());
 			assertEquals(OffsetDateTime.of(2023, 8, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt());
@@ -256,7 +256,7 @@ public class PhotoServiceImplIntegrationTest {
 			List<String> tags = new ArrayList<String>();
 			
 			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.photoAccountId("aaaaaaaa")
 					.directionKbn(DirectionEnum.NONE)
 					.isFavoriteOnly(true)
@@ -270,11 +270,11 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(2, actual.size());
 			
 			// List<PhotoModel>の並び順チェック
-			assertEquals(2, actual.get(0).getPhotoNo());
-			assertEquals(1, actual.get(1).getPhotoNo());
+			assertEquals(2L, actual.get(0).getPhotoNo());
+			assertEquals(1L, actual.get(1).getPhotoNo());
 			
 			// 抜き取りで、PhotoModelのデータチェック
-			assertEquals(1, actual.get(0).getAccountNo());
+			assertEquals(1L, actual.get(0).getAccountNo());
 			assertEquals(4, actual.get(0).getFavoriteCount());
 			assertTrue(actual.get(0).getIsFavorite());
 			assertEquals(OffsetDateTime.of(2021, 2, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt());
@@ -285,9 +285,9 @@ public class PhotoServiceImplIntegrationTest {
 			
 			// 抜き取りで、PhotoTagModelのデータチェック
 			PhotoTagModel actualTag = actual.get(0).getPhotoTagModelList().stream().filter(tag -> tag.getTagNo() == 1).toList().getFirst();
-			assertEquals(1, actualTag.getAccountNo());
-			assertEquals(2, actualTag.getPhotoNo());
-			assertEquals(1, actualTag.getTagNo());
+			assertEquals(1L, actualTag.getAccountNo());
+			assertEquals(2L, actualTag.getPhotoNo());
+			assertEquals(1L, actualTag.getTagNo());
 			assertEquals("太陽", actualTag.getTagJapaneseName());
 			assertEquals("sun", actualTag.getTagEnglishName());
 		}
@@ -301,7 +301,7 @@ public class PhotoServiceImplIntegrationTest {
 			tags.add("bluesky");
 			
 			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.photoAccountId("aaaaaaaa")
 					.directionKbn(DirectionEnum.NONE)
 					.isFavoriteOnly(false)
@@ -315,7 +315,7 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(1, actual.size());
 			
 			// 抜き取りで、PhotoModelのデータチェック
-			assertEquals(1, actual.get(0).getAccountNo());
+			assertEquals(1L, actual.get(0).getAccountNo());
 			assertEquals(3, actual.get(0).getFavoriteCount());
 			assertTrue(actual.get(0).getIsFavorite());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt());
@@ -326,9 +326,9 @@ public class PhotoServiceImplIntegrationTest {
 			
 			// 抜き取りで、PhotoTagModelのデータチェック
 			PhotoTagModel actualTag = actual.get(0).getPhotoTagModelList().stream().filter(tag -> tag.getTagNo() == 1).toList().getFirst();
-			assertEquals(1, actualTag.getAccountNo());
-			assertEquals(1, actualTag.getPhotoNo());
-			assertEquals(1, actualTag.getTagNo());
+			assertEquals(1L, actualTag.getAccountNo());
+			assertEquals(1L, actualTag.getPhotoNo());
+			assertEquals(1L, actualTag.getTagNo());
 			assertEquals("太陽", actualTag.getTagJapaneseName());
 			assertEquals("sun", actualTag.getTagEnglishName());
 		}
@@ -345,17 +345,17 @@ public class PhotoServiceImplIntegrationTest {
 		@DisplayName("正常系")
 		void getPhotoDetail_success() throws PhotoNotFoundException {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoAccountNo(1L)
+					.photoNo(1L)
 					.build();
 			
 			PhotoDetailModel actual = photoServiceImpl.getPhotoDetail(photoDetailGetModel);
-			assertEquals(1, actual.getAccountNo());
-			assertEquals(1, actual.getPhotoNo());
+			assertEquals(1L, actual.getAccountNo());
+			assertEquals(1L, actual.getPhotoNo());
 			assertTrue(actual.getIsFavorite());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getPhotoAt());
-			assertEquals(1, actual.getLocationNo());
+			assertEquals(1L, actual.getLocationNo());
 			assertEquals("住所1", actual.getAddress());
 			assertEquals(0, BigDecimal.valueOf(38.100).compareTo(actual.getLatitude()));
 			assertEquals(0, BigDecimal.valueOf(115.100).compareTo(actual.getLongitude()));
@@ -372,10 +372,10 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(100, actual.getIso());
 			assertEquals(2, actual.getPhotoTagModelList().size());
 			
-			assertEquals(1, actual.getPhotoTagModelList().get(0).getTagNo());
+			assertEquals(1L, actual.getPhotoTagModelList().get(0).getTagNo());
 			assertEquals("太陽", actual.getPhotoTagModelList().get(0).getTagJapaneseName());
 			assertEquals("sun", actual.getPhotoTagModelList().get(0).getTagEnglishName());
-			assertEquals(2, actual.getPhotoTagModelList().get(1).getTagNo());
+			assertEquals(2L, actual.getPhotoTagModelList().get(1).getTagNo());
 			assertEquals("青空", actual.getPhotoTagModelList().get(1).getTagJapaneseName());
 			assertEquals("bluesky", actual.getPhotoTagModelList().get(1).getTagEnglishName());
 		}
@@ -385,9 +385,9 @@ public class PhotoServiceImplIntegrationTest {
 		@DisplayName("異常系：PhotoNotFoundExceptionをthrowする")
 		void getPhotoDetail_PhotoNotFoundException() throws PhotoNotFoundException {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
-					.accountNo(1)
-					.photoAccountNo(1)
-					.photoNo(11)
+					.accountNo(1L)
+					.photoAccountNo(1L)
+					.photoNo(11L)
 					.build();
 			
 			assertThrows(PhotoNotFoundException.class, () -> photoServiceImpl.getPhotoDetail(photoDetailGetModel));
@@ -403,16 +403,16 @@ public class PhotoServiceImplIntegrationTest {
 		PhotoDetailModel createNewPhotoWithTag() {
 			List<PhotoTagModel> photoTagModelList = new ArrayList<PhotoTagModel>();
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(11)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(11L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build());
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(11)
-					.tagNo(2)
+					.accountNo(1L)
+					.photoNo(11L)
+					.tagNo(2L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build());
@@ -423,7 +423,7 @@ public class PhotoServiceImplIntegrationTest {
 					"image".getBytes()
 			);
 			return PhotoDetailModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.photoAt(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.imageFile(multipartFile)
 					.imageFilePath("")
@@ -446,7 +446,7 @@ public class PhotoServiceImplIntegrationTest {
 					"image".getBytes()
 				);
 			return PhotoDetailModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.imageFile(multipartFile)
 					.imageFilePath("")
 					.build();
@@ -455,16 +455,16 @@ public class PhotoServiceImplIntegrationTest {
 		PhotoDetailModel createUpdatePhotoWithTag() {
 			List<PhotoTagModel> photoTagModelList = new ArrayList<PhotoTagModel>();
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(2)
-					.tagNo(1)
+					.accountNo(1L)
+					.photoNo(2L)
+					.tagNo(1L)
 					.tagJapaneseName("太陽")
 					.tagEnglishName("sun")
 					.build());
 			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(1)
-					.photoNo(2)
-					.tagNo(2)
+					.accountNo(1L)
+					.photoNo(2L)
+					.tagNo(2L)
 					.tagJapaneseName("海")
 					.tagEnglishName("sea")
 					.build());
@@ -475,8 +475,8 @@ public class PhotoServiceImplIntegrationTest {
 					"sample image".getBytes()
 			);
 			return PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(2)
+					.accountNo(1L)
+					.photoNo(2L)
 					.photoAt(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.imageFile(multipartFile)
 					.imageFilePath("https://www.xxx.com/aaaaaaaa/DSC222.jpg")
@@ -499,8 +499,8 @@ public class PhotoServiceImplIntegrationTest {
 					"sample image".getBytes()
 			);
 			return PhotoDetailModel.builder()
-					.accountNo(1)
-					.photoNo(3)
+					.accountNo(1L)
+					.photoNo(3L)
 					.photoAt(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.imageFile(multipartFile)
 					.imageFilePath("https://www.xxx.com/aaaaaaaa/DSC333.jpg")
@@ -518,15 +518,15 @@ public class PhotoServiceImplIntegrationTest {
 			return jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no = (SELECT account_no FROM common.account where account_id='" + accountId + "')", (rs, rowNum) ->
 						PhotoMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.photoAt(rs.getObject("photo_at", OffsetDateTime.class))
-							.locationNo(rs.getInt("location_no"))
+							.locationNo(rs.getLong("location_no"))
 							.imageFilePath(rs.getString("image_file_path"))
 							.photoJapaneseTitle(rs.getString("photo_japanese_title"))
 							.photoEnglishTitle(rs.getString("photo_english_title"))
@@ -539,14 +539,14 @@ public class PhotoServiceImplIntegrationTest {
 							.build());
 		}
 		
-		List<PhotoTagMst> getPhotoTagMst(String accountId, Integer photoNo) {
+		List<PhotoTagMst> getPhotoTagMst(String accountId, Long photoNo) {
 			return jdbcTemplate.query(
 					"SELECT * FROM photo.photo_tag_mst WHERE account_no= (SELECT account_no FROM common.account where account_id='" + accountId + "') and photo_no=" + photoNo , (rs, rowNum) ->
 						PhotoTagMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.tagNo(rs.getInt("tag_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.tagNo(rs.getLong("tag_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.tagJapaneseName(rs.getObject("tag_japanese_name").toString())
 							.tagEnglishName(rs.getObject("tag_english_name").toString())
@@ -559,7 +559,7 @@ public class PhotoServiceImplIntegrationTest {
 		void savePhotos_photoDetailModelList_is_null() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
 			String accountId = "aaaaaaaa";
 			List<PhotoMst> beforeSaveData = getPhotoMstData(accountId);
-			Integer actual = photoServiceImpl.savePhotos(accountId, null);
+			Long actual = photoServiceImpl.savePhotos(accountId, null);
 			assertNull(actual);
 			List<PhotoMst> afterData = getPhotoMstData(accountId);
 			assertEquals(beforeSaveData.size(), afterData.size());
@@ -572,7 +572,7 @@ public class PhotoServiceImplIntegrationTest {
 			String accountId = "aaaaaaaa";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			List<PhotoMst> beforeSaveData = getPhotoMstData(accountId);
-			Integer actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
 			assertNull(actual);
 			List<PhotoMst> afterData = getPhotoMstData(accountId);
 			assertEquals(beforeSaveData.size(), afterData.size());
@@ -592,18 +592,18 @@ public class PhotoServiceImplIntegrationTest {
 			PhotoDetailModel photoDetailModel2 = createNewPhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			Integer actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
 
 			assertEquals(11, actual);
 			List<PhotoMst> actualData = getPhotoMstData(accountId).stream().filter(photoMst -> photoMst.getPhotoNo() > 10).toList();
 			assertEquals(2, actualData.size());
 
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(11, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(11L, actualData.get(0).getPhotoNo());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
 			assertEquals("https://www.xxx.com/" + accountId + "/DSC21.jpg", actualData.get(0).getImageFilePath());
-			assertEquals(0, actualData.get(0).getLocationNo());
+			assertEquals(0L, actualData.get(0).getLocationNo());
 			assertEquals("タイトル21", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title21", actualData.get(0).getPhotoEnglishTitle());
 			assertEquals("キャプション21", actualData.get(0).getCaption());
@@ -612,12 +612,12 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(0, BigDecimal.valueOf(0.01).compareTo(actualData.get(0).getShutterSpeed()));
 			assertEquals(100, actualData.get(0).getIso());
 
-			assertEquals(1, actualData.get(1).getAccountNo());
-			assertEquals(12, actualData.get(1).getPhotoNo());
+			assertEquals(1L, actualData.get(1).getAccountNo());
+			assertEquals(12L, actualData.get(1).getPhotoNo());
 			assertFalse(actualData.get(1).getIsDeleted());
 			assertEquals(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(1).getPhotoAt().plusHours(9));
 			assertEquals("https://www.xxx.com/" + accountId + "/DSC22.jpg", actualData.get(1).getImageFilePath());
-			assertEquals(0, actualData.get(1).getLocationNo());
+			assertEquals(0L, actualData.get(1).getLocationNo());
 			assertEquals("", actualData.get(1).getPhotoJapaneseTitle());
 			assertEquals("", actualData.get(1).getPhotoEnglishTitle());
 			assertEquals("", actualData.get(1).getCaption());
@@ -626,20 +626,20 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(0, BigDecimal.ZERO.compareTo(actualData.get(1).getShutterSpeed()));
 			assertEquals(0, actualData.get(1).getIso());
 			
-			List<PhotoTagMst> actualTagData1 = getPhotoTagMst(accountId, 11);
+			List<PhotoTagMst> actualTagData1 = getPhotoTagMst(accountId, 11L);
 			assertEquals(2, actualTagData1.size());
-			assertEquals(1, actualTagData1.get(0).getAccountNo());
-			assertEquals(11, actualTagData1.get(0).getPhotoNo());
-			assertEquals(1, actualTagData1.get(0).getTagNo());
+			assertEquals(1L, actualTagData1.get(0).getAccountNo());
+			assertEquals(11L, actualTagData1.get(0).getPhotoNo());
+			assertEquals(1L, actualTagData1.get(0).getTagNo());
 			assertEquals("太陽", actualTagData1.get(0).getTagJapaneseName());
 			assertEquals("sun", actualTagData1.get(0).getTagEnglishName());
-			assertEquals(1, actualTagData1.get(1).getAccountNo());
-			assertEquals(11, actualTagData1.get(1).getPhotoNo());
-			assertEquals(2, actualTagData1.get(1).getTagNo());
+			assertEquals(1L, actualTagData1.get(1).getAccountNo());
+			assertEquals(11L, actualTagData1.get(1).getPhotoNo());
+			assertEquals(2L, actualTagData1.get(1).getTagNo());
 			assertEquals("海", actualTagData1.get(1).getTagJapaneseName());
 			assertEquals("sea", actualTagData1.get(1).getTagEnglishName());
 			
-			List<PhotoTagMst> actualTagData2 = getPhotoTagMst(accountId, 12);
+			List<PhotoTagMst> actualTagData2 = getPhotoTagMst(accountId, 12L);
 			assertEquals(0, actualTagData2.size());
 		}
 		
@@ -657,17 +657,17 @@ public class PhotoServiceImplIntegrationTest {
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			Integer actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
 
 			assertEquals(3, actual);
 			List<PhotoMst> actualData1 = getPhotoMstData(accountId).stream().filter(photoMst -> photoMst.getPhotoNo()==2).toList();
 			assertEquals(1, actualData1.size());
-			assertEquals(1, actualData1.getFirst().getAccountNo());
-			assertEquals(2, actualData1.getFirst().getPhotoNo());
+			assertEquals(1L, actualData1.getFirst().getAccountNo());
+			assertEquals(2L, actualData1.getFirst().getPhotoNo());
 			assertFalse(actualData1.getFirst().getIsDeleted());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData1.getFirst().getPhotoAt());
 			assertEquals("https://www.xxx.com/" + accountId + "/DSC222.jpg", actualData1.getFirst().getImageFilePath());
-			assertEquals(0, actualData1.getFirst().getLocationNo());
+			assertEquals(0L, actualData1.getFirst().getLocationNo());
 			assertEquals("タイトル2", actualData1.getFirst().getPhotoJapaneseTitle());
 			assertEquals("title2", actualData1.getFirst().getPhotoEnglishTitle());
 			assertEquals("キャプション2", actualData1.getFirst().getCaption());
@@ -676,27 +676,27 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(0, BigDecimal.valueOf(0.01).compareTo(actualData1.getFirst().getShutterSpeed()));
 			assertEquals(100, actualData1.getFirst().getIso());
 			
-			List<PhotoTagMst> actualTagData1 = getPhotoTagMst(accountId, 2);
+			List<PhotoTagMst> actualTagData1 = getPhotoTagMst(accountId, 2L);
 			assertEquals(2, actualTagData1.size());
-			assertEquals(1, actualTagData1.get(0).getAccountNo());
-			assertEquals(2, actualTagData1.get(0).getPhotoNo());
-			assertEquals(1, actualTagData1.get(0).getTagNo());
+			assertEquals(1L, actualTagData1.get(0).getAccountNo());
+			assertEquals(2L, actualTagData1.get(0).getPhotoNo());
+			assertEquals(1L, actualTagData1.get(0).getTagNo());
 			assertEquals("太陽", actualTagData1.get(0).getTagJapaneseName());
 			assertEquals("sun", actualTagData1.get(0).getTagEnglishName());
-			assertEquals(1, actualTagData1.get(1).getAccountNo());
-			assertEquals(2, actualTagData1.get(1).getPhotoNo());
-			assertEquals(2, actualTagData1.get(1).getTagNo());
+			assertEquals(1L, actualTagData1.get(1).getAccountNo());
+			assertEquals(2L, actualTagData1.get(1).getPhotoNo());
+			assertEquals(2L, actualTagData1.get(1).getTagNo());
 			assertEquals("海", actualTagData1.get(1).getTagJapaneseName());
 			assertEquals("sea", actualTagData1.get(1).getTagEnglishName());
 			
 			List<PhotoMst> actualData2 = getPhotoMstData(accountId).stream().filter(photoMst -> photoMst.getPhotoNo()==3).toList();
 			assertEquals(1, actualData2.size());
-			assertEquals(1, actualData2.getFirst().getAccountNo());
-			assertEquals(3, actualData2.getFirst().getPhotoNo());
+			assertEquals(1L, actualData2.getFirst().getAccountNo());
+			assertEquals(3L, actualData2.getFirst().getPhotoNo());
 			assertFalse(actualData2.getFirst().getIsDeleted());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData2.getFirst().getPhotoAt());
 			assertEquals("https://www.xxx.com/" + accountId + "/DSC333.jpg", actualData2.getFirst().getImageFilePath());
-			assertEquals(0, actualData2.getFirst().getLocationNo());
+			assertEquals(0L, actualData2.getFirst().getLocationNo());
 			assertEquals("タイトル3", actualData2.getFirst().getPhotoJapaneseTitle());
 			assertEquals("title3", actualData2.getFirst().getPhotoEnglishTitle());
 			assertEquals("キャプション3", actualData2.getFirst().getCaption());
@@ -705,7 +705,7 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(0, BigDecimal.valueOf(0.01).compareTo(actualData2.getFirst().getShutterSpeed()));
 			assertEquals(100, actualData2.getFirst().getIso());
 			
-			List<PhotoTagMst> actualTagData2 = getPhotoTagMst(accountId, 3);
+			List<PhotoTagMst> actualTagData2 = getPhotoTagMst(accountId, 3L);
 			assertEquals(0, actualTagData2.size());
 		}
 		
@@ -723,18 +723,18 @@ public class PhotoServiceImplIntegrationTest {
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			Integer actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
 
 			assertEquals(3, actual);
 			List<PhotoMst> actualData = getPhotoMstData(accountId).stream().filter(photoMst -> photoMst.getPhotoNo() > 10).toList();
 			assertEquals(1, actualData.size());
 
-			assertEquals(1, actualData.get(0).getAccountNo());
-			assertEquals(11, actualData.get(0).getPhotoNo());
+			assertEquals(1L, actualData.get(0).getAccountNo());
+			assertEquals(11L, actualData.get(0).getPhotoNo());
 			assertFalse(actualData.get(0).getIsDeleted());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt());
 			assertEquals("https://www.xxx.com/" + accountId + "/DSC21.jpg", actualData.get(0).getImageFilePath());
-			assertEquals(0, actualData.get(0).getLocationNo());
+			assertEquals(0L, actualData.get(0).getLocationNo());
 			assertEquals("タイトル21", actualData.get(0).getPhotoJapaneseTitle());
 			assertEquals("title21", actualData.get(0).getPhotoEnglishTitle());
 			assertEquals("キャプション21", actualData.get(0).getCaption());
@@ -743,27 +743,27 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(0, BigDecimal.valueOf(0.01).compareTo(actualData.get(0).getShutterSpeed()));
 			assertEquals(100, actualData.get(0).getIso());
 			
-			List<PhotoTagMst> actualTagData1 = getPhotoTagMst(accountId, 11);
+			List<PhotoTagMst> actualTagData1 = getPhotoTagMst(accountId, 11L);
 			assertEquals(2, actualTagData1.size());
-			assertEquals(1, actualTagData1.get(0).getAccountNo());
-			assertEquals(11, actualTagData1.get(0).getPhotoNo());
-			assertEquals(1, actualTagData1.get(0).getTagNo());
+			assertEquals(1L, actualTagData1.get(0).getAccountNo());
+			assertEquals(11L, actualTagData1.get(0).getPhotoNo());
+			assertEquals(1L, actualTagData1.get(0).getTagNo());
 			assertEquals("太陽", actualTagData1.get(0).getTagJapaneseName());
 			assertEquals("sun", actualTagData1.get(0).getTagEnglishName());
-			assertEquals(1, actualTagData1.get(1).getAccountNo());
-			assertEquals(11, actualTagData1.get(1).getPhotoNo());
-			assertEquals(2, actualTagData1.get(1).getTagNo());
+			assertEquals(1L, actualTagData1.get(1).getAccountNo());
+			assertEquals(11L, actualTagData1.get(1).getPhotoNo());
+			assertEquals(2L, actualTagData1.get(1).getTagNo());
 			assertEquals("海", actualTagData1.get(1).getTagJapaneseName());
 			assertEquals("sea", actualTagData1.get(1).getTagEnglishName());
 			
 			List<PhotoMst> actualData2 = getPhotoMstData(accountId).stream().filter(photoMst -> photoMst.getPhotoNo()==3).toList();
 			assertEquals(1, actualData2.size());
-			assertEquals(1, actualData2.getFirst().getAccountNo());
-			assertEquals(3, actualData2.getFirst().getPhotoNo());
+			assertEquals(1L, actualData2.getFirst().getAccountNo());
+			assertEquals(3L, actualData2.getFirst().getPhotoNo());
 			assertFalse(actualData2.getFirst().getIsDeleted());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData2.getFirst().getPhotoAt());
 			assertEquals("https://www.xxx.com/" + accountId + "/DSC333.jpg", actualData2.getFirst().getImageFilePath());
-			assertEquals(0, actualData2.getFirst().getLocationNo());
+			assertEquals(0L, actualData2.getFirst().getLocationNo());
 			assertEquals("タイトル3", actualData2.getFirst().getPhotoJapaneseTitle());
 			assertEquals("title3", actualData2.getFirst().getPhotoEnglishTitle());
 			assertEquals("キャプション3", actualData2.getFirst().getCaption());
@@ -772,7 +772,7 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(0, BigDecimal.valueOf(0.01).compareTo(actualData2.getFirst().getShutterSpeed()));
 			assertEquals(100, actualData2.getFirst().getIso());
 			
-			List<PhotoTagMst> actualTagData2 = getPhotoTagMst(accountId, 3);
+			List<PhotoTagMst> actualTagData2 = getPhotoTagMst(accountId, 3L);
 			assertEquals(0, actualTagData2.size());
 		}
 		
@@ -791,7 +791,7 @@ public class PhotoServiceImplIntegrationTest {
 					"sample image".getBytes()
 			);
 			PhotoDetailModel photoDetailModel1 = PhotoDetailModel.builder()
-					.accountNo(1)
+					.accountNo(1L)
 					.photoAt(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))
 					.imageFile(multipartFile)
 					.imageFilePath("https://www.xxx.com/aaaaaaaa/DSC11.jpg")
@@ -827,15 +827,15 @@ public class PhotoServiceImplIntegrationTest {
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no = (SELECT account_no FROM common.account where account_id='aaaaaaaa')", (rs, rowNum) ->
 						PhotoMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.photoAt(rs.getObject("photo_at", OffsetDateTime.class))
-							.locationNo(rs.getInt("location_no"))
+							.locationNo(rs.getLong("location_no"))
 							.imageFilePath(rs.getString("image_file_path"))
 							.photoJapaneseTitle(rs.getString("photo_japanese_title"))
 							.photoEnglishTitle(rs.getString("photo_english_title"))
@@ -856,13 +856,13 @@ public class PhotoServiceImplIntegrationTest {
 		void deletePhotos_success() throws UpdateFailureException {
 			List<PhotoDeleteModel> photoDeleteModelList = new ArrayList<PhotoDeleteModel>();
 			photoDeleteModelList.add(PhotoDeleteModel.builder()
-					.accountNo(1)
-					.photoNo(1)
+					.accountNo(1L)
+					.photoNo(1L)
 					.imageFilePath("DSC11.jpg")
 					.build());
 			photoDeleteModelList.add(PhotoDeleteModel.builder()
-					.accountNo(1)
-					.photoNo(2)
+					.accountNo(1L)
+					.photoNo(2L)
 					.imageFilePath("DSC12.jpg")
 					.build());
 			
@@ -871,15 +871,15 @@ public class PhotoServiceImplIntegrationTest {
 			List<PhotoMst> actualPhotoMstData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no=1 and photo_no in (1, 2)", (rs, rowNum) ->
 						PhotoMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.photoAt(rs.getObject("photo_at", OffsetDateTime.class))
-							.locationNo(rs.getInt("location_no"))
+							.locationNo(rs.getLong("location_no"))
 							.imageFilePath(rs.getString("image_file_path"))
 							.photoJapaneseTitle(rs.getString("photo_japanese_title"))
 							.photoEnglishTitle(rs.getString("photo_english_title"))
@@ -897,15 +897,15 @@ public class PhotoServiceImplIntegrationTest {
 			List<PhotoMst> actualPhotoMstRestData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no=1 and is_deleted=false", (rs, rowNum) ->
 						PhotoMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
-							.updatedBy(rs.getInt("updated_by"))
+							.updatedBy(rs.getLong("updated_by"))
 							.updatedAt(rs.getObject("updated_at", OffsetDateTime.class))
 							.isDeleted(rs.getBoolean("is_deleted"))
 							.photoAt(rs.getObject("photo_at", OffsetDateTime.class))
-							.locationNo(rs.getInt("location_no"))
+							.locationNo(rs.getLong("location_no"))
 							.imageFilePath(rs.getString("image_file_path"))
 							.photoJapaneseTitle(rs.getString("photo_japanese_title"))
 							.photoEnglishTitle(rs.getString("photo_english_title"))
@@ -921,10 +921,10 @@ public class PhotoServiceImplIntegrationTest {
 			List<PhotoFavorite> actualPhotoFavoriteData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite where favorite_photo_account_no=1 and favorite_photo_no in (1, 2)", (rs, rowNum) ->
 						PhotoFavorite.builder()
-							.accountNo(rs.getInt("account_no"))
-							.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-							.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+							.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.build());
 			assertEquals(0, actualPhotoFavoriteData.size());
@@ -932,10 +932,10 @@ public class PhotoServiceImplIntegrationTest {
 			List<PhotoFavorite> actualPhotoFavoriteRestData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite", (rs, rowNum) ->
 						PhotoFavorite.builder()
-							.accountNo(rs.getInt("account_no"))
-							.favoritePhotoAccountNo(rs.getInt("favorite_photo_account_no"))
-							.favoritePhotoNo(rs.getInt("favorite_photo_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.favoritePhotoAccountNo(rs.getLong("favorite_photo_account_no"))
+							.favoritePhotoNo(rs.getLong("favorite_photo_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.build());
 			assertEquals(4, actualPhotoFavoriteRestData.size());
@@ -943,10 +943,10 @@ public class PhotoServiceImplIntegrationTest {
 			List<PhotoTagMst> actualPhotoTagData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_tag_mst WHERE account_no=1 and photo_no in (1,2)", (rs, rowNum) ->
 						PhotoTagMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.tagNo(rs.getInt("tag_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.tagNo(rs.getLong("tag_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.tagJapaneseName(rs.getObject("tag_japanese_name").toString())
 							.tagEnglishName(rs.getObject("tag_english_name").toString())
@@ -956,10 +956,10 @@ public class PhotoServiceImplIntegrationTest {
 			List<PhotoTagMst> actualPhotoTagRestData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_tag_mst", (rs, rowNum) ->
 						PhotoTagMst.builder()
-							.accountNo(rs.getInt("account_no"))
-							.photoNo(rs.getInt("photo_no"))
-							.tagNo(rs.getInt("tag_no"))
-							.createdBy(rs.getInt("created_by"))
+							.accountNo(rs.getLong("account_no"))
+							.photoNo(rs.getLong("photo_no"))
+							.tagNo(rs.getLong("tag_no"))
+							.createdBy(rs.getLong("created_by"))
 							.createdAt(rs.getObject("created_at", OffsetDateTime.class))
 							.tagJapaneseName(rs.getObject("tag_japanese_name").toString())
 							.tagEnglishName(rs.getObject("tag_english_name").toString())
@@ -973,8 +973,8 @@ public class PhotoServiceImplIntegrationTest {
 		void deletePhotos_UpdateFailureException() throws UpdateFailureException {
 			List<PhotoDeleteModel> photoDeleteModelList = new ArrayList<PhotoDeleteModel>();
 			photoDeleteModelList.add(PhotoDeleteModel.builder()
-					.accountNo(1)
-					.photoNo(99)
+					.accountNo(1L)
+					.photoNo(99L)
 					.imageFilePath("DSC99.jpg")
 					.build());
 			
@@ -999,7 +999,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：mini-userで、上限まで登録済みの場合")
 		void isReachedUpperLimit_mini_user_reached() {
-			Integer accountNo = 1;
+			Long accountNo = 1L;
 			assertTrue(photoServiceImpl.isReachedUpperLimit(accountNo));
 		}
 		
@@ -1007,7 +1007,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Order(3)
 		@DisplayName("正常系：mini-userで、上限まで未登録の場合")
 		void isReachedUpperLimit_mini_user_not_reached() {
-			Integer accountNo = 2;
+			Long accountNo = 2L;
 			assertFalse(photoServiceImpl.isReachedUpperLimit(accountNo));
 		}
 		
@@ -1015,7 +1015,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Order(4)
 		@DisplayName("正常系：normal-userで、上限まで登録済みの場合")
 		void isReachedUpperLimit_normal_user_reached() {
-			Integer accountNo = 3;
+			Long accountNo = 3L;
 			assertTrue(photoServiceImpl.isReachedUpperLimit(accountNo));
 		}
 		
@@ -1023,7 +1023,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Order(5)
 		@DisplayName("正常系：normal-userで、上限まで未登録の場合")
 		void isReachedUpperLimit_normal_user_not_reached() {
-			Integer accountNo = 4;
+			Long accountNo = 4L;
 			assertFalse(photoServiceImpl.isReachedUpperLimit(accountNo));
 		}
 		
@@ -1031,7 +1031,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Order(6)
 		@DisplayName("正常系：special-userの場合")
 		void isReachedUpperLimit_special_user() {
-			Integer accountNo = 5;
+			Long accountNo = 5L;
 			assertFalse(photoServiceImpl.isReachedUpperLimit(accountNo));
 		}
 		
@@ -1039,7 +1039,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Order(7)
 		@DisplayName("正常系：administratorの場合")
 		void isReachedUpperLimit_administrator() {
-			Integer accountNo = 6;
+			Long accountNo = 6L;
 			assertFalse(photoServiceImpl.isReachedUpperLimit(accountNo));
 		}
 	}

--- a/db/common/account.sql
+++ b/db/common/account.sql
@@ -6,13 +6,13 @@ DROP TABLE IF EXISTS common.account;
 CREATE TABLE common.account
 (
 	-- アカウント番号
-	account_no serial NOT NULL,
+	account_no bigserial NOT NULL,
 	-- 作成者
-	created_by int NOT NULL,
+	created_by bigint NOT NULL,
 	-- 作成日時
 	created_at timestamp with time zone NOT NULL,
 	-- 更新者
-	updated_by int NOT NULL,
+	updated_by bigint NOT NULL,
 	-- 更新日時
 	updated_at timestamp with time zone NOT NULL,
 	-- 削除フラグ

--- a/db/common/location_mst.sql
+++ b/db/common/location_mst.sql
@@ -6,17 +6,17 @@ DROP TABLE IF EXISTS common.location_mst;
 CREATE TABLE common.location_mst
 (
 	-- ID
-	id serial NOT NULL,
+	id bigserial NOT NULL,
 	-- アカウント番号
-	account_no int NOT NULL,
+	account_no bigint NOT NULL,
 	-- ロケーション番号
-	location_no int NOT NULL,
+	location_no bigint NOT NULL,
 	-- 作成者
-	created_by int NOT NULL,
+	created_by bigint NOT NULL,
 	-- 作成日時
 	created_at timestamp with time zone NOT NULL,
 	-- 更新者
-	updated_by int NOT NULL,
+	updated_by bigint NOT NULL,
 	-- 更新日時
 	updated_at timestamp with time zone NOT NULL,
 	-- 削除フラグ

--- a/db/common/refresh_token.sql
+++ b/db/common/refresh_token.sql
@@ -6,9 +6,9 @@ DROP TABLE IF EXISTS common.refresh_token;
 CREATE TABLE common.refresh_token
 (
 	-- トークンID
-	token_id serial NOT NULL,
+	token_id bigserial NOT NULL,
 	-- アカウント番号
-	account_no integer NOT NULL,
+	account_no bigint NOT NULL,
 	-- トークンハッシュ
 	token_hash varchar(256) NOT NULL,
 	-- 有効期限

--- a/db/photo/photo_favorite.sql
+++ b/db/photo/photo_favorite.sql
@@ -6,15 +6,15 @@ DROP TABLE IF EXISTS photo.photo_favorite;
 CREATE TABLE photo.photo_favorite
 (
 	-- ID
-	id serial NOT NULL,
+	id bigserial NOT NULL,
 	-- アカウント番号
-	account_no int NOT NULL,
+	account_no bigint NOT NULL,
 	-- お気に入り写真アカウント番号
-	favorite_photo_account_no int NOT NULL,
+	favorite_photo_account_no bigint NOT NULL,
 	-- お気に入り写真番号
-	favorite_photo_no int NOT NULL,
+	favorite_photo_no bigint NOT NULL,
 	-- 作成者
-	created_by int NOT NULL,
+	created_by bigint NOT NULL,
 	-- 作成日時
 	created_at timestamp with time zone NOT NULL,
 	PRIMARY KEY (id),

--- a/db/photo/photo_mst.sql
+++ b/db/photo/photo_mst.sql
@@ -6,17 +6,17 @@ DROP TABLE IF EXISTS photo.photo_mst;
 CREATE TABLE photo.photo_mst
 (
 	-- ID
-	id serial NOT NULL,
+	id bigserial NOT NULL,
 	-- アカウント番号
-	account_no int NOT NULL,
+	account_no bigint NOT NULL,
 	-- 写真番号
-	photo_no int NOT NULL,
+	photo_no bigint NOT NULL,
 	-- 作成者
-	created_by int NOT NULL,
+	created_by bigint NOT NULL,
 	-- 作成日時
 	created_at timestamp with time zone NOT NULL,
 	-- 更新者
-	updated_by int NOT NULL,
+	updated_by bigint NOT NULL,
 	-- 更新日時
 	updated_at timestamp with time zone NOT NULL,
 	-- 削除フラグ
@@ -24,7 +24,7 @@ CREATE TABLE photo.photo_mst
 	-- 撮影日時
 	photo_at timestamp with time zone NOT NULL,
 	-- ロケーション番号
-	location_no int NOT NULL,
+	location_no bigint NOT NULL,
 	-- 画像ファイルパス: 空文字不可
 	image_file_path text NOT NULL,
 	-- 写真タイトル日本語名: 空文字不可

--- a/db/photo/photo_tag_mst.sql
+++ b/db/photo/photo_tag_mst.sql
@@ -6,15 +6,15 @@ DROP TABLE IF EXISTS photo.photo_tag_mst;
 CREATE TABLE photo.photo_tag_mst
 (
 	-- ID
-	id serial NOT NULL,
+	id bigserial NOT NULL,
 	-- アカウント番号
-	account_no int NOT NULL,
+	account_no bigint NOT NULL,
 	-- 写真番号
-	photo_no int NOT NULL,
+	photo_no bigint NOT NULL,
 	-- タグ番号
-	tag_no int NOT NULL,
+	tag_no bigint NOT NULL,
 	-- 作成者
-	created_by int NOT NULL,
+	created_by bigint NOT NULL,
 	-- 作成日時
 	created_at timestamp with time zone NOT NULL,
 	-- タグ日本語名: 空文字不可

--- a/doc/database/data-dictionary.md
+++ b/doc/database/data-dictionary.md
@@ -8,23 +8,23 @@
 |----|--------|--------|----------|-------------|----------|-------------|
 | 1 | account_id | アカウントID | varchar(20) | - | 8〜20文字の英数字。ログイン時に使用する一意の識別子 | account |
 | 2 | account_name | アカウント名 | varchar(50) | - | ユーザーの表示名 | account |
-| 3 | account_no | アカウント番号 | serial / int | (自動採番) / - | アカウントを一意に特定するための番号。accountテーブルではPK（自動採番）、他テーブルではFK | account, location_mst, refresh_token, photo_mst, photo_tag_mst, photo_favorite |
+| 3 | account_no | アカウント番号 | bigserial / bigint | (自動採番) / - | アカウントを一意に特定するための番号。accountテーブルではPK（自動採番）、他テーブルではFK | account, location_mst, refresh_token, photo_mst, photo_tag_mst, photo_favorite |
 | 4 | address | 住所 | text | '' | 撮影場所の住所 | location_mst |
 | 5 | authority_kbn | 権限区分 | common.authority_enum | - | mini-user/normal-user/special-user/administratorの4段階。写真アップロード上限に影響 | account |
 | 6 | birthdate | 生年月日 | date | '1900-01-01' | 個人情報管理の観点で、必須入力なし、かつ年月まで。データ登録時にすべて1日に変換する | account |
 | 7 | birthplace_prefecture_kbn_code | 出身地都道府県区分コード | varchar(20) | 'none' | kbn_mstの都道府県区分コードを参照。未設定時は'none' | account |
 | 8 | caption | キャプション | text | '""' | 写真の説明文 | photo_mst |
 | 9 | created_at | 作成日時 | timestamp with time zone | - / NOW() | レコード作成日時（タイムゾーン付き） | account, kbn_mst, location_mst, refresh_token, photo_mst, photo_tag_mst, photo_favorite |
-| 10 | created_by | 作成者 | int | - | レコードを作成したアカウント番号。システム側が作成した場合は'0'を入れる | account, kbn_mst, location_mst, photo_mst, photo_tag_mst, photo_favorite |
+| 10 | created_by | 作成者 | bigint | - | レコードを作成したアカウント番号。システム側が作成した場合は'0'を入れる | account, kbn_mst, location_mst, photo_mst, photo_tag_mst, photo_favorite |
 | 11 | direction_kbn | 写真の向き | photo.direction_enum | 'none' | vertical（縦）/horizontal（横）/square（正方形）/none（未設定） | photo_mst |
 | 12 | explanation | 説明 | text | '""' | 区分コードの補足説明 | kbn_mst |
 | 13 | expires_at | 有効期限 | timestamp with time zone | - | リフレッシュトークンの有効期限 | refresh_token |
 | 14 | f_value | F値 | decimal(5,2) | - | EXIF情報から取得した絞り値 | photo_mst |
-| 15 | favorite_photo_account_no | 写真所有者のアカウント番号 | int | - | お気に入り対象の写真を所有するアカウント番号。photo_mst(account_no)へのFK | photo_favorite |
-| 16 | favorite_photo_no | お気に入り写真番号 | int | - | お気に入り対象の写真番号。photo_mst(photo_no)へのFK | photo_favorite |
+| 15 | favorite_photo_account_no | 写真所有者のアカウント番号 | bigint | - | お気に入り対象の写真を所有するアカウント番号。photo_mst(account_no)へのFK | photo_favorite |
+| 16 | favorite_photo_no | お気に入り写真番号 | bigint | - | お気に入り対象の写真番号。photo_mst(photo_no)へのFK | photo_favorite |
 | 17 | focal_length | 焦点距離 | int | - | EXIF情報から取得した焦点距離（mm単位） | photo_mst |
 | 18 | free_memo | フリーメモ | text | '""' | ユーザーが自由に入力できるメモ欄 | account |
-| 19 | id | ID | serial | (自動採番) | サロゲートキー（自動採番） | location_mst, photo_mst, photo_tag_mst, photo_favorite |
+| 19 | id | ID | bigserial | (自動採番) | サロゲートキー（自動採番） | location_mst, photo_mst, photo_tag_mst, photo_favorite |
 | 20 | image_file_path | 画像ファイルパス | text | - | サーバー上の画像ファイルの保存パス | photo_mst |
 | 21 | is_deleted | 削除フラグ | boolean | false | 論理削除フラグ。trueの場合は削除済み | account, location_mst, photo_mst |
 | 22 | is_revoked | 無効化フラグ | boolean | false | リフレッシュトークンの無効化フラグ。ログアウト時やトークンローテーション時にtrueに設定 | refresh_token |
@@ -41,25 +41,25 @@
 | 33 | last_login_datetime | 最終ログイン日時 | timestamp with time zone | - | ユーザーが最後にログインした日時 | account |
 | 34 | latitude | 緯度 | decimal(11,4) | - | 撮影場所の緯度座標 | location_mst |
 | 35 | location_name | ロケーション名 | text | - | 撮影場所の名称。同一アカウント内で一意 | location_mst |
-| 36 | location_no | ロケーション番号 | int | - | アカウント単位のロケーション連番 | location_mst, photo_mst |
+| 36 | location_no | ロケーション番号 | bigint | - | アカウント単位のロケーション連番 | location_mst, photo_mst |
 | 37 | login_failure_count | ログイン失敗回数 | smallint | 0 | 連続ログイン失敗回数。ログイン成功時にリセット | account |
 | 38 | longitude | 経度 | decimal(11,4) | - | 撮影場所の経度座標 | location_mst |
 | 39 | password | パスワード | text | - | BCryptでハッシュ化されたパスワード | account |
 | 40 | photo_at | 撮影日時 | timestamp with time zone | - | 写真を撮影した日時 | photo_mst |
 | 41 | photo_english_title | 写真タイトル（英語） | varchar(100) | '""' | 写真の英語タイトル（任意入力） | photo_mst |
 | 42 | photo_japanese_title | 写真タイトル（日本語） | varchar(100) | - | 写真の日本語タイトル（必須入力） | photo_mst |
-| 43 | photo_no | 写真番号 | int | - | アカウント単位の写真連番。account_noとの複合UNIQUEを構成 | photo_mst, photo_tag_mst |
+| 43 | photo_no | 写真番号 | bigint | - | アカウント単位の写真連番。account_noとの複合UNIQUEを構成 | photo_mst, photo_tag_mst |
 | 44 | resident_prefecture_kbn_code | 居住地都道府県区分コード | varchar(20) | 'none' | kbn_mstの都道府県区分コードを参照。未設定時は'none' | account |
 | 45 | sex_kbn | 性別区分 | common.sex_enum | 'none' | man（男性）/woman（女性）/none（未設定） | account |
 | 46 | shutter_speed | シャッタースピード | decimal(10,5) | - | EXIF情報から取得したシャッタースピード（秒単位） | photo_mst |
 | 47 | sort_order | 表示順 | int | - | 画面表示時のソート順序 | kbn_mst |
 | 48 | tag_english_name | タグ名（英語） | varchar(20) | '""' | 写真に付与するタグの英語名（任意入力） | photo_tag_mst |
 | 49 | tag_japanese_name | タグ名（日本語） | varchar(20) | - | 写真に付与するタグの日本語名（必須入力） | photo_tag_mst |
-| 50 | tag_no | タグ番号 | int | - | 写真単位のタグ連番。account_no, photo_noとの複合UNIQUEを構成 | photo_tag_mst |
+| 50 | tag_no | タグ番号 | bigint | - | 写真単位のタグ連番。account_no, photo_noとの複合UNIQUEを構成 | photo_tag_mst |
 | 51 | token_hash | トークンハッシュ | varchar(256) | - | リフレッシュトークンをSHA-256でハッシュ化した値。検索用インデックスあり | refresh_token |
-| 52 | token_id | トークンID | serial | (自動採番) | リフレッシュトークンのPK（自動採番） | refresh_token |
+| 52 | token_id | トークンID | bigserial | (自動採番) | リフレッシュトークンのPK（自動採番） | refresh_token |
 | 53 | updated_at | 更新日時 | timestamp with time zone | - | レコード最終更新日時（タイムゾーン付き） | account, location_mst, photo_mst |
-| 54 | updated_by | 更新者 | int | - | レコードを最後に更新したアカウント番号 | account, location_mst, photo_mst |
+| 54 | updated_by | 更新者 | bigint | - | レコードを最後に更新したアカウント番号 | account, location_mst, photo_mst |
 
 ## カスタム型辞書
 

--- a/doc/database/er-diagram.md
+++ b/doc/database/er-diagram.md
@@ -7,10 +7,10 @@ erDiagram
     %% ========== common スキーマ ==========
 
     account {
-        serial account_no PK "アカウント番号"
-        int created_by "作成者"
+        bigserial account_no PK "アカウント番号"
+        bigint created_by "作成者"
         timestamptz created_at "作成日時"
-        int updated_by "更新者"
+        bigint updated_by "更新者"
         timestamptz updated_at "更新日時"
         boolean is_deleted "削除フラグ"
         varchar account_id UK "アカウントID"
@@ -43,12 +43,12 @@ erDiagram
     }
 
     location_mst {
-        serial id PK "ロケーションID"
-        int account_no FK,UK "アカウント番号"
-        int location_no UK "ロケーション番号"
-        int created_by "作成者"
+        bigserial id PK "ロケーションID"
+        bigint account_no FK,UK "アカウント番号"
+        bigint location_no UK "ロケーション番号"
+        bigint created_by "作成者"
         timestamptz created_at "作成日時"
-        int updated_by "更新者"
+        bigint updated_by "更新者"
         timestamptz updated_at "更新日時"
         boolean is_deleted "削除フラグ"
         text location_name UK "ロケーション名"
@@ -58,8 +58,8 @@ erDiagram
     }
 
     refresh_token {
-        serial token_id PK "トークンID"
-        int account_no FK "アカウント番号"
+        bigserial token_id PK "トークンID"
+        bigint account_no FK "アカウント番号"
         varchar token_hash "トークンハッシュ"
         timestamptz expires_at "有効期限"
         timestamptz created_at "作成日時"
@@ -69,16 +69,16 @@ erDiagram
     %% ========== photo スキーマ ==========
 
     photo_mst {
-        serial id PK "写真ID"
-        int account_no FK,UK "アカウント番号"
-        int photo_no UK "写真番号"
-        int created_by "作成者"
+        bigserial id PK "写真ID"
+        bigint account_no FK,UK "アカウント番号"
+        bigint photo_no UK "写真番号"
+        bigint created_by "作成者"
         timestamptz created_at "作成日時"
-        int updated_by "更新者"
+        bigint updated_by "更新者"
         timestamptz updated_at "更新日時"
         boolean is_deleted "削除フラグ"
         timestamptz photo_at "撮影日時"
-        int location_no "ロケーション番号"
+        bigint location_no "ロケーション番号"
         text image_file_path "画像ファイルパス"
         varchar photo_japanese_title "写真タイトル(日本語)"
         varchar photo_english_title "写真タイトル(英語)"
@@ -91,22 +91,22 @@ erDiagram
     }
 
     photo_tag_mst {
-        serial id PK "タグID"
-        int account_no FK,UK "アカウント番号"
-        int photo_no FK,UK "写真番号"
-        int tag_no UK "タグ番号"
-        int created_by "作成者"
+        bigserial id PK "タグID"
+        bigint account_no FK,UK "アカウント番号"
+        bigint photo_no FK,UK "写真番号"
+        bigint tag_no UK "タグ番号"
+        bigint created_by "作成者"
         timestamptz created_at "作成日時"
         varchar tag_japanese_name "タグ名(日本語)"
         varchar tag_english_name "タグ名(英語)"
     }
 
     photo_favorite {
-        serial id PK "お気に入りID"
-        int account_no FK,UK "アカウント番号"
-        int favorite_photo_account_no FK,UK "写真所有者アカウント番号"
-        int favorite_photo_no FK,UK "写真番号"
-        int created_by "作成者"
+        bigserial id PK "お気に入りID"
+        bigint account_no FK,UK "アカウント番号"
+        bigint favorite_photo_account_no FK,UK "写真所有者アカウント番号"
+        bigint favorite_photo_no FK,UK "写真番号"
+        bigint created_by "作成者"
         timestamptz created_at "作成日時"
     }
 
@@ -127,10 +127,10 @@ erDiagram
 ```mermaid
 erDiagram
     account {
-        serial account_no PK "アカウント番号"
-        int created_by "作成者"
+        bigserial account_no PK "アカウント番号"
+        bigint created_by "作成者"
         timestamptz created_at "作成日時"
-        int updated_by "更新者"
+        bigint updated_by "更新者"
         timestamptz updated_at "更新日時"
         boolean is_deleted "削除フラグ"
         varchar account_id UK "アカウントID"
@@ -163,12 +163,12 @@ erDiagram
     }
 
     location_mst {
-        serial id PK "ロケーションID"
-        int account_no FK,UK "アカウント番号"
-        int location_no UK "ロケーション番号"
-        int created_by "作成者"
+        bigserial id PK "ロケーションID"
+        bigint account_no FK,UK "アカウント番号"
+        bigint location_no UK "ロケーション番号"
+        bigint created_by "作成者"
         timestamptz created_at "作成日時"
-        int updated_by "更新者"
+        bigint updated_by "更新者"
         timestamptz updated_at "更新日時"
         boolean is_deleted "削除フラグ"
         text location_name UK "ロケーション名"
@@ -178,8 +178,8 @@ erDiagram
     }
 
     refresh_token {
-        serial token_id PK "トークンID"
-        int account_no FK "アカウント番号"
+        bigserial token_id PK "トークンID"
+        bigint account_no FK "アカウント番号"
         varchar token_hash "トークンハッシュ"
         timestamptz expires_at "有効期限"
         timestamptz created_at "作成日時"
@@ -195,22 +195,22 @@ erDiagram
 ```mermaid
 erDiagram
     account {
-        serial account_no PK "アカウント番号"
+        bigserial account_no PK "アカウント番号"
         varchar account_id UK "アカウントID"
         varchar account_name "アカウント名"
     }
 
     photo_mst {
-        serial id PK "写真ID"
-        int account_no FK,UK "アカウント番号"
-        int photo_no UK "写真番号"
-        int created_by "作成者"
+        bigserial id PK "写真ID"
+        bigint account_no FK,UK "アカウント番号"
+        bigint photo_no UK "写真番号"
+        bigint created_by "作成者"
         timestamptz created_at "作成日時"
-        int updated_by "更新者"
+        bigint updated_by "更新者"
         timestamptz updated_at "更新日時"
         boolean is_deleted "削除フラグ"
         timestamptz photo_at "撮影日時"
-        int location_no "ロケーション番号"
+        bigint location_no "ロケーション番号"
         text image_file_path "画像ファイルパス"
         varchar photo_japanese_title "写真タイトル(日本語)"
         varchar photo_english_title "写真タイトル(英語)"
@@ -223,22 +223,22 @@ erDiagram
     }
 
     photo_tag_mst {
-        serial id PK "タグID"
-        int account_no FK,UK "アカウント番号"
-        int photo_no FK,UK "写真番号"
-        int tag_no UK "タグ番号"
-        int created_by "作成者"
+        bigserial id PK "タグID"
+        bigint account_no FK,UK "アカウント番号"
+        bigint photo_no FK,UK "写真番号"
+        bigint tag_no UK "タグ番号"
+        bigint created_by "作成者"
         timestamptz created_at "作成日時"
         varchar tag_japanese_name "タグ名(日本語)"
         varchar tag_english_name "タグ名(英語)"
     }
 
     photo_favorite {
-        serial id PK "お気に入りID"
-        int account_no FK,UK "アカウント番号"
-        int favorite_photo_account_no FK,UK "写真所有者アカウント番号"
-        int favorite_photo_no FK,UK "写真番号"
-        int created_by "作成者"
+        bigserial id PK "お気に入りID"
+        bigint account_no FK,UK "アカウント番号"
+        bigint favorite_photo_account_no FK,UK "写真所有者アカウント番号"
+        bigint favorite_photo_no FK,UK "写真番号"
+        bigint created_by "作成者"
         timestamptz created_at "作成日時"
     }
 

--- a/doc/database/table-definition.md
+++ b/doc/database/table-definition.md
@@ -37,10 +37,10 @@
 
 | No | カラム名 | データ型 | NOT NULL | デフォルト値 | 説明 |
 |----|----------|----------|----------|-------------|------|
-| 1 | account_no | serial | YES | (自動採番) | アカウント番号 |
-| 2 | created_by | int | YES | - | 作成者 |
+| 1 | account_no | bigserial | YES | (自動採番) | アカウント番号 |
+| 2 | created_by | bigint | YES | - | 作成者 |
 | 3 | created_at | timestamp with time zone | YES | - | 作成日時 |
-| 4 | updated_by | int | YES | - | 更新者 |
+| 4 | updated_by | bigint | YES | - | 更新者 |
 | 5 | updated_at | timestamp with time zone | YES | - | 更新日時 |
 | 6 | is_deleted | boolean | YES | false | 削除フラグ |
 | 7 | account_id | varchar(20) | YES | - | アカウントID（8〜20文字の英数字） |
@@ -117,12 +117,12 @@
 
 | No | カラム名 | データ型 | NOT NULL | デフォルト値 | 説明 |
 |----|----------|----------|----------|-------------|------|
-| 1 | id | serial | YES | (自動採番) | ロケーションID |
-| 2 | account_no | int | YES | - | アカウント番号 |
-| 3 | location_no | int | YES | - | ロケーション番号 |
-| 4 | created_by | int | YES | - | 作成者 |
+| 1 | id | bigserial | YES | (自動採番) | ロケーションID |
+| 2 | account_no | bigint | YES | - | アカウント番号 |
+| 3 | location_no | bigint | YES | - | ロケーション番号 |
+| 4 | created_by | bigint | YES | - | 作成者 |
 | 5 | created_at | timestamp with time zone | YES | - | 作成日時 |
-| 6 | updated_by | int | YES | - | 更新者 |
+| 6 | updated_by | bigint | YES | - | 更新者 |
 | 7 | updated_at | timestamp with time zone | YES | - | 更新日時 |
 | 8 | is_deleted | boolean | YES | false | 削除フラグ |
 | 9 | location_name | text | YES | - | ロケーション名 |
@@ -149,8 +149,8 @@ JWT認証のリフレッシュトークンを管理するテーブル。
 
 | No | カラム名 | データ型 | NOT NULL | デフォルト値 | 説明 |
 |----|----------|----------|----------|-------------|------|
-| 1 | token_id | serial | YES | (自動採番) | トークンID |
-| 2 | account_no | int | YES | - | アカウント番号 |
+| 1 | token_id | bigserial | YES | (自動採番) | トークンID |
+| 2 | account_no | bigint | YES | - | アカウント番号 |
 | 3 | token_hash | varchar(256) | YES | - | トークンハッシュ（SHA-256） |
 | 4 | expires_at | timestamp with time zone | YES | - | 有効期限 |
 | 5 | created_at | timestamp with time zone | YES | NOW() | 作成日時 |
@@ -180,16 +180,16 @@ JWT認証のリフレッシュトークンを管理するテーブル。
 
 | No | カラム名 | データ型 | NOT NULL | デフォルト値 | 説明 |
 |----|----------|----------|----------|-------------|------|
-| 1 | id | serial | YES | (自動採番) | 写真ID |
-| 2 | account_no | int | YES | - | アカウント番号 |
-| 3 | photo_no | int | YES | - | 写真番号 |
-| 4 | created_by | int | YES | - | 作成者 |
+| 1 | id | bigserial | YES | (自動採番) | 写真ID |
+| 2 | account_no | bigint | YES | - | アカウント番号 |
+| 3 | photo_no | bigint | YES | - | 写真番号 |
+| 4 | created_by | bigint | YES | - | 作成者 |
 | 5 | created_at | timestamp with time zone | YES | - | 作成日時 |
-| 6 | updated_by | int | YES | - | 更新者 |
+| 6 | updated_by | bigint | YES | - | 更新者 |
 | 7 | updated_at | timestamp with time zone | YES | - | 更新日時 |
 | 8 | is_deleted | boolean | YES | false | 削除フラグ |
 | 9 | photo_at | timestamp with time zone | YES | - | 撮影日時 |
-| 10 | location_no | int | YES | - | ロケーション番号 |
+| 10 | location_no | bigint | YES | - | ロケーション番号 |
 | 11 | image_file_path | text | YES | - | 画像ファイルパス |
 | 12 | photo_japanese_title | varchar(100) | YES | - | 写真タイトル（日本語） |
 | 13 | photo_english_title | varchar(100) | YES | '""' | 写真タイトル（英語） |
@@ -218,11 +218,11 @@ JWT認証のリフレッシュトークンを管理するテーブル。
 
 | No | カラム名 | データ型 | NOT NULL | デフォルト値 | 説明 |
 |----|----------|----------|----------|-------------|------|
-| 1 | id | serial | YES | (自動採番) | タグID |
-| 2 | account_no | int | YES | - | アカウント番号 |
-| 3 | photo_no | int | YES | - | 写真番号 |
-| 4 | tag_no | int | YES | - | タグ番号 |
-| 5 | created_by | int | YES | - | 作成者 |
+| 1 | id | bigserial | YES | (自動採番) | タグID |
+| 2 | account_no | bigint | YES | - | アカウント番号 |
+| 3 | photo_no | bigint | YES | - | 写真番号 |
+| 4 | tag_no | bigint | YES | - | タグ番号 |
+| 5 | created_by | bigint | YES | - | 作成者 |
 | 6 | created_at | timestamp with time zone | YES | - | 作成日時 |
 | 7 | tag_japanese_name | varchar(20) | YES | - | タグ名（日本語） |
 | 8 | tag_english_name | varchar(20) | YES | '""' | タグ名（英語） |
@@ -245,11 +245,11 @@ JWT認証のリフレッシュトークンを管理するテーブル。
 
 | No | カラム名 | データ型 | NOT NULL | デフォルト値 | 説明 |
 |----|----------|----------|----------|-------------|------|
-| 1 | id | serial | YES | (自動採番) | お気に入りID |
-| 2 | account_no | int | YES | - | アカウント番号（お気に入りしたユーザー） |
-| 3 | favorite_photo_account_no | int | YES | - | 写真所有者のアカウント番号 |
-| 4 | favorite_photo_no | int | YES | - | 写真番号 |
-| 5 | created_by | int | YES | - | 作成者 |
+| 1 | id | bigserial | YES | (自動採番) | お気に入りID |
+| 2 | account_no | bigint | YES | - | アカウント番号（お気に入りしたユーザー） |
+| 3 | favorite_photo_account_no | bigint | YES | - | 写真所有者のアカウント番号 |
+| 4 | favorite_photo_no | bigint | YES | - | 写真番号 |
+| 5 | created_by | bigint | YES | - | 作成者 |
 | 6 | created_at | timestamp with time zone | YES | - | 作成日時 |
 
 ### 制約


### PR DESCRIPTION
## Summary
- PostgreSQLのPKを`serial`→`bigserial`、FK/参照カラムを`int`/`integer`→`bigint`に変更
- Java側のID関連フィールド(`accountNo`, `photoNo`, `tagNo`, `locationNo`, `tokenId`, `createdBy`, `updatedBy`, `favoritePhotoAccountNo`, `favoritePhotoNo`)を`Integer`→`Long`に統一
- MyBatis XMLの`parameterType`/`resultType`を`Long`に更新

## 変更対象
- SQLスキーマファイル (6ファイル)
- Entity (5), Model (12), DTO (4), Request (8), Response (4)
- Mapper (2), Repository (6), Service (2), Controller (1), Security (2)
- MyBatis XML (2)
- テストコード (33ファイル)

## 変更しないフィールド
`loginFailureCount`, `focalLength`, `iso`, `favoriteCount`, `fValue`, `shutterSpeed`等の非IDフィールドは`Integer`のまま

## Test plan
- [x] `./backend/gradlew -p backend clean build` でコンパイル成功を確認
- [ ] `./backend/gradlew -p backend test` で全テスト通過を確認
- [ ] Docker PostgreSQLを起動して統合テストを実行
- [ ] DBスキーマの再作成と動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)