### PR TITLE
JIG(Java Integration Graph)を導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   - [ビルド・テスト](#ビルドテスト)
   - [アーキテクチャ](#アーキテクチャ)
   - [データベース構成](#データベース構成)
+  - [コード構造の可視化（JIG）](#コード構造の可視化jig)
   - [画面設計](#画面設計)
   - [API](#api)
   - [プロジェクト構成](#プロジェクト構成)
@@ -188,6 +189,16 @@ docker compose --profile docs run --rm schemaspy
 ```
 
 生成後、`doc/database/common/index.html`（commonスキーマ）と`doc/database/photo/index.html`（photoスキーマ）をブラウザで開いてください。
+
+## コード構造の可視化（JIG）
+
+[JIG（Java Integration Graph）](https://github.com/dddjava/jig)によるコード構造のドキュメントを自動生成できます。パッケージ関連図・ユースケース図・ドメインモデルなどが出力されます。
+
+```bash
+./backend/gradlew -p backend jigReports
+```
+
+生成後、`backend/build/jig/index.html` をブラウザで開いてください。
 
 ## 画面設計
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -4,6 +4,7 @@ plugins {
 	id 'checkstyle'
 	id 'org.springframework.boot' version '4.0.6'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.dddjava.jig-gradle-plugin' version '2026.5.4'
 }
 
 checkstyle {
@@ -90,4 +91,12 @@ tasks.register('generateModulithDocs', Test) {
 	group = 'documentation'
 	useJUnitPlatform()
 	include '**/ModulithDocumentationTest*'
+}
+
+jig {
+	modelPattern = 'com\\.web\\.gallery\\..*'
+}
+
+tasks.named('jigReports') {
+	dependsOn 'classes'
 }


### PR DESCRIPTION
## Summary
- JIG Gradleプラグイン(`org.dddjava.jig-gradle-plugin` v2026.5.4)を`build.gradle`に追加
- `modelPattern`にプロジェクトのベースパッケージ(`com.web.gallery`)を設定
- Gradle 8.14向けに`jigReports`タスクの`classes`への明示的依存関係を追加

## Test plan
- [x] `./backend/gradlew -p backend jigReports` を実行し、`backend/build/jig/` にドキュメントが生成されることを確認
- [x] 生成された `index.html` をブラウザで開き、パッケージ関連図・ユースケース図等が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)