### PR TITLE
管理者専用アカウント管理機能を追加

### DIFF
--- a/backend/src/main/java/com/web/gallery/AccountPrincipal.java
+++ b/backend/src/main/java/com/web/gallery/AccountPrincipal.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import com.web.gallery.enumuration.AuthorityEnum;
 import com.web.gallery.model.AccountModel;
 
 /**
@@ -45,6 +46,15 @@ public class AccountPrincipal implements UserDetails {
 	 */
 	public Long getAccountNo() {
 		return accountModel.getAccountNo();
+	}
+
+	/**
+	 * 権限区分を取得する
+	 *
+	 * @return	権限区分
+	 */
+	public AuthorityEnum getAuthorityKbn() {
+		return accountModel.getAuthorityKbn();
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/constant/ApiRoutes.java
+++ b/backend/src/main/java/com/web/gallery/constant/ApiRoutes.java
@@ -46,4 +46,14 @@ public final class ApiRoutes {
 	// お気に入り関連
 	/** お気に入りAPI（POST=登録, DELETE=解除） */
 	public static final String API_FAVORITES = API_PREFIX + "/photos/favorites";
+
+	// 管理者関連
+	/** アカウント番号 */
+	public static final String ACCOUNT_NO = "{accountNo}";
+	/** 管理者用アカウント一覧API */
+	public static final String API_ADMIN_ACCOUNTS = API_PREFIX + "/admin/accounts";
+	/** 管理者用アカウントロック解除API */
+	public static final String API_ADMIN_ACCOUNT_UNLOCK = API_ADMIN_ACCOUNTS + "/" + ACCOUNT_NO + "/unlock";
+	/** 管理者用アカウント強制ロックAPI */
+	public static final String API_ADMIN_ACCOUNT_LOCK = API_ADMIN_ACCOUNTS + "/" + ACCOUNT_NO + "/lock";
 }

--- a/backend/src/main/java/com/web/gallery/constant/MessageConst.java
+++ b/backend/src/main/java/com/web/gallery/constant/MessageConst.java
@@ -28,4 +28,9 @@ public final class MessageConst {
 	public static final String ERR_DUPLICATE_PHOTO_FILE = "写真登録でエラーが発生しました。（既に同じファイル名でアップロード済みです）";
 	public static final String ERR_PHOTO_NOT_FOUND = "写真が存在しません。";
 	public static final String ERR_REACHED_REGISTRATION_LIMIT = "写真の登録枚数が上限に達しています。";
+	public static final String ERR_NOT_AUTHORIZED_TO_ADMIN = "管理者権限がありません。";
+
+	// Admin
+	public static final String UNLOCK_ACCOUNT = "アカウントのロックを解除しました。";
+	public static final String LOCK_ACCOUNT = "アカウントをロックしました。";
 }

--- a/backend/src/main/java/com/web/gallery/controller/AdminAccountRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/AdminAccountRestController.java
@@ -1,0 +1,116 @@
+package com.web.gallery.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.web.gallery.constant.ApiRoutes;
+import com.web.gallery.constant.MessageConst;
+import com.web.gallery.controller.response.AdminAccountListItemResponse;
+import com.web.gallery.controller.response.AdminAccountLockResponse;
+import com.web.gallery.enumuration.AuthorityEnum;
+import com.web.gallery.enumuration.ErrorEnum;
+import com.web.gallery.exception.ForbiddenAccountException;
+import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.helper.SessionHelper;
+import com.web.gallery.service.impl.AccountServiceImpl;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 管理者用アカウント管理に関するAPI通信を扱うRestControllerクラス
+ */
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "管理者アカウント管理", description = "管理者用アカウント管理に関するAPI")
+@SecurityRequirement(name = "Bearer")
+public class AdminAccountRestController {
+	private final AccountServiceImpl accountServiceImpl;
+	private final SessionHelper sessionHelper;
+
+	/**
+	 * 管理者用アカウント一覧取得
+	 *
+	 * @return	{@link AdminAccountListItemResponse}のリスト
+	 * @throws	ForbiddenAccountException	管理者権限がない場合
+	 */
+	@Operation(summary = "管理者用アカウント一覧取得", description = "削除済みを含む全アカウントの一覧を取得する")
+	@ApiResponse(responseCode = "200", description = "取得成功")
+	@ApiResponse(responseCode = "403", description = "管理者権限がない", content = @Content)
+	@GetMapping(ApiRoutes.API_ADMIN_ACCOUNTS)
+	public ResponseEntity<List<AdminAccountListItemResponse>> getAdminAccountList()
+			throws ForbiddenAccountException {
+
+		validateAdminAuthority();
+
+		List<AdminAccountListItemResponse> responseList = accountServiceImpl.getAccountListForAdmin().stream()
+				.map(AdminAccountListItemResponse::from)
+				.toList();
+
+		return ResponseEntity.ok(responseList);
+	}
+
+	/**
+	 * アカウントロック解除
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @return				{@link AdminAccountLockResponse}
+	 * @throws	ForbiddenAccountException	管理者権限がない場合
+	 * @throws	UpdateFailureException		更新に失敗した場合
+	 */
+	@Operation(summary = "アカウントロック解除", description = "指定したアカウントのロックを解除する")
+	@ApiResponse(responseCode = "200", description = "ロック解除成功")
+	@ApiResponse(responseCode = "403", description = "管理者権限がない", content = @Content)
+	@PutMapping(ApiRoutes.API_ADMIN_ACCOUNT_UNLOCK)
+	public ResponseEntity<AdminAccountLockResponse> unlockAccount(
+			@PathVariable Long accountNo) throws ForbiddenAccountException, UpdateFailureException {
+
+		validateAdminAuthority();
+
+		accountServiceImpl.unlockAccount(accountNo);
+
+		return ResponseEntity.ok(AdminAccountLockResponse.of(MessageConst.UNLOCK_ACCOUNT));
+	}
+
+	/**
+	 * アカウント強制ロック
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @return				{@link AdminAccountLockResponse}
+	 * @throws	ForbiddenAccountException	管理者権限がない場合
+	 * @throws	UpdateFailureException		更新に失敗した場合
+	 */
+	@Operation(summary = "アカウント強制ロック", description = "指定したアカウントを強制的にロックする")
+	@ApiResponse(responseCode = "200", description = "ロック成功")
+	@ApiResponse(responseCode = "403", description = "管理者権限がない", content = @Content)
+	@PutMapping(ApiRoutes.API_ADMIN_ACCOUNT_LOCK)
+	public ResponseEntity<AdminAccountLockResponse> lockAccount(
+			@PathVariable Long accountNo) throws ForbiddenAccountException, UpdateFailureException {
+
+		validateAdminAuthority();
+
+		accountServiceImpl.lockAccount(accountNo);
+
+		return ResponseEntity.ok(AdminAccountLockResponse.of(MessageConst.LOCK_ACCOUNT));
+	}
+
+	/**
+	 * 管理者権限のバリデーションを行う
+	 *
+	 * @throws	ForbiddenAccountException	管理者権限がない場合
+	 */
+	private void validateAdminAuthority() throws ForbiddenAccountException {
+		if (sessionHelper.getAuthorityKbn() != AuthorityEnum.ADMINISTRATOR) {
+			throw new ForbiddenAccountException(ErrorEnum.NOT_AUTHORIZED_TO_ADMIN);
+		}
+	}
+}

--- a/backend/src/main/java/com/web/gallery/controller/CommonRestControllerAdvice.java
+++ b/backend/src/main/java/com/web/gallery/controller/CommonRestControllerAdvice.java
@@ -26,6 +26,7 @@ import com.web.gallery.exception.UpdateFailureException;
 @Hidden
 @RestControllerAdvice(assignableTypes = {
 		AccountRestController.class,
+		AdminAccountRestController.class,
 		KbnMstRestController.class,
 		PhotoFavoriteController.class,
 		PhotoRestController.class

--- a/backend/src/main/java/com/web/gallery/controller/response/AdminAccountListItemResponse.java
+++ b/backend/src/main/java/com/web/gallery/controller/response/AdminAccountListItemResponse.java
@@ -1,0 +1,64 @@
+package com.web.gallery.controller.response;
+
+import java.time.OffsetDateTime;
+
+import com.web.gallery.enumuration.AuthorityEnum;
+import com.web.gallery.model.AccountModel;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * 管理者用アカウント一覧のレスポンスパラメータを保持するクラス
+ */
+@Schema(description = "管理者用アカウント一覧アイテムレスポンス")
+@Data
+@Builder
+public class AdminAccountListItemResponse {
+	/** アカウント番号 */
+	@Schema(description = "アカウント番号", example = "1")
+	private Long accountNo;
+
+	/** アカウントID */
+	@Schema(description = "アカウントID", example = "testuser01")
+	private String accountId;
+
+	/** アカウント名 */
+	@Schema(description = "アカウント名", example = "テストユーザー")
+	private String accountName;
+
+	/** 権限区分 */
+	@Schema(description = "権限区分", example = "administrator")
+	private String authorityKbn;
+
+	/** 削除フラグ */
+	@Schema(description = "削除フラグ", example = "false")
+	private Boolean isDeleted;
+
+	/** 最終ログイン日時 */
+	@Schema(description = "最終ログイン日時")
+	private OffsetDateTime lastLoginDatetime;
+
+	/** ログイン失敗回数 */
+	@Schema(description = "ログイン失敗回数", example = "0")
+	private Integer loginFailureCount;
+
+	/**
+	 * AccountModelからAdminAccountListItemResponseを生成する
+	 *
+	 * @param	model	{@link AccountModel}
+	 * @return			{@link AdminAccountListItemResponse}
+	 */
+	public static AdminAccountListItemResponse from(AccountModel model) {
+		return AdminAccountListItemResponse.builder()
+				.accountNo(model.getAccountNo())
+				.accountId(model.getAccountId())
+				.accountName(model.getAccountName())
+				.authorityKbn(model.getAuthorityKbn().getDbValue())
+				.isDeleted(model.getIsDeleted())
+				.lastLoginDatetime(model.getLastLoginDatetime())
+				.loginFailureCount(model.getLoginFailureCount())
+				.build();
+	}
+}

--- a/backend/src/main/java/com/web/gallery/controller/response/AdminAccountLockResponse.java
+++ b/backend/src/main/java/com/web/gallery/controller/response/AdminAccountLockResponse.java
@@ -1,0 +1,41 @@
+package com.web.gallery.controller.response;
+
+import org.springframework.http.HttpStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * 管理者用アカウントロック操作のレスポンスパラメータを保持するクラス
+ */
+@Schema(description = "管理者用アカウントロック操作レスポンス")
+@Data
+@Builder
+public class AdminAccountLockResponse {
+	/** HTTPステータス */
+	@Schema(description = "HTTPステータスコード", example = "200")
+	private Integer httpStatus;
+
+	/** 成功フラグ */
+	@Schema(description = "成功", example = "true")
+	private Boolean isSuccess;
+
+	/** メッセージ */
+	@Schema(description = "メッセージ")
+	private String message;
+
+	/**
+	 * 成功レスポンスを生成する
+	 *
+	 * @param	message	メッセージ
+	 * @return			{@link AdminAccountLockResponse}
+	 */
+	public static AdminAccountLockResponse of(String message) {
+		return AdminAccountLockResponse.builder()
+				.httpStatus(HttpStatus.OK.value())
+				.isSuccess(true)
+				.message(message)
+				.build();
+	}
+}

--- a/backend/src/main/java/com/web/gallery/entity/Account.java
+++ b/backend/src/main/java/com/web/gallery/entity/Account.java
@@ -205,4 +205,13 @@ public class Account {
 				.isDeleted(false)
 				.build();
 	}
+
+	/**
+	 * 管理者用アカウント一覧取得用の条件Accountエンティティを生成する（全件取得）
+	 *
+	 * @return	{@link Account}
+	 */
+	public static Account conditionForAdminList() {
+		return Account.builder().build();
+	}
 }

--- a/backend/src/main/java/com/web/gallery/enumuration/ErrorEnum.java
+++ b/backend/src/main/java/com/web/gallery/enumuration/ErrorEnum.java
@@ -107,7 +107,14 @@ public enum ErrorEnum {
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_REACHED_REGISTRATION_LIMIT}
 	 */
-	REACHED_REGISTRATION_LIMIT("E-P-0010", MessageConst.ERR_REACHED_REGISTRATION_LIMIT);
+	REACHED_REGISTRATION_LIMIT("E-P-0010", MessageConst.ERR_REACHED_REGISTRATION_LIMIT),
+
+	/**
+	 * エラーコード：E-A-0001
+	 * <p>
+	 * エラーメッセージ：{@value MessageConst#ERR_NOT_AUTHORIZED_TO_ADMIN}
+	 */
+	NOT_AUTHORIZED_TO_ADMIN("E-A-0001", MessageConst.ERR_NOT_AUTHORIZED_TO_ADMIN);
 	
 	/** エラーコード */
 	private final String errorCode;

--- a/backend/src/main/java/com/web/gallery/helper/SessionHelper.java
+++ b/backend/src/main/java/com/web/gallery/helper/SessionHelper.java
@@ -5,6 +5,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import com.web.gallery.AccountPrincipal;
+import com.web.gallery.enumuration.AuthorityEnum;
 
 /**
  * セッション管理のためのHelperクラス
@@ -33,7 +34,7 @@ public class SessionHelper {
 	
 	/**
 	 * セッション情報からアカウントIDを取得する
-	 * 
+	 *
 	 * @return	アカウントID
 	 */
 	public String getAccountId() {
@@ -41,13 +42,33 @@ public class SessionHelper {
 
 		Authentication authentication =
 				SecurityContextHolder.getContext().getAuthentication();
-		
+
 		if (authentication.getPrincipal() instanceof AccountPrincipal) {
 			AccountPrincipal accountPrincipal =
 					AccountPrincipal.class.cast(authentication.getPrincipal());
 			accountId = accountPrincipal.getUsername();
 		}
-		
+
 		return accountId;
+	}
+
+	/**
+	 * セッション情報から権限区分を取得する
+	 *
+	 * @return	権限区分
+	 */
+	public AuthorityEnum getAuthorityKbn() {
+		AuthorityEnum authorityKbn = null;
+
+		Authentication authentication =
+				SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication.getPrincipal() instanceof AccountPrincipal) {
+			AccountPrincipal accountPrincipal =
+					AccountPrincipal.class.cast(authentication.getPrincipal());
+			authorityKbn = accountPrincipal.getAuthorityKbn();
+		}
+
+		return authorityKbn;
 	}
 }

--- a/backend/src/main/java/com/web/gallery/repository/AccountRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/AccountRepository.java
@@ -67,4 +67,11 @@ public interface AccountRepository {
 	 * @return	{@link AccountModel}
 	 */
 	List<AccountModel> getAccountList();
+
+	/**
+	 * 削除済みを含む全アカウントの一覧を取得する
+	 *
+	 * @return	{@link AccountModel}
+	 */
+	List<AccountModel> getAccountListAll();
 }

--- a/backend/src/main/java/com/web/gallery/repository/impl/AccountRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/AccountRepositoryImpl.java
@@ -129,4 +129,15 @@ public class AccountRepositoryImpl implements AccountRepository {
 		List<Account> accountList = accountMapper.select(Account.conditionForList());
 		return accountList.stream().map(AccountModel::from).toList();
 	}
+
+	/**
+	 * 削除済みを含む全アカウントの一覧を取得する
+	 *
+	 * @return	{@link AccountModel}
+	 */
+	@Override
+	public List<AccountModel> getAccountListAll() {
+		List<Account> accountList = accountMapper.select(Account.conditionForAdminList());
+		return accountList.stream().map(AccountModel::from).toList();
+	}
 }

--- a/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
@@ -106,6 +106,47 @@ public class AccountServiceImpl implements UserDetailsService {
 	}
 
 	/**
+	 * 管理者用：削除済みを含む全アカウントの一覧を取得する
+	 *
+	 * @return	{@link AccountModel}
+	 */
+	@Transactional(readOnly = true)
+	public List<AccountModel> getAccountListForAdmin() {
+		return accountRepository.getAccountListAll().stream().sorted(Comparator.comparing(AccountModel::getAccountId)).toList();
+	}
+
+	/**
+	 * 管理者用：アカウントのロックを解除する（ログイン失敗回数を0にリセット）
+	 *
+	 * @param	accountNo				アカウント番号
+	 * @throws	UpdateFailureException	更新に失敗した場合
+	 */
+	@Transactional
+	public void unlockAccount(Long accountNo) throws UpdateFailureException {
+		AccountModel updateModel = AccountModel.builder()
+				.accountNo(accountNo)
+				.lastLoginDatetime(OffsetDateTime.now(Consts.JST))
+				.loginFailureCount(0)
+				.build();
+		accountRepository.updateLoginFailureCount(updateModel);
+	}
+
+	/**
+	 * 管理者用：アカウントを強制ロックする（ログイン失敗回数を上限超過に設定）
+	 *
+	 * @param	accountNo				アカウント番号
+	 * @throws	UpdateFailureException	更新に失敗した場合
+	 */
+	@Transactional
+	public void lockAccount(Long accountNo) throws UpdateFailureException {
+		AccountModel updateModel = AccountModel.builder()
+				.accountNo(accountNo)
+				.loginFailureCount(loginConfig.getFailCount())
+				.build();
+		accountRepository.updateLoginFailureCount(updateModel);
+	}
+
+	/**
 	 * 認証成功
 	 *
 	 * @param	event					{@link AuthenticationSuccessEvent}

--- a/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
@@ -125,7 +125,6 @@ public class AccountServiceImpl implements UserDetailsService {
 	public void unlockAccount(Long accountNo) throws UpdateFailureException {
 		AccountModel updateModel = AccountModel.builder()
 				.accountNo(accountNo)
-				.lastLoginDatetime(OffsetDateTime.now(Consts.JST))
 				.loginFailureCount(0)
 				.build();
 		accountRepository.updateLoginFailureCount(updateModel);

--- a/backend/src/test/java/com/web/gallery/controller/AdminAccountRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/AdminAccountRestControllerTest.java
@@ -1,0 +1,222 @@
+package com.web.gallery.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import tools.jackson.databind.json.JsonMapper;
+import com.web.gallery.constant.MessageConst;
+import com.web.gallery.enumuration.AuthorityEnum;
+import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.helper.SessionHelper;
+import com.web.gallery.model.AccountModel;
+import com.web.gallery.service.impl.AccountServiceImpl;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class AdminAccountRestControllerTest {
+	@InjectMocks
+	private AdminAccountRestController adminAccountRestController;
+
+	@Mock
+	private AccountServiceImpl accountServiceImpl;
+
+	@Mock
+	private SessionHelper sessionHelper;
+
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp() {
+		JsonMapper jsonMapper = JsonMapper.builder().build();
+
+		JacksonJsonHttpMessageConverter converter = new JacksonJsonHttpMessageConverter(jsonMapper);
+
+		mockMvc = MockMvcBuilders.standaloneSetup(adminAccountRestController)
+				.setMessageConverters(converter)
+				.setControllerAdvice(new CommonRestControllerAdvice())
+				.build();
+	}
+
+	@Nested
+	@Order(1)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class getAdminAccountList {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：管理者がアカウント一覧を取得できること")
+		void getAdminAccountList_success() throws Exception {
+			doReturn(AuthorityEnum.ADMINISTRATOR).when(sessionHelper).getAuthorityKbn();
+
+			List<AccountModel> accountModels = List.of(
+					AccountModel.builder()
+							.accountNo(1L)
+							.accountId("aaaaaaaa")
+							.accountName("AAAAAAAA")
+							.authorityKbn(AuthorityEnum.ADMINISTRATOR)
+							.isDeleted(false)
+							.lastLoginDatetime(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9)))
+							.loginFailureCount(0)
+							.build(),
+					AccountModel.builder()
+							.accountNo(2L)
+							.accountId("bbbbbbbb")
+							.accountName("BBBBBBBB")
+							.authorityKbn(AuthorityEnum.MINI)
+							.isDeleted(true)
+							.lastLoginDatetime(OffsetDateTime.of(2024, 1, 2, 0, 0, 0, 0, ZoneOffset.ofHours(9)))
+							.loginFailureCount(5)
+							.build()
+			);
+
+			doReturn(accountModels).when(accountServiceImpl).getAccountListForAdmin();
+
+			mockMvc.perform(get("/api/v1/admin/accounts"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$[0].accountNo").value(1))
+				.andExpect(jsonPath("$[0].accountId").value("aaaaaaaa"))
+				.andExpect(jsonPath("$[0].accountName").value("AAAAAAAA"))
+				.andExpect(jsonPath("$[0].authorityKbn").value("administrator"))
+				.andExpect(jsonPath("$[0].isDeleted").value(false))
+				.andExpect(jsonPath("$[0].loginFailureCount").value(0))
+				.andExpect(jsonPath("$[1].accountNo").value(2))
+				.andExpect(jsonPath("$[1].accountId").value("bbbbbbbb"))
+				.andExpect(jsonPath("$[1].isDeleted").value(true))
+				.andExpect(jsonPath("$[1].loginFailureCount").value(5));
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("正常系：アカウントが0件の場合は空リストを返すこと")
+		void getAdminAccountList_empty() throws Exception {
+			doReturn(AuthorityEnum.ADMINISTRATOR).when(sessionHelper).getAuthorityKbn();
+			doReturn(Collections.emptyList()).when(accountServiceImpl).getAccountListForAdmin();
+
+			mockMvc.perform(get("/api/v1/admin/accounts"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$").isArray())
+				.andExpect(jsonPath("$").isEmpty());
+		}
+
+		@Test
+		@Order(3)
+		@DisplayName("異常系：管理者以外は403を返すこと")
+		void getAdminAccountList_forbidden() throws Exception {
+			doReturn(AuthorityEnum.NORMAL).when(sessionHelper).getAuthorityKbn();
+
+			mockMvc.perform(get("/api/v1/admin/accounts"))
+				.andExpect(status().isForbidden());
+
+			verify(accountServiceImpl, times(0)).getAccountListForAdmin();
+		}
+	}
+
+	@Nested
+	@Order(2)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class unlockAccountTest {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウントのロックを解除できること")
+		void unlockAccount_success() throws Exception {
+			doReturn(AuthorityEnum.ADMINISTRATOR).when(sessionHelper).getAuthorityKbn();
+			doNothing().when(accountServiceImpl).unlockAccount(1L);
+
+			mockMvc.perform(put("/api/v1/admin/accounts/1/unlock"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.httpStatus").value(200))
+				.andExpect(jsonPath("$.isSuccess").value(true))
+				.andExpect(jsonPath("$.message").value(MessageConst.UNLOCK_ACCOUNT));
+
+			verify(accountServiceImpl, times(1)).unlockAccount(1L);
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("異常系：管理者以外は403を返すこと")
+		void unlockAccount_forbidden() throws Exception {
+			doReturn(AuthorityEnum.MINI).when(sessionHelper).getAuthorityKbn();
+
+			mockMvc.perform(put("/api/v1/admin/accounts/1/unlock"))
+				.andExpect(status().isForbidden());
+
+			verify(accountServiceImpl, times(0)).unlockAccount(anyLong());
+		}
+
+		@Test
+		@Order(3)
+		@DisplayName("異常系：UpdateFailureExceptionが発生した場合は409を返すこと")
+		void unlockAccount_updateFailure() throws Exception {
+			doReturn(AuthorityEnum.ADMINISTRATOR).when(sessionHelper).getAuthorityKbn();
+			doThrow(UpdateFailureException.class).when(accountServiceImpl).unlockAccount(999L);
+
+			mockMvc.perform(put("/api/v1/admin/accounts/999/unlock"))
+				.andExpect(status().isConflict());
+		}
+	}
+
+	@Nested
+	@Order(3)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class lockAccountTest {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウントを強制ロックできること")
+		void lockAccount_success() throws Exception {
+			doReturn(AuthorityEnum.ADMINISTRATOR).when(sessionHelper).getAuthorityKbn();
+			doNothing().when(accountServiceImpl).lockAccount(1L);
+
+			mockMvc.perform(put("/api/v1/admin/accounts/1/lock"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.httpStatus").value(200))
+				.andExpect(jsonPath("$.isSuccess").value(true))
+				.andExpect(jsonPath("$.message").value(MessageConst.LOCK_ACCOUNT));
+
+			verify(accountServiceImpl, times(1)).lockAccount(1L);
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("異常系：管理者以外は403を返すこと")
+		void lockAccount_forbidden() throws Exception {
+			doReturn(AuthorityEnum.SPECIAL).when(sessionHelper).getAuthorityKbn();
+
+			mockMvc.perform(put("/api/v1/admin/accounts/1/lock"))
+				.andExpect(status().isForbidden());
+
+			verify(accountServiceImpl, times(0)).lockAccount(anyLong());
+		}
+
+		@Test
+		@Order(3)
+		@DisplayName("異常系：UpdateFailureExceptionが発生した場合は409を返すこと")
+		void lockAccount_updateFailure() throws Exception {
+			doReturn(AuthorityEnum.ADMINISTRATOR).when(sessionHelper).getAuthorityKbn();
+			doThrow(UpdateFailureException.class).when(accountServiceImpl).lockAccount(999L);
+
+			mockMvc.perform(put("/api/v1/admin/accounts/999/lock"))
+				.andExpect(status().isConflict());
+		}
+	}
+}

--- a/backend/src/test/java/com/web/gallery/controller/integration/AdminAccountRestControllerIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/integration/AdminAccountRestControllerIntegrationTest.java
@@ -1,0 +1,229 @@
+package com.web.gallery.controller.integration;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.web.gallery.AccountPrincipal;
+import com.web.gallery.constant.MessageConst;
+import com.web.gallery.enumuration.AuthorityEnum;
+import com.web.gallery.enumuration.ErrorEnum;
+import com.web.gallery.model.AccountModel;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+public class AdminAccountRestControllerIntegrationTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	private Authentication createAdminAuthentication() {
+		AccountModel sessionAccount = AccountModel.builder()
+				.accountNo(1L)
+				.accountId("aaaaaaaa")
+				.accountName("AAAAAAAA")
+				.password("$2a$10$password1")
+				.authorityKbn(AuthorityEnum.ADMINISTRATOR)
+				.build();
+		AccountPrincipal accountPrincipal = new AccountPrincipal(sessionAccount, 0);
+		return new UsernamePasswordAuthenticationToken(accountPrincipal, null, accountPrincipal.getAuthorities());
+	}
+
+	private Authentication createNonAdminAuthentication() {
+		AccountModel sessionAccount = AccountModel.builder()
+				.accountNo(2L)
+				.accountId("bbbbbbbb")
+				.accountName("BBBBBBBB")
+				.password("$2a$10$password2")
+				.authorityKbn(AuthorityEnum.MINI)
+				.build();
+		AccountPrincipal accountPrincipal = new AccountPrincipal(sessionAccount, 0);
+		return new UsernamePasswordAuthenticationToken(accountPrincipal, null, accountPrincipal.getAuthorities());
+	}
+
+	@Nested
+	@Order(1)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	@Sql("/sql/common/cleanup.sql")
+	@Sql("/sql/controller/AdminAccountRestControllerIntegrationTest.sql")
+	class getAdminAccountList {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：管理者が全アカウント一覧を取得できる（削除済み含む）")
+		void getAdminAccountList_success() throws Exception {
+			mockMvc.perform(
+					get("/api/v1/admin/accounts")
+					.with(SecurityMockMvcRequestPostProcessors.authentication(createAdminAuthentication()))
+					.with(csrf())
+				)
+				.andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$.length()").value(3))
+				.andExpect(jsonPath("$[0].accountId").value("aaaaaaaa"))
+				.andExpect(jsonPath("$[0].accountName").value("AAAAAAAA"))
+				.andExpect(jsonPath("$[0].authorityKbn").value("administrator"))
+				.andExpect(jsonPath("$[0].isDeleted").value(false))
+				.andExpect(jsonPath("$[0].loginFailureCount").value(0))
+				.andExpect(jsonPath("$[1].accountId").value("bbbbbbbb"))
+				.andExpect(jsonPath("$[1].isDeleted").value(false))
+				.andExpect(jsonPath("$[1].loginFailureCount").value(10))
+				.andExpect(jsonPath("$[2].accountId").value("cccccccc"))
+				.andExpect(jsonPath("$[2].isDeleted").value(true));
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("異常系：管理者以外は403を返す")
+		void getAdminAccountList_forbidden() throws Exception {
+			mockMvc.perform(
+					get("/api/v1/admin/accounts")
+					.with(SecurityMockMvcRequestPostProcessors.authentication(createNonAdminAuthentication()))
+					.with(csrf())
+				)
+				.andExpect(status().isForbidden())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$.httpStatus").value(HttpStatus.FORBIDDEN.value()))
+				.andExpect(jsonPath("$.errorCode").value(ErrorEnum.NOT_AUTHORIZED_TO_ADMIN.getErrorCode()))
+				.andExpect(jsonPath("$.errorMessage").value(ErrorEnum.NOT_AUTHORIZED_TO_ADMIN.getErrorMessage()));
+		}
+	}
+
+	@Nested
+	@Order(2)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	@Sql("/sql/common/cleanup.sql")
+	@Sql("/sql/controller/AdminAccountRestControllerIntegrationTest.sql")
+	class unlockAccountTest {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：ロックされたアカウントを解除できる")
+		void unlockAccount_success() throws Exception {
+			mockMvc.perform(
+					put("/api/v1/admin/accounts/2/unlock")
+					.with(SecurityMockMvcRequestPostProcessors.authentication(createAdminAuthentication()))
+					.with(csrf())
+				)
+				.andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$.httpStatus").value(200))
+				.andExpect(jsonPath("$.isSuccess").value(true))
+				.andExpect(jsonPath("$.message").value(MessageConst.UNLOCK_ACCOUNT));
+
+			Integer loginFailureCount = jdbcTemplate.queryForObject(
+					"SELECT login_failure_count FROM common.account WHERE account_no = 2",
+					Integer.class);
+			assertEquals(0, loginFailureCount);
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("異常系：管理者以外は403を返す")
+		void unlockAccount_forbidden() throws Exception {
+			mockMvc.perform(
+					put("/api/v1/admin/accounts/2/unlock")
+					.with(SecurityMockMvcRequestPostProcessors.authentication(createNonAdminAuthentication()))
+					.with(csrf())
+				)
+				.andExpect(status().isForbidden());
+
+			Integer loginFailureCount = jdbcTemplate.queryForObject(
+					"SELECT login_failure_count FROM common.account WHERE account_no = 2",
+					Integer.class);
+			assertEquals(10, loginFailureCount);
+		}
+
+		@Test
+		@Order(3)
+		@DisplayName("異常系：存在しないアカウント番号の場合は409を返す")
+		void unlockAccount_notFound() throws Exception {
+			mockMvc.perform(
+					put("/api/v1/admin/accounts/999/unlock")
+					.with(SecurityMockMvcRequestPostProcessors.authentication(createAdminAuthentication()))
+					.with(csrf())
+				)
+				.andExpect(status().isConflict());
+		}
+	}
+
+	@Nested
+	@Order(3)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	@Sql("/sql/common/cleanup.sql")
+	@Sql("/sql/controller/AdminAccountRestControllerIntegrationTest.sql")
+	class lockAccountTest {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウントを強制ロックできる")
+		void lockAccount_success() throws Exception {
+			mockMvc.perform(
+					put("/api/v1/admin/accounts/1/lock")
+					.with(SecurityMockMvcRequestPostProcessors.authentication(createAdminAuthentication()))
+					.with(csrf())
+				)
+				.andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$.httpStatus").value(200))
+				.andExpect(jsonPath("$.isSuccess").value(true))
+				.andExpect(jsonPath("$.message").value(MessageConst.LOCK_ACCOUNT));
+
+			Integer loginFailureCount = jdbcTemplate.queryForObject(
+					"SELECT login_failure_count FROM common.account WHERE account_no = 1",
+					Integer.class);
+			assertTrue(loginFailureCount > 0);
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("異常系：管理者以外は403を返す")
+		void lockAccount_forbidden() throws Exception {
+			mockMvc.perform(
+					put("/api/v1/admin/accounts/1/lock")
+					.with(SecurityMockMvcRequestPostProcessors.authentication(createNonAdminAuthentication()))
+					.with(csrf())
+				)
+				.andExpect(status().isForbidden());
+
+			Integer loginFailureCount = jdbcTemplate.queryForObject(
+					"SELECT login_failure_count FROM common.account WHERE account_no = 1",
+					Integer.class);
+			assertEquals(0, loginFailureCount);
+		}
+
+		@Test
+		@Order(3)
+		@DisplayName("異常系：存在しないアカウント番号の場合は409を返す")
+		void lockAccount_notFound() throws Exception {
+			mockMvc.perform(
+					put("/api/v1/admin/accounts/999/lock")
+					.with(SecurityMockMvcRequestPostProcessors.authentication(createAdminAuthentication()))
+					.with(csrf())
+				)
+				.andExpect(status().isConflict());
+		}
+	}
+}

--- a/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
@@ -238,6 +238,97 @@ public class AccountServiceImplTest {
 	@Nested
 	@Order(6)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class getAccountListForAdmin {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：全アカウントを取得（削除済み含む）してソートされること")
+		void getAccountListForAdmin_found() {
+			List<AccountModel> accountModelList = new ArrayList<AccountModel>();
+			accountModelList.add(AccountModel.builder().accountId("cccccccc").isDeleted(true).build());
+			accountModelList.add(AccountModel.builder().accountId("bbbbbbbb").isDeleted(false).build());
+			accountModelList.add(AccountModel.builder().accountId("aaaaaaaa").isDeleted(false).build());
+
+			doReturn(accountModelList).when(accountRepositoryImpl).getAccountListAll();
+
+			List<AccountModel> actual = accountServiceImpl.getAccountListForAdmin();
+			assertEquals(3, actual.size());
+			assertEquals("aaaaaaaa", actual.get(0).getAccountId());
+			assertEquals("bbbbbbbb", actual.get(1).getAccountId());
+			assertEquals("cccccccc", actual.get(2).getAccountId());
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("正常系：アカウントが存在しない場合")
+		void getAccountListForAdmin_not_found() {
+			doReturn(new ArrayList<AccountModel>()).when(accountRepositoryImpl).getAccountListAll();
+
+			List<AccountModel> actual = accountServiceImpl.getAccountListForAdmin();
+			assertEquals(0, actual.size());
+		}
+	}
+
+	@Nested
+	@Order(7)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class unlockAccountTest {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：ログイン失敗回数が0にリセットされること")
+		void unlockAccount_success() throws UpdateFailureException {
+			ArgumentCaptor<AccountModel> captor = ArgumentCaptor.forClass(AccountModel.class);
+			doNothing().when(accountRepositoryImpl).updateLoginFailureCount(captor.capture());
+
+			accountServiceImpl.unlockAccount(1L);
+
+			AccountModel accountModel = captor.getValue();
+			assertEquals(1L, accountModel.getAccountNo());
+			assertEquals(0, accountModel.getLoginFailureCount());
+			assertNotNull(accountModel.getLastLoginDatetime());
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
+		void unlockAccount_UpdateFailureException() throws UpdateFailureException {
+			doThrow(UpdateFailureException.class).when(accountRepositoryImpl).updateLoginFailureCount(any(AccountModel.class));
+			assertThrows(UpdateFailureException.class, () -> accountServiceImpl.unlockAccount(999L));
+		}
+	}
+
+	@Nested
+	@Order(8)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class lockAccountTest {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：ログイン失敗回数が上限値に設定されること")
+		void lockAccount_success() throws UpdateFailureException {
+			doReturn(10).when(loginConfig).getFailCount();
+
+			ArgumentCaptor<AccountModel> captor = ArgumentCaptor.forClass(AccountModel.class);
+			doNothing().when(accountRepositoryImpl).updateLoginFailureCount(captor.capture());
+
+			accountServiceImpl.lockAccount(1L);
+
+			AccountModel accountModel = captor.getValue();
+			assertEquals(1L, accountModel.getAccountNo());
+			assertEquals(10, accountModel.getLoginFailureCount());
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
+		void lockAccount_UpdateFailureException() throws UpdateFailureException {
+			doReturn(10).when(loginConfig).getFailCount();
+			doThrow(UpdateFailureException.class).when(accountRepositoryImpl).updateLoginFailureCount(any(AccountModel.class));
+			assertThrows(UpdateFailureException.class, () -> accountServiceImpl.lockAccount(999L));
+		}
+	}
+
+	@Nested
+	@Order(9)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	class handleAuthenticationSuccess {
 		@Test
 		@Order(1)
@@ -313,7 +404,7 @@ public class AccountServiceImplTest {
 	}
 	
 	@Nested
-	@Order(7)
+	@Order(10)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	class handleAuthenticationFailureBadCredentials {
 		@Test

--- a/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
@@ -284,7 +284,7 @@ public class AccountServiceImplTest {
 			AccountModel accountModel = captor.getValue();
 			assertEquals(1L, accountModel.getAccountNo());
 			assertEquals(0, accountModel.getLoginFailureCount());
-			assertNotNull(accountModel.getLastLoginDatetime());
+			assertNull(accountModel.getLastLoginDatetime());
 		}
 
 		@Test

--- a/backend/src/test/resources/sql/controller/AdminAccountRestControllerIntegrationTest.sql
+++ b/backend/src/test/resources/sql/controller/AdminAccountRestControllerIntegrationTest.sql
@@ -1,0 +1,4 @@
+insert into common.account values(1,  1,  '2000-01-01 09:00:00 Asia/Tokyo', 1,  '2001-01-01 09:00:00 Asia/Tokyo', false, 'aaaaaaaa', 'AAAAAAAA', '$2a$10$password1', '1991-02-14', 'none', 'none',     'none', '', 'administrator', '2002-01-01 09:00:00 Asia/Tokyo', 0);
+insert into common.account values(2,  2,  '2000-01-02 09:00:00 Asia/Tokyo', 2,  '2001-01-02 09:00:00 Asia/Tokyo', false, 'bbbbbbbb', 'BBBBBBBB', '$2a$10$password2', '1900-01-01', 'man',  'none',     'none', '', 'mini-user',     '2002-01-01 09:00:00 Asia/Tokyo', 10);
+insert into common.account values(3,  3,  '2000-01-03 09:00:00 Asia/Tokyo', 3,  '2001-01-03 09:00:00 Asia/Tokyo', true,  'cccccccc', 'CCCCCCCC', '$2a$10$password3', '1900-01-01', 'none', 'Hokkaido', 'none', '', 'normal-user',   '2002-01-01 09:00:00 Asia/Tokyo', 0);
+ALTER SEQUENCE common.account_account_no_seq RESTART 4;

--- a/frontend/e2e/admin_account_management.spec.ts
+++ b/frontend/e2e/admin_account_management.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("管理者用アカウント管理ページ", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/admin/account_management");
+  });
+
+  test("ページタイトルが正しいこと", async ({ page }) => {
+    await expect(page).toHaveTitle(/アカウント管理/);
+  });
+
+  test("未ログイン状態では管理者権限エラーが表示されること", async ({ page }) => {
+    await expect(page.locator("text=管理者権限がありません")).toBeVisible({
+      timeout: 5000,
+    });
+  });
+});

--- a/frontend/src/app/admin/account_management/AdminAccountManagement.tsx
+++ b/frontend/src/app/admin/account_management/AdminAccountManagement.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@/lib/auth/AuthProvider";
+import {
+  getAdminAccountList,
+  unlockAccount,
+  lockAccount,
+  type AdminAccountListItem,
+} from "@/lib/api/client";
+
+/**
+ * 管理者用アカウント管理コンポーネント
+ */
+export function AdminAccountManagement() {
+  const { user, isAuthenticated, isLoading: isAuthLoading } = useAuth();
+  const [accounts, setAccounts] = useState<AdminAccountListItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const isAdmin = user?.role === "ROLE_ADMIN";
+
+  useEffect(() => {
+    if (isAuthLoading) return;
+    if (!isAuthenticated || !isAdmin) {
+      setIsLoading(false);
+      return;
+    }
+
+    fetchAccounts();
+  }, [isAuthLoading, isAuthenticated, isAdmin]);
+
+  const fetchAccounts = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await getAdminAccountList();
+      setAccounts(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleUnlock = async (accountNo: number, accountId: string) => {
+    if (!confirm(`${accountId} のロックを解除しますか？`)) return;
+    setMessage(null);
+    setError(null);
+    try {
+      const result = await unlockAccount(accountNo);
+      setMessage(result.message);
+      await fetchAccounts();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+    }
+  };
+
+  const handleLock = async (accountNo: number, accountId: string) => {
+    if (!confirm(`${accountId} を強制ロックしますか？`)) return;
+    setMessage(null);
+    setError(null);
+    try {
+      const result = await lockAccount(accountNo);
+      setMessage(result.message);
+      await fetchAccounts();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+    }
+  };
+
+  if (isAuthLoading || isLoading) {
+    return (
+      <div className="flex justify-center items-center min-h-[200px]">
+        <p>読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated || !isAdmin) {
+    return (
+      <div className="flex justify-center items-center min-h-[200px]">
+        <p className="text-red-500">管理者権限がありません。</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col justify-center items-center min-h-[200px] gap-4">
+        <p className="text-red-500">{error}</p>
+        <button
+          onClick={fetchAccounts}
+          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+        >
+          再読み込み
+        </button>
+      </div>
+    );
+  }
+
+  const formatDatetime = (datetime: string | null): string => {
+    if (!datetime) return "-";
+    const date = new Date(datetime);
+    if (date.getFullYear() <= 1900) return "-";
+    return date.toLocaleString("ja-JP");
+  };
+
+  const authorityLabel = (kbn: string): string => {
+    switch (kbn) {
+      case "administrator": return "管理者";
+      case "special-user": return "特別ユーザー";
+      case "normal-user": return "一般ユーザー";
+      case "mini-user": return "簡易ユーザー";
+      default: return kbn;
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center py-8 gap-4">
+      <h2 className="text-xl font-bold">アカウント管理</h2>
+
+      {message && (
+        <p className="text-green-600 font-medium">{message}</p>
+      )}
+
+      <div
+        className="w-full max-w-[1100px] overflow-x-auto"
+        style={{ boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15)" }}
+      >
+        <table className="w-full border-collapse">
+          <thead>
+            <tr style={{ backgroundColor: "#2196F3" }}>
+              <th className="py-3 px-4 text-left text-white font-bold border border-gray-300">No</th>
+              <th className="py-3 px-4 text-left text-white font-bold border border-gray-300">ID</th>
+              <th className="py-3 px-4 text-left text-white font-bold border border-gray-300">アカウント名</th>
+              <th className="py-3 px-4 text-left text-white font-bold border border-gray-300">権限</th>
+              <th className="py-3 px-4 text-left text-white font-bold border border-gray-300">状態</th>
+              <th className="py-3 px-4 text-left text-white font-bold border border-gray-300">最終ログイン</th>
+              <th className="py-3 px-4 text-left text-white font-bold border border-gray-300">失敗回数</th>
+              <th className="py-3 px-4 text-left text-white font-bold border border-gray-300">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {accounts.map((account) => (
+              <tr
+                key={account.accountNo}
+                className="bg-white transition-colors"
+                style={{ cursor: "default" }}
+                onMouseEnter={(e) =>
+                  (e.currentTarget.style.backgroundColor = "#fffae9")
+                }
+                onMouseLeave={(e) =>
+                  (e.currentTarget.style.backgroundColor = "white")
+                }
+              >
+                <td className="py-3 px-4 border border-gray-300">{account.accountNo}</td>
+                <td className="py-3 px-4 border border-gray-300">{account.accountId}</td>
+                <td className="py-3 px-4 border border-gray-300">{account.accountName}</td>
+                <td className="py-3 px-4 border border-gray-300">{authorityLabel(account.authorityKbn)}</td>
+                <td className="py-3 px-4 border border-gray-300">
+                  {account.isDeleted ? (
+                    <span className="text-gray-500">削除済み</span>
+                  ) : account.loginFailureCount >= 10 ? (
+                    <span className="text-red-500 font-bold">ロック中</span>
+                  ) : (
+                    <span className="text-green-600">有効</span>
+                  )}
+                </td>
+                <td className="py-3 px-4 border border-gray-300">{formatDatetime(account.lastLoginDatetime)}</td>
+                <td className="py-3 px-4 border border-gray-300">{account.loginFailureCount}</td>
+                <td className="py-3 px-4 border border-gray-300">
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => handleUnlock(account.accountNo, account.accountId)}
+                      className="px-3 py-1 text-sm bg-green-500 text-white rounded hover:bg-green-600 disabled:opacity-50"
+                      disabled={account.loginFailureCount === 0}
+                    >
+                      ロック解除
+                    </button>
+                    <button
+                      onClick={() => handleLock(account.accountNo, account.accountId)}
+                      className="px-3 py-1 text-sm bg-red-500 text-white rounded hover:bg-red-600 disabled:opacity-50"
+                      disabled={account.loginFailureCount >= 10}
+                    >
+                      強制ロック
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/account_management/page.tsx
+++ b/frontend/src/app/admin/account_management/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { AdminAccountManagement } from "./AdminAccountManagement";
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+
+export const metadata: Metadata = {
+  title: "アカウント管理 - WebGallery",
+};
+
+/**
+ * 管理者用アカウント管理ページ
+ */
+export default function AdminAccountManagementPage() {
+  return (
+    <>
+      <Header />
+      <AdminAccountManagement />
+      <Footer />
+    </>
+  );
+}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -469,3 +469,64 @@ export async function savePhoto(
   }
   return response.json();
 }
+
+/** 管理者用アカウント一覧アイテム */
+export interface AdminAccountListItem {
+  accountNo: number;
+  accountId: string;
+  accountName: string;
+  authorityKbn: string;
+  isDeleted: boolean;
+  lastLoginDatetime: string | null;
+  loginFailureCount: number;
+}
+
+/** 管理者用アカウントロック操作結果 */
+export interface AdminAccountLockResult {
+  httpStatus: number;
+  isSuccess: boolean;
+  message: string;
+}
+
+/**
+ * 管理者用アカウント一覧を取得する
+ */
+export async function getAdminAccountList(): Promise<AdminAccountListItem[]> {
+  const response = await fetchWithAuth("/api/v1/admin/accounts");
+  if (!response.ok) {
+    throw new Error("アカウント一覧の取得に失敗しました");
+  }
+  return response.json();
+}
+
+/**
+ * 管理者用アカウントロック解除
+ */
+export async function unlockAccount(
+  accountNo: number
+): Promise<AdminAccountLockResult> {
+  const response = await fetchWithAuth(
+    `/api/v1/admin/accounts/${accountNo}/unlock`,
+    { method: "PUT" }
+  );
+  if (!response.ok) {
+    throw new Error("アカウントのロック解除に失敗しました");
+  }
+  return response.json();
+}
+
+/**
+ * 管理者用アカウント強制ロック
+ */
+export async function lockAccount(
+  accountNo: number
+): Promise<AdminAccountLockResult> {
+  const response = await fetchWithAuth(
+    `/api/v1/admin/accounts/${accountNo}/lock`,
+    { method: "PUT" }
+  );
+  if (!response.ok) {
+    throw new Error("アカウントのロックに失敗しました");
+  }
+  return response.json();
+}

--- a/frontend/src/lib/auth/AuthProvider.tsx
+++ b/frontend/src/lib/auth/AuthProvider.tsx
@@ -13,6 +13,7 @@ import * as apiClient from "@/lib/api/client";
 export interface User {
   accountId: string;
   accountNo: number;
+  role: string;
 }
 
 interface AuthContextType {
@@ -41,7 +42,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         const token = apiClient.getAccessToken();
         if (token) {
           const payload = parseJwt(token);
-          setUser({ accountId: payload.sub, accountNo: payload.accountNo });
+          setUser({ accountId: payload.sub, accountNo: payload.accountNo, role: payload.role });
         }
       }
       setIsLoading(false);
@@ -54,7 +55,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     const token = apiClient.getAccessToken();
     if (token) {
       const payload = parseJwt(token);
-      setUser({ accountId, accountNo: payload.accountNo });
+      setUser({ accountId, accountNo: payload.accountNo, role: payload.role });
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- 管理者（authority_kbn = administrator）がアカウントのロック解除・強制ロックを管理できるAPIとフロントエンドページを新規追加
- バックエンドAPI: `GET /api/v1/admin/accounts`（一覧取得）、`PUT /api/v1/admin/accounts/{accountNo}/unlock`（ロック解除）、`PUT /api/v1/admin/accounts/{accountNo}/lock`（強制ロック）
- フロントエンド: `/admin/account_management` ページで管理者権限チェック付きのアカウント管理テーブルを表示

## Test plan
- [x] `./backend/gradlew -p backend test` で全テスト成功を確認
- [x] Docker PostgreSQL起動後、`./backend/gradlew -p backend bootRun` でアプリ起動
- [x] 管理者アカウントでログインし、`/admin/account_management` にアクセスして一覧表示を確認
- [x] ロック解除・強制ロック操作の動作確認
- [x] 非管理者でアクセスした場合のアクセス拒否表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)