### PR TITLE
アカウント退会（物理削除）機能を追加

### DIFF
--- a/backend/src/main/java/com/web/gallery/constant/MessageConst.java
+++ b/backend/src/main/java/com/web/gallery/constant/MessageConst.java
@@ -29,6 +29,7 @@ public final class MessageConst {
 	public static final String ERR_PHOTO_NOT_FOUND = "写真が存在しません。";
 	public static final String ERR_REACHED_REGISTRATION_LIMIT = "写真の登録枚数が上限に達しています。";
 	public static final String ERR_NOT_AUTHORIZED_TO_ADMIN = "管理者権限がありません。";
+	public static final String ERR_FAIL_TO_DELETE_ACCOUNT = "アカウント削除でエラーが発生しました。削除をやり直してください。";
 
 	// Admin
 	public static final String UNLOCK_ACCOUNT = "アカウントのロックを解除しました。";

--- a/backend/src/main/java/com/web/gallery/controller/AccountRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/AccountRestController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -180,6 +181,30 @@ public class AccountRestController {
 					Consts.STRING_EMPTY));
 	}
 	
+	/**
+	 * アカウント削除
+	 *
+	 * @param	accountId				アカウントID
+	 * @return							{@link ResponseEntity}
+	 * @throws	ForbiddenAccountException	認証ユーザーと異なるアカウントIDの場合
+	 */
+	@Operation(summary = "アカウント削除", description = "アカウントと関連データをすべて物理削除する")
+	@ApiResponse(responseCode = "200", description = "削除成功")
+	@ApiResponse(responseCode = "403", description = "認証ユーザーと異なるアカウントIDを指定", content = @Content)
+	@SecurityRequirement(name = "Bearer")
+	@DeleteMapping(ApiRoutes.API_ACCOUNT)
+	public ResponseEntity<Void> deleteAccount(
+			@PathVariable String accountId) throws ForbiddenAccountException {
+
+		if (!accountId.equals(sessionHelper.getAccountId())) {
+			throw new ForbiddenAccountException(ErrorEnum.NOT_AUTHORIZED_TO_EDIT_ACCOUNT);
+		}
+
+		accountServiceImpl.deleteAccount(sessionHelper.getAccountNo(), accountId);
+
+		return ResponseEntity.ok().build();
+	}
+
 	/**
 	 * アカウント登録に失敗した時のExceptionHandler
 	 * 

--- a/backend/src/main/java/com/web/gallery/enumuration/ErrorEnum.java
+++ b/backend/src/main/java/com/web/gallery/enumuration/ErrorEnum.java
@@ -114,7 +114,14 @@ public enum ErrorEnum {
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_NOT_AUTHORIZED_TO_ADMIN}
 	 */
-	NOT_AUTHORIZED_TO_ADMIN("E-A-0001", MessageConst.ERR_NOT_AUTHORIZED_TO_ADMIN);
+	NOT_AUTHORIZED_TO_ADMIN("E-A-0001", MessageConst.ERR_NOT_AUTHORIZED_TO_ADMIN),
+
+	/**
+	 * エラーコード：E-C-0004
+	 * <p>
+	 * エラーメッセージ：{@value MessageConst#ERR_FAIL_TO_DELETE_ACCOUNT}
+	 */
+	FAIL_TO_DELETE_ACCOUNT("E-C-0004", MessageConst.ERR_FAIL_TO_DELETE_ACCOUNT);
 	
 	/** エラーコード */
 	private final String errorCode;

--- a/backend/src/main/java/com/web/gallery/mapper/PhotoMstMapper.java
+++ b/backend/src/main/java/com/web/gallery/mapper/PhotoMstMapper.java
@@ -45,9 +45,17 @@ public interface PhotoMstMapper {
 	
 	/**
 	 * ファイル名から登録済みの写真家判定する
-	 * 
+	 *
 	 * @param	photoMst	{@link PhotoMst}
 	 * @return				登録有無
 	 */
 	public Boolean isExistPhoto(PhotoMst photoMst);
+
+	/**
+	 * 写真マスタを物理削除する
+	 *
+	 * @param	photoMst	削除対象の抽出条件
+	 * @return				削除件数
+	 */
+	public Integer delete(PhotoMst photoMst);
 }

--- a/backend/src/main/java/com/web/gallery/repository/AccountRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/AccountRepository.java
@@ -74,4 +74,11 @@ public interface AccountRepository {
 	 * @return	{@link AccountModel}
 	 */
 	List<AccountModel> getAccountListAll();
+
+	/**
+	 * Accountテーブルから該当するレコードを物理削除する
+	 *
+	 * @param	accountNo	アカウント番号
+	 */
+	void delete(Long accountNo);
 }

--- a/backend/src/main/java/com/web/gallery/repository/impl/AccountRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/AccountRepositoryImpl.java
@@ -140,4 +140,14 @@ public class AccountRepositoryImpl implements AccountRepository {
 		List<Account> accountList = accountMapper.select(Account.conditionForAdminList());
 		return accountList.stream().map(AccountModel::from).toList();
 	}
+
+	/**
+	 * Accountテーブルから該当するレコードを物理削除する
+	 *
+	 * @param	accountNo	アカウント番号
+	 */
+	@Override
+	public void delete(Long accountNo) {
+		accountMapper.delete(Account.conditionByAccountNo(accountNo));
+	}
 }

--- a/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
@@ -16,12 +16,20 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.web.gallery.AccountPrincipal;
 import com.web.gallery.config.LoginConfig;
+import com.web.gallery.config.PhotoConfig;
 import com.web.gallery.constant.Consts;
 import com.web.gallery.constant.MessageConst;
+import com.web.gallery.entity.PhotoFavorite;
+import com.web.gallery.entity.PhotoMst;
+import com.web.gallery.entity.PhotoTagMst;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.mapper.PhotoFavoriteMapper;
+import com.web.gallery.mapper.PhotoMstMapper;
+import com.web.gallery.mapper.PhotoTagMstMapper;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.repository.AccountRepository;
+import com.web.gallery.repository.FileRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,7 +43,12 @@ import lombok.extern.slf4j.Slf4j;
 public class AccountServiceImpl implements UserDetailsService {
 
 	private final AccountRepository accountRepository;
+	private final FileRepository fileRepository;
+	private final PhotoFavoriteMapper photoFavoriteMapper;
+	private final PhotoTagMstMapper photoTagMstMapper;
+	private final PhotoMstMapper photoMstMapper;
 	private final LoginConfig loginConfig;
+	private final PhotoConfig photoConfig;
 
 	/**
 	 * アカウントIDからアカウント情報の存在を確認する
@@ -143,6 +156,33 @@ public class AccountServiceImpl implements UserDetailsService {
 				.loginFailureCount(loginConfig.getFailCount())
 				.build();
 		accountRepository.updateLoginFailureCount(updateModel);
+	}
+
+	/**
+	 * アカウントを削除する
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @param	accountId	アカウントID
+	 */
+	@Transactional
+	public void deleteAccount(Long accountNo, String accountId) {
+		// 自分が登録したお気に入りを削除
+		photoFavoriteMapper.delete(PhotoFavorite.builder().accountNo(accountNo).build());
+
+		// 自分の写真に対する他人のお気に入りを削除
+		photoFavoriteMapper.delete(PhotoFavorite.builder().favoritePhotoAccountNo(accountNo).build());
+
+		// 写真タグを削除
+		photoTagMstMapper.delete(PhotoTagMst.builder().accountNo(accountNo).build());
+
+		// 写真マスタを物理削除
+		photoMstMapper.delete(PhotoMst.builder().accountNo(accountNo).build());
+
+		// アカウントを物理削除
+		accountRepository.delete(accountNo);
+
+		// 写真ファイルのディレクトリを削除
+		fileRepository.delete(photoConfig.getOutputPath() + accountId + "/");
 	}
 
 	/**

--- a/backend/src/main/resources/com/web/gallery/mapper/PhotoMstMapper.xml
+++ b/backend/src/main/resources/com/web/gallery/mapper/PhotoMstMapper.xml
@@ -130,4 +130,13 @@
 		AND image_file_path LIKE CONCAT('%', #{imageFilePath})
 		AND is_deleted = false
 	</select>
+
+	<delete id="delete" parameterType="com.web.gallery.entity.PhotoMst">
+		DELETE FROM
+			photo.photo_mst
+		<where>
+			<if test="accountNo != null"> AND account_no = #{accountNo}</if>
+			<if test="photoNo != null"> AND photo_no = #{photoNo}</if>
+		</where>
+	</delete>
 </mapper>

--- a/backend/src/test/java/com/web/gallery/controller/AccountRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/AccountRestControllerTest.java
@@ -517,6 +517,39 @@ public class AccountRestControllerTest {
 	@Nested
 	@Order(5)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class deleteAccount {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウント削除に成功する")
+		void deleteAccount_success() throws Exception {
+			String accountId = "aaaaaaaa";
+
+			doReturn(accountId).when(sessionHelper).getAccountId();
+			doReturn(1L).when(sessionHelper).getAccountNo();
+			doNothing().when(accountServiceImpl).deleteAccount(1L, accountId);
+
+			mockMvc.perform(delete("/api/v1/accounts/" + accountId))
+				.andExpect(status().isOk());
+
+			verify(accountServiceImpl, times(1)).deleteAccount(1L, accountId);
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("異常系：認証ユーザーと異なるアカウントIDの場合は403を返すこと")
+		void deleteAccount_forbidden() throws Exception {
+			doReturn("bbbbbbbb").when(sessionHelper).getAccountId();
+
+			mockMvc.perform(delete("/api/v1/accounts/aaaaaaaa"))
+				.andExpect(status().isForbidden());
+
+			verify(accountServiceImpl, times(0)).deleteAccount(anyLong(), anyString());
+		}
+	}
+
+	@Nested
+	@Order(6)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	class handleInsertFailedException {
 		@Test
 		@Order(1)

--- a/backend/src/test/java/com/web/gallery/controller/integration/AccountRestControllerIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/integration/AccountRestControllerIntegrationTest.java
@@ -697,4 +697,93 @@ public class AccountRestControllerIntegrationTest {
 				.andExpect(jsonPath("$.errorMessage").value(ErrorEnum.FAIL_TO_UPDATE_ACCOUNT.getErrorMessage()));
 		}
 	}
+
+	@Nested
+	@Order(5)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	@Sql("/sql/common/cleanup.sql")
+	@Sql("/sql/controller/AccountRestControllerDeleteAccountIntegrationTest.sql")
+	class deleteAccount {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウント削除に成功する")
+		void deleteAccount_success() throws Exception {
+			String accountId = "aaaaaaaa";
+
+			AccountModel sessionAccount = AccountModel.builder()
+					.accountNo(1L)
+					.accountId(accountId)
+					.accountName("AAAAAAAA")
+					.password("$2a$10$password1")
+					.authorityKbn(AuthorityEnum.ADMINISTRATOR)
+					.build();
+
+			AccountPrincipal accountPrincipal = new AccountPrincipal(sessionAccount, 0);
+			Authentication authentication = new UsernamePasswordAuthenticationToken(
+					accountPrincipal, null, accountPrincipal.getAuthorities());
+
+			mockMvc.perform(
+					delete("/api/v1/accounts/" + accountId)
+					.with(SecurityMockMvcRequestPostProcessors.authentication(authentication))
+					.with(csrf())
+				)
+				.andExpect(status().isOk());
+
+			// アカウントが削除されたことを確認
+			Integer accountCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM common.account where account_no=1", Integer.class);
+			assertEquals(0, accountCount);
+
+			// 写真マスタが削除されたことを確認
+			Integer photoMstCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM photo.photo_mst where account_no=1", Integer.class);
+			assertEquals(0, photoMstCount);
+
+			// 写真タグが削除されたことを確認
+			Integer photoTagCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM photo.photo_tag_mst where account_no=1", Integer.class);
+			assertEquals(0, photoTagCount);
+
+			// お気に入りが削除されたことを確認（自分が登録したもの＋自分の写真に対する他人のもの）
+			Integer favoriteCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM photo.photo_favorite where account_no=1 or favorite_photo_account_no=1", Integer.class);
+			assertEquals(0, favoriteCount);
+
+			// account_no=2は残っていること
+			Integer otherAccountCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM common.account where account_no=2", Integer.class);
+			assertEquals(1, otherAccountCount);
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("異常系：認証ユーザーと異なるアカウントIDの場合は403を返すこと")
+		void deleteAccount_forbidden() throws Exception {
+			String accountId = "aaaaaaaa";
+
+			AccountModel sessionAccount = AccountModel.builder()
+					.accountNo(2L)
+					.accountId("bbbbbbbb")
+					.accountName("BBBBBBBB")
+					.password("$2a$10$password2")
+					.authorityKbn(AuthorityEnum.ADMINISTRATOR)
+					.build();
+
+			AccountPrincipal accountPrincipal = new AccountPrincipal(sessionAccount, 0);
+			Authentication authentication = new UsernamePasswordAuthenticationToken(
+					accountPrincipal, null, accountPrincipal.getAuthorities());
+
+			mockMvc.perform(
+					delete("/api/v1/accounts/" + accountId)
+					.with(SecurityMockMvcRequestPostProcessors.authentication(authentication))
+					.with(csrf())
+				)
+				.andExpect(status().isForbidden());
+
+			// アカウントは削除されていないことを確認
+			Integer accountCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM common.account where account_no=1", Integer.class);
+			assertEquals(1, accountCount);
+		}
+	}
 }

--- a/backend/src/test/java/com/web/gallery/mapper/PhotoMstMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/PhotoMstMapperTest.java
@@ -782,6 +782,66 @@ public class PhotoMstMapperTest {
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	@Sql("/sql/common/cleanup.sql")
 	@Sql("/sql/mapper/PhotoMstMapperTest.sql")
+	class delete {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウント番号でのdeleteで複数件削除される場合")
+		void delete_by_accountNo() {
+			PhotoMst photoMst = PhotoMst.builder().accountNo(1L).build();
+			Integer actual = photoMstMapper.delete(photoMst);
+			assertEquals(3, actual);
+
+			Integer remainCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM photo.photo_mst WHERE account_no=1", Integer.class);
+			assertEquals(0, remainCount);
+
+			// 他のアカウントの写真は残っていること
+			Integer otherCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM photo.photo_mst WHERE account_no=2", Integer.class);
+			assertEquals(3, otherCount);
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("正常系：写真番号でのdeleteで複数件削除される場合")
+		void delete_by_photoNo() {
+			PhotoMst photoMst = PhotoMst.builder().photoNo(1L).build();
+			Integer actual = photoMstMapper.delete(photoMst);
+			assertEquals(2, actual);
+
+			Integer remainCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM photo.photo_mst WHERE photo_no=1", Integer.class);
+			assertEquals(0, remainCount);
+		}
+
+		@Test
+		@Order(3)
+		@DisplayName("正常系：アカウント番号と写真番号でのdeleteで1件削除される場合")
+		void delete_by_accountNo_and_photoNo() {
+			PhotoMst photoMst = PhotoMst.builder().accountNo(1L).photoNo(1L).build();
+			Integer actual = photoMstMapper.delete(photoMst);
+			assertEquals(1, actual);
+
+			Integer remainCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM photo.photo_mst WHERE account_no=1", Integer.class);
+			assertEquals(2, remainCount);
+		}
+
+		@Test
+		@Order(4)
+		@DisplayName("正常系：該当するレコードがない場合は0件")
+		void delete_not_found() {
+			PhotoMst photoMst = PhotoMst.builder().accountNo(100L).build();
+			Integer actual = photoMstMapper.delete(photoMst);
+			assertEquals(0, actual);
+		}
+	}
+
+	@Nested
+	@Order(5)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	@Sql("/sql/common/cleanup.sql")
+	@Sql("/sql/mapper/PhotoMstMapperTest.sql")
 	class getMaxPhotoNo {
 		@Test
 		@Order(1)
@@ -801,7 +861,7 @@ public class PhotoMstMapperTest {
 	}
 	
 	@Nested
-	@Order(5)
+	@Order(6)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	@Sql("/sql/common/cleanup.sql")
 	@Sql("/sql/mapper/PhotoMstMapperTest.sql")

--- a/backend/src/test/java/com/web/gallery/repository/impl/AccountRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/AccountRepositoryImplTest.java
@@ -563,6 +563,25 @@ public class AccountRepositoryImplTest {
 	@Nested
 	@Order(6)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class delete {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウントを物理削除する")
+		void delete_success() {
+			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
+			doReturn(1).when(accountMapper).delete(accountCaptor.capture());
+
+			accountRepositoryImpl.delete(1L);
+
+			verify(accountMapper, times(1)).delete(any(Account.class));
+			Account accountCapture = accountCaptor.getValue();
+			assertEquals(1L, accountCapture.getAccountNo());
+		}
+	}
+
+	@Nested
+	@Order(7)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	class isExistAccount {
 		@Test
 		@Order(1)
@@ -570,33 +589,33 @@ public class AccountRepositoryImplTest {
 		void isExistAccount_true() {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(true).when(accountMapper).isExistAccount(accountCaptor.capture());
-			
+
 			assertTrue(accountRepositoryImpl.isExistAccount(1L, "aaaaaaaa"));
 			verify(accountMapper, times(1)).isExistAccount(any(Account.class));
-			
+
 			Account accountCapture = accountCaptor.getValue();
 			assertEquals(1L, accountCapture.getAccountNo());
 			assertEquals("aaaaaaaa", accountCapture.getAccountId());
 		}
-		
+
 		@Test
 		@Order(2)
 		@DisplayName("正常系：アカウントが存在しない場合")
 		void isExistAccount_false() {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(false).when(accountMapper).isExistAccount(accountCaptor.capture());
-			
+
 			assertFalse(accountRepositoryImpl.isExistAccount(1L, "aaaaaaaa"));
 			verify(accountMapper, times(1)).isExistAccount(any());
-			
+
 			Account accountCapture = accountCaptor.getValue();
 			assertEquals(1L, accountCapture.getAccountNo());
 			assertEquals("aaaaaaaa", accountCapture.getAccountId());
 		}
 	}
-	
+
 	@Nested
-	@Order(7)
+	@Order(8)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	class getAccountList {
 		@Test

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/AccountRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/AccountRepositoryImplIntegrationTest.java
@@ -538,4 +538,33 @@ public class AccountRepositoryImplIntegrationTest {
 			assertEquals(0, actual.size());
 		}
 	}
+
+	@Nested
+	@Order(8)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	@Sql("/sql/common/cleanup.sql")
+	@Sql("/sql/repository/AccountRepositoryImplIntegrationTest.sql")
+	class delete {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウントを物理削除する")
+		void delete_success() {
+			accountRepositoryImpl.delete(1L);
+
+			List<Account> actualData = jdbcTemplate.query(
+					"SELECT * FROM common.account where account_no=1", (rs, rowNum) ->
+						Account.builder()
+							.accountNo(rs.getLong("account_no"))
+							.build());
+			assertEquals(0, actualData.size());
+
+			// 他のアカウントは残っていることを確認
+			List<Account> otherData = jdbcTemplate.query(
+					"SELECT * FROM common.account where account_no=2", (rs, rowNum) ->
+						Account.builder()
+							.accountNo(rs.getLong("account_no"))
+							.build());
+			assertEquals(1, otherData.size());
+		}
+	}
 }

--- a/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
@@ -360,6 +360,7 @@ public class AccountServiceImplTest {
 			Long accountNo = 1L;
 			String accountId = "aaaaaaaa";
 
+			ArgumentCaptor<PhotoFavorite> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavorite.class);
 			doReturn(1).when(photoFavoriteMapper).delete(any(PhotoFavorite.class));
 			doReturn(1).when(photoTagMstMapper).delete(any(PhotoTagMst.class));
 			doReturn(1).when(photoMstMapper).delete(any(PhotoMst.class));
@@ -369,7 +370,17 @@ public class AccountServiceImplTest {
 
 			accountServiceImpl.deleteAccount(accountNo, accountId);
 
-			verify(photoFavoriteMapper, times(2)).delete(any(PhotoFavorite.class));
+			verify(photoFavoriteMapper, times(2)).delete(photoFavoriteCaptor.capture());
+			List<PhotoFavorite> capturedFavorites = photoFavoriteCaptor.getAllValues();
+
+			// 1回目：自分が登録したお気に入りの削除（accountNoで指定）
+			assertEquals(accountNo, capturedFavorites.get(0).getAccountNo());
+			assertNull(capturedFavorites.get(0).getFavoritePhotoAccountNo());
+
+			// 2回目：自分の写真に対する他人のお気に入りの削除（favoritePhotoAccountNoで指定）
+			assertNull(capturedFavorites.get(1).getAccountNo());
+			assertEquals(accountNo, capturedFavorites.get(1).getFavoritePhotoAccountNo());
+
 			verify(photoTagMstMapper, times(1)).delete(any(PhotoTagMst.class));
 			verify(photoMstMapper, times(1)).delete(any(PhotoMst.class));
 			verify(accountRepositoryImpl, times(1)).delete(accountNo);

--- a/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
@@ -31,9 +31,17 @@ import org.springframework.test.context.ActiveProfiles;
 
 import com.web.gallery.AccountPrincipal;
 import com.web.gallery.config.LoginConfig;
+import com.web.gallery.config.PhotoConfig;
+import com.web.gallery.entity.PhotoFavorite;
+import com.web.gallery.entity.PhotoMst;
+import com.web.gallery.entity.PhotoTagMst;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.mapper.PhotoFavoriteMapper;
+import com.web.gallery.mapper.PhotoMstMapper;
+import com.web.gallery.mapper.PhotoTagMstMapper;
 import com.web.gallery.model.AccountModel;
+import com.web.gallery.repository.FileRepository;
 import com.web.gallery.repository.impl.AccountRepositoryImpl;
 
 @ActiveProfiles("test")
@@ -44,12 +52,27 @@ public class AccountServiceImplTest {
 	
 	@Mock
 	private AccountRepositoryImpl accountRepositoryImpl;
-	
+
+	@Mock
+	private FileRepository fileRepository;
+
+	@Mock
+	private PhotoFavoriteMapper photoFavoriteMapper;
+
+	@Mock
+	private PhotoTagMstMapper photoTagMstMapper;
+
+	@Mock
+	private PhotoMstMapper photoMstMapper;
+
 	@Mock
 	private AccountPrincipal accountPrincipal;
-	
+
 	@Mock
 	private LoginConfig loginConfig;
+
+	@Mock
+	private PhotoConfig photoConfig;
 	
 	@Nested
 	@Order(1)
@@ -329,6 +352,34 @@ public class AccountServiceImplTest {
 	@Nested
 	@Order(9)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class deleteAccountTest {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウントを削除する")
+		void deleteAccount_success() {
+			Long accountNo = 1L;
+			String accountId = "aaaaaaaa";
+
+			doReturn(1).when(photoFavoriteMapper).delete(any(PhotoFavorite.class));
+			doReturn(1).when(photoTagMstMapper).delete(any(PhotoTagMst.class));
+			doReturn(1).when(photoMstMapper).delete(any(PhotoMst.class));
+			doNothing().when(accountRepositoryImpl).delete(accountNo);
+			doReturn("/output/").when(photoConfig).getOutputPath();
+			doNothing().when(fileRepository).delete("/output/" + accountId + "/");
+
+			accountServiceImpl.deleteAccount(accountNo, accountId);
+
+			verify(photoFavoriteMapper, times(2)).delete(any(PhotoFavorite.class));
+			verify(photoTagMstMapper, times(1)).delete(any(PhotoTagMst.class));
+			verify(photoMstMapper, times(1)).delete(any(PhotoMst.class));
+			verify(accountRepositoryImpl, times(1)).delete(accountNo);
+			verify(fileRepository, times(1)).delete("/output/" + accountId + "/");
+		}
+	}
+
+	@Nested
+	@Order(10)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	class handleAuthenticationSuccess {
 		@Test
 		@Order(1)
@@ -404,7 +455,7 @@ public class AccountServiceImplTest {
 	}
 	
 	@Nested
-	@Order(10)
+	@Order(11)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	class handleAuthenticationFailureBadCredentials {
 		@Test

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/AccountServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/AccountServiceImplIntegrationTest.java
@@ -325,6 +325,66 @@ public class AccountServiceImplIntegrationTest {
 	@Order(6)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	@Sql("/sql/common/cleanup.sql")
+	@Sql("/sql/service/AccountServiceImplDeleteAccountIntegrationTest.sql")
+	class deleteAccount {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウントと関連データがすべて物理削除されること")
+		void deleteAccount_success() {
+			accountServiceImpl.deleteAccount(1L, "aaaaaaaa");
+
+			// アカウントが削除されたことを確認
+			List<Account> accountData = jdbcTemplate.query(
+					"SELECT * FROM common.account where account_no=1", (rs, rowNum) ->
+						Account.builder()
+							.accountNo(rs.getLong("account_no"))
+							.build());
+			assertEquals(0, accountData.size());
+
+			// account_no=2のアカウントは残っていること
+			List<Account> otherAccountData = jdbcTemplate.query(
+					"SELECT * FROM common.account where account_no=2", (rs, rowNum) ->
+						Account.builder()
+							.accountNo(rs.getLong("account_no"))
+							.build());
+			assertEquals(1, otherAccountData.size());
+
+			// 写真マスタが削除されたことを確認
+			Integer photoMstCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM photo.photo_mst where account_no=1", Integer.class);
+			assertEquals(0, photoMstCount);
+
+			// account_no=2の写真マスタは残っていること
+			Integer otherPhotoMstCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM photo.photo_mst where account_no=2", Integer.class);
+			assertEquals(1, otherPhotoMstCount);
+
+			// 写真タグが削除されたことを確認
+			Integer photoTagCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM photo.photo_tag_mst where account_no=1", Integer.class);
+			assertEquals(0, photoTagCount);
+
+			// 自分が登録したお気に入りが削除されたことを確認
+			Integer favoriteByAccount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM photo.photo_favorite where account_no=1", Integer.class);
+			assertEquals(0, favoriteByAccount);
+
+			// 他人が自分の写真に対して登録したお気に入りが削除されたことを確認
+			Integer favoriteForAccount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM photo.photo_favorite where favorite_photo_account_no=1", Integer.class);
+			assertEquals(0, favoriteForAccount);
+
+			// account_no=2が自分の写真をお気に入りにしたレコードは残っていること
+			Integer otherFavoriteCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM photo.photo_favorite where account_no=2 and favorite_photo_account_no=2", Integer.class);
+			assertEquals(1, otherFavoriteCount);
+		}
+	}
+
+	@Nested
+	@Order(7)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	@Sql("/sql/common/cleanup.sql")
 	@Sql("/sql/service/AccountServiceImplIntegrationTest.sql")
 	class handleAuthenticationSuccess {
 		@Test
@@ -384,7 +444,7 @@ public class AccountServiceImplIntegrationTest {
 	}
 	
 	@Nested
-	@Order(7)
+	@Order(8)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	@Sql("/sql/common/cleanup.sql")
 	@Sql("/sql/service/AccountServiceImplIntegrationTest.sql")

--- a/backend/src/test/resources/sql/controller/AccountRestControllerDeleteAccountIntegrationTest.sql
+++ b/backend/src/test/resources/sql/controller/AccountRestControllerDeleteAccountIntegrationTest.sql
@@ -1,0 +1,13 @@
+-- common.account
+insert into common.account values(1, 1, '2000-01-01 09:00:00 Asia/Tokyo', 1, '2001-01-01 09:00:00 Asia/Tokyo', false, 'aaaaaaaa', 'AAAAAAAA', '$2a$10$password1', '1991-02-14', 'none', 'none', 'none', '', 'administrator', '2002-01-01 09:00:00 Asia/Tokyo', 0);
+insert into common.account values(2, 2, '2000-01-02 09:00:00 Asia/Tokyo', 2, '2001-01-02 09:00:00 Asia/Tokyo', false, 'bbbbbbbb', 'BBBBBBBB', '$2a$10$password2', '1900-01-01', 'man',  'none', 'none', '', 'administrator', '2002-01-01 09:00:00 Asia/Tokyo', 0);
+
+-- photo.photo_mst
+insert into photo.photo_mst values(DEFAULT, 1, 1, 1, '2000-01-01 09:00:00 Asia/Tokyo', 1, '2000-01-01 09:00:00 Asia/Tokyo', false, '2021-01-01 09:00:00 Asia/Tokyo', 1, 'https://www.xxx.com/aaaaaaaa/DSC11.jpg', 'タイトル11', 'title11', 'キャプション11', 'horizontal', 24, 8.0, 1, 100);
+
+-- photo.photo_tag_mst
+insert into photo.photo_tag_mst values(DEFAULT, 1, 1, 1, 1, '2000-01-01 10:00:00 Asia/Tokyo', '太陽', 'sun');
+
+-- photo.photo_favorite
+insert into photo.photo_favorite values(DEFAULT, 1, 1, 1, 1, now());
+insert into photo.photo_favorite values(DEFAULT, 2, 1, 1, 1, now());

--- a/backend/src/test/resources/sql/service/AccountServiceImplDeleteAccountIntegrationTest.sql
+++ b/backend/src/test/resources/sql/service/AccountServiceImplDeleteAccountIntegrationTest.sql
@@ -1,0 +1,23 @@
+-- common.account
+insert into common.account values(1, 1, '2000-01-01 09:00:00 Asia/Tokyo', 1, '2001-01-01 09:00:00 Asia/Tokyo', false, 'aaaaaaaa', 'AAAAAAAA', '$2a$10$password1', '1991-02-14', 'none', 'none', 'none', '', 'administrator', '2002-01-01 09:00:00 Asia/Tokyo', 0);
+insert into common.account values(2, 2, '2000-01-02 09:00:00 Asia/Tokyo', 2, '2001-01-02 09:00:00 Asia/Tokyo', false, 'bbbbbbbb', 'BBBBBBBB', '$2a$10$password2', '1900-01-01', 'man',  'none', 'none', '', 'administrator', '2002-01-01 09:00:00 Asia/Tokyo', 0);
+
+-- photo.photo_mst (account_no=1の写真2件、account_no=2の写真1件)
+insert into photo.photo_mst values(DEFAULT, 1, 1, 1, '2000-01-01 09:00:00 Asia/Tokyo', 1, '2000-01-01 09:00:00 Asia/Tokyo', false, '2021-01-01 09:00:00 Asia/Tokyo', 1, 'https://www.xxx.com/aaaaaaaa/DSC11.jpg', 'タイトル11', 'title11', 'キャプション11', 'horizontal', 24, 8.0, 1, 100);
+insert into photo.photo_mst values(DEFAULT, 1, 2, 1, '2000-01-01 09:00:00 Asia/Tokyo', 1, '2000-01-01 09:00:00 Asia/Tokyo', false, '2021-02-01 09:00:00 Asia/Tokyo', 2, 'https://www.xxx.com/aaaaaaaa/DSC12.jpg', 'タイトル12', 'title12', 'キャプション12', 'horizontal', 36, 9.0, 2, 200);
+insert into photo.photo_mst values(DEFAULT, 2, 1, 2, '2000-01-01 09:00:00 Asia/Tokyo', 2, '2000-01-01 09:00:00 Asia/Tokyo', false, '2021-01-01 09:00:00 Asia/Tokyo', 1, 'https://www.xxx.com/bbbbbbbb/DSC21.jpg', 'タイトル21', 'title21', 'キャプション21', 'horizontal', 24, 8.0, 1, 100);
+
+-- photo.photo_tag_mst (account_no=1の写真タグ)
+insert into photo.photo_tag_mst values(DEFAULT, 1, 1, 1, 1, '2000-01-01 10:00:00 Asia/Tokyo', '太陽', 'sun');
+insert into photo.photo_tag_mst values(DEFAULT, 1, 1, 2, 1, '2000-01-01 11:00:00 Asia/Tokyo', '青空', 'bluesky');
+insert into photo.photo_tag_mst values(DEFAULT, 1, 2, 1, 1, '2000-02-01 10:00:00 Asia/Tokyo', '太陽', 'sun');
+
+-- photo.photo_favorite
+-- account_no=1が自分の写真をお気に入り
+insert into photo.photo_favorite values(DEFAULT, 1, 1, 1, 1, now());
+-- account_no=2がaccount_no=1の写真をお気に入り
+insert into photo.photo_favorite values(DEFAULT, 2, 1, 1, 1, now());
+-- account_no=1がaccount_no=2の写真をお気に入り
+insert into photo.photo_favorite values(DEFAULT, 1, 2, 1, 1, now());
+-- account_no=2が自分の写真をお気に入り
+insert into photo.photo_favorite values(DEFAULT, 2, 2, 1, 1, now());

--- a/frontend/src/app/[accountId]/account_setting/AccountSettingForm.tsx
+++ b/frontend/src/app/[accountId]/account_setting/AccountSettingForm.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/lib/auth/AuthProvider";
 import {
   getAccount,
   updateAccount,
+  deleteAccount,
   getPrefectures,
 } from "@/lib/api/client";
 import type {
@@ -37,6 +38,10 @@ export function AccountSettingForm({ accountId }: AccountSettingFormProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showModal, setShowModal] = useState(false);
+
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [showDeleteCompleteModal, setShowDeleteCompleteModal] = useState(false);
 
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [duplicateError, setDuplicateError] = useState("");
@@ -137,6 +142,27 @@ export function AccountSettingForm({ accountId }: AccountSettingFormProps) {
       setDuplicateError("更新に失敗しました");
     } finally {
       setIsSubmitting(false);
+    }
+  };
+
+  /**
+   * アカウント削除
+   */
+  const handleDeleteAccount = async () => {
+    setIsDeleting(true);
+    try {
+      await deleteAccount(accountId);
+      await logout();
+      setShowDeleteConfirm(false);
+      setShowDeleteCompleteModal(true);
+      setTimeout(() => {
+        router.push("/login");
+      }, 3000);
+    } catch {
+      setShowDeleteConfirm(false);
+      setDuplicateError("アカウント削除に失敗しました");
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -320,8 +346,57 @@ export function AccountSettingForm({ accountId }: AccountSettingFormProps) {
               )}
             </button>
           </form>
+
+          <div className="mt-6 bg-white rounded-md shadow-[0px_1px_5px_rgba(0,0,0,0.3)] p-5">
+            <p className="text-[#444] text-sm mb-3">アカウントを削除すると、登録した写真やお気に入りはすべて削除され、復旧できなくなります。</p>
+            <button
+              type="button"
+              onClick={() => setShowDeleteConfirm(true)}
+              className="w-full h-[50px] bg-[#e53935] text-white border-none rounded-sm cursor-pointer transition-all duration-100 hover:shadow-[0px_1px_3px_#e53935]"
+            >
+              アカウント削除
+            </button>
+          </div>
         </div>
       </div>
+
+      {showDeleteConfirm && (
+        <div className="fixed inset-0 bg-[rgba(0,0,0,0.5)] flex items-center justify-center z-[2000]">
+          <div className="bg-white rounded-md p-6 shadow-lg relative max-w-[300px] w-[90%]">
+            <p className="text-[#444] text-center mb-4">
+              登録した写真やお気に入りはすべて削除され、復旧できなくなります。よろしいですか？
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowDeleteConfirm(false)}
+                disabled={isDeleting}
+                className="flex-1 h-[40px] bg-gray-300 text-[#444] border-none rounded-sm cursor-pointer disabled:opacity-70 disabled:cursor-not-allowed"
+              >
+                いいえ
+              </button>
+              <button
+                onClick={handleDeleteAccount}
+                disabled={isDeleting}
+                className="flex-1 h-[40px] bg-[#e53935] text-white border-none rounded-sm cursor-pointer disabled:opacity-70 disabled:cursor-not-allowed"
+              >
+                {isDeleting ? (
+                  <span className="inline-block w-5 h-5 border-[3px] border-white border-t-[rgba(255,255,255,0.3)] rounded-full animate-spin" />
+                ) : (
+                  "はい"
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showDeleteCompleteModal && (
+        <div className="fixed inset-0 bg-[rgba(0,0,0,0.5)] flex items-center justify-center z-[2000]">
+          <div className="bg-white rounded-md p-6 shadow-lg relative max-w-[300px] w-[90%]">
+            <p className="text-[#444] text-center">アカウントを削除しました</p>
+          </div>
+        </div>
+      )}
 
       {showModal && (
         <div className="fixed inset-0 bg-[rgba(0,0,0,0.5)] flex items-center justify-center z-[2000]">

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -140,6 +140,18 @@ export async function getAccount(accountId: string): Promise<AccountDetail> {
 }
 
 /**
+ * アカウントを削除する
+ */
+export async function deleteAccount(accountId: string): Promise<void> {
+  const response = await fetchWithAuth(`/api/v1/accounts/${accountId}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) {
+    throw new Error("アカウントの削除に失敗しました");
+  }
+}
+
+/**
  * アカウント情報を更新する
  */
 export async function updateAccount(


### PR DESCRIPTION
## Summary
- アカウント設定ページに「アカウント削除」ボタンを追加し、確認ダイアログ付きでアカウントの物理削除を実行できる機能を実装
- バックエンドにDELETE `/api/v1/accounts/{accountId}` エンドポイントを追加し、外部キー制約を考慮した順序で関連データ（お気に入り→写真タグ→写真マスタ→アカウント→写真ファイル）をすべて物理削除
- フロントエンドに削除確認ダイアログと完了モーダルを追加し、削除後はログアウトしてログインページへ遷移

## Test plan
- [x] バックエンドのビルドが成功すること (`./backend/gradlew -p backend build`)
- [x] 既存のユニットテスト・統合テストがすべてパスすること
- [x] アカウント設定ページで「アカウント削除」ボタンが表示されること
- [x] ボタン押下時に確認ダイアログが表示されること
- [x] 「いいえ」選択時にダイアログが閉じ、何も起こらないこと
- [x] 「はい」選択時にAPIが呼ばれ、関連データがすべて物理削除されること
- [x] 削除完了後「アカウントを削除しました」モーダルが表示され、ログインページに遷移すること
- [x] 他人のアカウントIDを指定した場合に403エラーが返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)