### PR TITLE
chore: Bash経由のsed・grepコマンドの実行を許可

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,6 +26,8 @@
       "Bash(docker*)",
       "Bash(just*)",
       "Bash(find*)",
+      "Bash(grep*)",
+      "Bash(sed*)",
       "Bash(./backend/gradlew*)",
       "Bash(npm *)",
       "Bash(npx *)",


### PR DESCRIPTION
# 概要

## 背景

Bashツール経由でsed・grepコマンドを実行する際に毎回確認プロンプトが表示されるため、開発作業の効率化のために許可設定を追加する。

## 変更内容

`.claude/settings.json`のpermissions.allowに以下を追加。

- `Bash(grep*)`
- `Bash(sed*)`


# 検証事項

設定ファイルのみの変更のため、backend/frontendのビルド・テストは対象外。

- [x] `jq`コマンドでJSON構文が正しいことを確認


# 懸念事項

特になし