### PR TITLE
refactor: List<XxxModel>をソート・フィルター機能付きコレクションクラスに置換

### DIFF
--- a/.claude/rules/model.md
+++ b/.claude/rules/model.md
@@ -18,3 +18,11 @@ paths:
 ## 命名規則
 
 - クラス名サフィックス: `Model`
+- Modelのコレクションを表すクラスのクラス名サフィックス: `ModelList`（例：`AccountModelList`、`PhotoModelList`）
+
+## コレクションクラス（`XxxModelList`）
+
+- 対象のModelクラスのリストを1フィールドで保持し、`@NonNull`を付与する
+- ソート機能・フィルター機能はインスタンスメソッドとして提供し、新しい`XxxModelList`を返すこと（元のインスタンスを変更しない）
+- ファクトリメソッドとして、Modelのリストから生成する`of()`、対応するEntity等のリストから生成する`from()`、空インスタンスを生成する`empty()`を提供すること
+- `size()`、`isEmpty()`、`get(int)`、`stream()`、`toList()`を提供し、`Iterable<XxxModel>`を実装すること

--- a/.claude/rules/model.md
+++ b/.claude/rules/model.md
@@ -22,7 +22,8 @@ paths:
 
 ## コレクションクラス（`XxxModelList`）
 
-- 対象のModelクラスのリストを1フィールドで保持し、`@NonNull`を付与する
+- `record XxxModelList(List<XxxModel> xxxModelList) implements Iterable<XxxModel>`として実装する（Lombokの`@Value`/`@Builder`は使用しない）
+- コンパクトコンストラクタで`Objects.requireNonNull()`によるnullチェックを行う
 - ソート機能・フィルター機能はインスタンスメソッドとして提供し、新しい`XxxModelList`を返すこと（元のインスタンスを変更しない）
 - ファクトリメソッドとして、Modelのリストから生成する`of()`、対応するEntity等のリストから生成する`from()`、空インスタンスを生成する`empty()`を提供すること
-- `size()`、`isEmpty()`、`get(int)`、`stream()`、`toList()`を提供し、`Iterable<XxxModel>`を実装すること
+- `size()`、`isEmpty()`、`get(int)`、`stream()`、`toList()`を提供し、`iterator()`をオーバーライドすること

--- a/.claude/rules/model.md
+++ b/.claude/rules/model.md
@@ -24,6 +24,7 @@ paths:
 
 - `record XxxModelList(List<XxxModel> xxxModelList) implements Iterable<XxxModel>`として実装する（Lombokの`@Value`/`@Builder`は使用しない）
 - コンパクトコンストラクタで`Objects.requireNonNull()`によるnullチェックを行う
+- クラスのJavadocコメントに、レコードコンポーネントを説明する`@param`タグを付与すること（checkstyleのJavadocTypeルールで必須）
 - ソート機能・フィルター機能はインスタンスメソッドとして提供し、新しい`XxxModelList`を返すこと（元のインスタンスを変更しない）
 - ファクトリメソッドとして、Modelのリストから生成する`of()`、対応するEntity等のリストから生成する`from()`、空インスタンスを生成する`empty()`を提供すること
 - `size()`、`isEmpty()`、`get(int)`、`stream()`、`toList()`を提供し、`iterator()`をオーバーライドすること

--- a/backend/src/main/java/com/web/gallery/controller/KbnMstRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/KbnMstRestController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.web.gallery.constant.ApiRoutes;
 import com.web.gallery.controller.response.PrefectureGroupResponse;
 import com.web.gallery.helper.KbnHelper;
-import com.web.gallery.model.KbnMstModel;
+import com.web.gallery.model.KbnMstModelList;
 import com.web.gallery.service.KbnMstService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -42,8 +42,8 @@ public class KbnMstRestController {
 	@ApiResponse(responseCode = "200", description = "取得成功")
 	@GetMapping(ApiRoutes.API_PREFECTURES)
 	public ResponseEntity<List<PrefectureGroupResponse>> getPrefectures() {
-		List<KbnMstModel> prefectureList = kbnMstService.getPrefectureList();
-		Map<String, List<KbnMstModel>> groupedMap = kbnHelper.convertToLinkedHashMap(prefectureList);
+		KbnMstModelList prefectureList = kbnMstService.getPrefectureList();
+		Map<String, KbnMstModelList> groupedMap = kbnHelper.convertToLinkedHashMap(prefectureList);
 
 		List<PrefectureGroupResponse> response = groupedMap.entrySet().stream()
 				.map(entry -> PrefectureGroupResponse.from(entry.getKey(), entry.getValue()))

--- a/backend/src/main/java/com/web/gallery/controller/PhotoRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/PhotoRestController.java
@@ -42,7 +42,7 @@ import com.web.gallery.model.PhotoDeleteModel;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
 import com.web.gallery.model.PhotoListGetModel;
-import com.web.gallery.model.PhotoModel;
+import com.web.gallery.model.PhotoModelList;
 import com.web.gallery.service.PhotoService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -85,7 +85,7 @@ public class PhotoRestController {
 			@PathVariable String photoAccountId,
 			@ModelAttribute @Validated PhotoListRequest photoListRequest) {
 		// 抽出条件に該当する写真の一覧を、指定の並び順で取得する
-		List<PhotoModel> photoList = photoService.getPhotoList(
+		PhotoModelList photoList = photoService.getPhotoList(
 				PhotoListGetModel.from(photoListRequest, sessionHelper.getAccountNo(), photoAccountId));
 		return ResponseEntity.ok(PhotoListGetResponse.from(photoList, photoListRequest.getPageNo(), photoConfig.getPhotoCountPerPage()));
 	}

--- a/backend/src/main/java/com/web/gallery/controller/PhotoRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/PhotoRestController.java
@@ -39,8 +39,10 @@ import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.helper.SessionHelper;
 import com.web.gallery.model.PhotoDeleteModel;
+import com.web.gallery.model.PhotoDeleteModelList;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
+import com.web.gallery.model.PhotoDetailModelList;
 import com.web.gallery.model.PhotoListGetModel;
 import com.web.gallery.model.PhotoModelList;
 import com.web.gallery.service.PhotoService;
@@ -180,7 +182,7 @@ public class PhotoRestController {
 			}
 		};
 		
-		List<PhotoDetailModel> photoDetailModelList = List.of(PhotoDetailModel.from(photoSaveRequest));
+		PhotoDetailModelList photoDetailModelList = PhotoDetailModelList.of(List.of(PhotoDetailModel.from(photoSaveRequest)));
 
 		Long savedPhotoNo = photoService.savePhotos(photoAccountId, photoDetailModelList);
 
@@ -227,7 +229,7 @@ public class PhotoRestController {
 			throw new BadRequestException(ErrorEnum.INVALID_INPUT);
 		}
 		
-		List<PhotoDeleteModel> photoDeleteModelList = List.of(PhotoDeleteModel.from(photoDeleteRequest));
+		PhotoDeleteModelList photoDeleteModelList = PhotoDeleteModelList.of(List.of(PhotoDeleteModel.from(photoDeleteRequest)));
 
 		photoService.deletePhotos(photoAccountId, photoDeleteModelList);
 		

--- a/backend/src/main/java/com/web/gallery/controller/response/PhotoListGetResponse.java
+++ b/backend/src/main/java/com/web/gallery/controller/response/PhotoListGetResponse.java
@@ -2,7 +2,7 @@ package com.web.gallery.controller.response;
 
 import java.util.List;
 
-import com.web.gallery.model.PhotoModel;
+import com.web.gallery.model.PhotoModelList;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -26,15 +26,15 @@ public class PhotoListGetResponse {
 	/**
 	 * 写真リストとページネーション情報からPhotoListGetResponseを生成する
 	 *
-	 * @param	photoList			{@link PhotoModel}のリスト
+	 * @param	photoList			{@link PhotoModelList}
 	 * @param	pageNo				ページ番号
 	 * @param	photoCountPerPage	1ページあたりの写真数
 	 * @return						{@link PhotoListGetResponse}
 	 */
-	public static PhotoListGetResponse from(List<PhotoModel> photoList, Integer pageNo, Integer photoCountPerPage) {
-		List<PhotoListResponse> photoListResponseList = photoList.subList(
-				(pageNo - 1) * photoCountPerPage,
-				Math.min(pageNo * photoCountPerPage, photoList.size())).stream()
+	public static PhotoListGetResponse from(PhotoModelList photoList, Integer pageNo, Integer photoCountPerPage) {
+		List<PhotoListResponse> photoListResponseList = photoList.stream()
+				.skip((long) (pageNo - 1) * photoCountPerPage)
+				.limit(photoCountPerPage)
 				.map(PhotoListResponse::from)
 				.toList();
 

--- a/backend/src/main/java/com/web/gallery/controller/response/PrefectureGroupResponse.java
+++ b/backend/src/main/java/com/web/gallery/controller/response/PrefectureGroupResponse.java
@@ -2,7 +2,7 @@ package com.web.gallery.controller.response;
 
 import java.util.List;
 
-import com.web.gallery.model.KbnMstModel;
+import com.web.gallery.model.KbnMstModelList;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -24,13 +24,13 @@ public class PrefectureGroupResponse {
 	private List<PrefectureResponse> prefectures;
 
 	/**
-	 * グループ名とKbnMstModelリストからPrefectureGroupResponseを生成する
+	 * グループ名とKbnMstModelListからPrefectureGroupResponseを生成する
 	 *
 	 * @param	groupName		グループ名
-	 * @param	kbnMstModels	{@link KbnMstModel}のリスト
+	 * @param	kbnMstModels	{@link KbnMstModelList}
 	 * @return					{@link PrefectureGroupResponse}
 	 */
-	public static PrefectureGroupResponse from(String groupName, List<KbnMstModel> kbnMstModels) {
+	public static PrefectureGroupResponse from(String groupName, KbnMstModelList kbnMstModels) {
 		List<PrefectureResponse> prefectures = kbnMstModels.stream()
 				.map(PrefectureResponse::from)
 				.toList();

--- a/backend/src/main/java/com/web/gallery/helper/KbnHelper.java
+++ b/backend/src/main/java/com/web/gallery/helper/KbnHelper.java
@@ -1,14 +1,11 @@
 package com.web.gallery.helper;
 
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
-import com.web.gallery.model.KbnMstModel;
+import com.web.gallery.model.KbnMstModelList;
 
 /**
  * 区分マスタに関するHelperクラス
@@ -18,37 +15,16 @@ public class KbnHelper {
 	/**
 	 * データベースから取得した区分マスタの一覧を、グループ単位に分けてLinkedHashMapに変換する
 	 *
-	 * @param kbnMstModelList	{@link KbnMstModel}
+	 * @param kbnMstModelList	{@link KbnMstModelList}
 	 * @return					区分マスタのLinkedHashMap
 	 */
-	public Map<String, List<KbnMstModel>> convertToLinkedHashMap(List<KbnMstModel> kbnMstModelList){
-		LinkedHashMap<String, List<KbnMstModel>> kbnMstLinkedHashMap = new LinkedHashMap<String, List<KbnMstModel>>();
+	public Map<String, KbnMstModelList> convertToLinkedHashMap(KbnMstModelList kbnMstModelList){
+		KbnMstModelList sortedKbnMstModelList = kbnMstModelList.sortBySortOrder();
 
-		kbnMstModelList = kbnMstModelList.stream().sorted(Comparator.comparing(m -> m.getSortOrder().value())).toList();
-		KbnMstModel firstKbnMstModel = kbnMstModelList.getFirst();
-		KbnMstModel lastKbnMstModel = kbnMstModelList.getLast();
-		List<KbnMstModel> tempKbnMstModelList = new ArrayList<KbnMstModel>();
-		String kbnGroupJapaneseName = null;
-
-		for(KbnMstModel kbnMstModel : kbnMstModelList) {
-			if(kbnMstModel.equals(firstKbnMstModel)) {
-				kbnGroupJapaneseName = kbnMstModel.getKbnGroupJapaneseName().value();
-				tempKbnMstModelList.add(kbnMstModel);
-			}
-			else if(kbnMstModel.equals(lastKbnMstModel)) {
-				tempKbnMstModelList.add(kbnMstModel);
-				kbnMstLinkedHashMap.put(kbnGroupJapaneseName, tempKbnMstModelList);
-			}
-			else if(!kbnGroupJapaneseName.equals(kbnMstModel.getKbnGroupJapaneseName().value())) {
-				kbnMstLinkedHashMap.put(kbnGroupJapaneseName, tempKbnMstModelList);
-				tempKbnMstModelList = new ArrayList<KbnMstModel>();
-				kbnGroupJapaneseName = kbnMstModel.getKbnGroupJapaneseName().value();
-				tempKbnMstModelList.add(kbnMstModel);
-			}
-			else {
-				tempKbnMstModelList.add(kbnMstModel);
-			}
-		};
+		LinkedHashMap<String, KbnMstModelList> kbnMstLinkedHashMap = new LinkedHashMap<String, KbnMstModelList>();
+		for(String kbnGroupJapaneseName : sortedKbnMstModelList.stream().map(kbnMstModel -> kbnMstModel.getKbnGroupJapaneseName().value()).distinct().toList()) {
+			kbnMstLinkedHashMap.put(kbnGroupJapaneseName, sortedKbnMstModelList.filterByKbnGroupJapaneseName(kbnGroupJapaneseName));
+		}
 
 		return kbnMstLinkedHashMap;
 	}

--- a/backend/src/main/java/com/web/gallery/helper/KbnHelper.java
+++ b/backend/src/main/java/com/web/gallery/helper/KbnHelper.java
@@ -2,6 +2,7 @@ package com.web.gallery.helper;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import org.springframework.stereotype.Component;
 
@@ -19,6 +20,8 @@ public class KbnHelper {
 	 * @return					区分マスタのLinkedHashMap
 	 */
 	public Map<String, KbnMstModelList> convertToLinkedHashMap(KbnMstModelList kbnMstModelList){
+		if(kbnMstModelList.isEmpty()) throw new NoSuchElementException();
+
 		KbnMstModelList sortedKbnMstModelList = kbnMstModelList.sortBySortOrder();
 
 		LinkedHashMap<String, KbnMstModelList> kbnMstLinkedHashMap = new LinkedHashMap<String, KbnMstModelList>();

--- a/backend/src/main/java/com/web/gallery/model/AccountModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/AccountModelList.java
@@ -10,6 +10,8 @@ import com.web.gallery.entity.Account;
 
 /**
  * AccountModelのコレクションを表すクラス
+ *
+ * @param	accountModelList	{@link AccountModel}のリスト
  */
 public record AccountModelList(List<AccountModel> accountModelList) implements Iterable<AccountModel> {
 

--- a/backend/src/main/java/com/web/gallery/model/AccountModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/AccountModelList.java
@@ -1,0 +1,126 @@
+package com.web.gallery.model;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import com.web.gallery.entity.Account;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+/**
+ * AccountModelのコレクションを表すクラス
+ */
+@Value
+@Builder
+public class AccountModelList implements Iterable<AccountModel> {
+	/** AccountModelのリスト */
+	@NonNull
+	private List<AccountModel> accountModelList;
+
+	/**
+	 * AccountModelのリストからAccountModelListを生成する
+	 *
+	 * @param	accountModelList	{@link AccountModel}のリスト
+	 * @return						{@link AccountModelList}
+	 */
+	public static AccountModelList of(List<AccountModel> accountModelList) {
+		return AccountModelList.builder().accountModelList(accountModelList).build();
+	}
+
+	/**
+	 * 空のAccountModelListを生成する
+	 *
+	 * @return	{@link AccountModelList}
+	 */
+	public static AccountModelList empty() {
+		return AccountModelList.of(List.of());
+	}
+
+	/**
+	 * AccountエンティティのリストからAccountModelListを生成する
+	 *
+	 * @param	accountList	{@link Account}のリスト
+	 * @return				{@link AccountModelList}
+	 */
+	public static AccountModelList from(List<Account> accountList) {
+		return AccountModelList.of(accountList.stream().map(AccountModel::from).toList());
+	}
+
+	/**
+	 * アカウントIDの昇順でソートしたAccountModelListを生成する
+	 *
+	 * @return	{@link AccountModelList}
+	 */
+	public AccountModelList sortByAccountId() {
+		return AccountModelList.of(accountModelList.stream()
+				.sorted(Comparator.comparing(accountModel -> accountModel.getAccountId().value()))
+				.toList());
+	}
+
+	/**
+	 * 削除フラグでフィルタリングしたAccountModelListを生成する
+	 *
+	 * @param	isDeleted	フィルター条件の削除フラグ
+	 * @return				{@link AccountModelList}
+	 */
+	public AccountModelList filterByIsDeleted(Boolean isDeleted) {
+		return AccountModelList.of(accountModelList.stream()
+				.filter(accountModel -> accountModel.getIsDeleted().value().equals(isDeleted))
+				.toList());
+	}
+
+	/**
+	 * 要素数を取得する
+	 *
+	 * @return	要素数
+	 */
+	public Integer size() {
+		return accountModelList.size();
+	}
+
+	/**
+	 * 要素が空かどうかを取得する
+	 *
+	 * @return	要素が空の場合はtrue
+	 */
+	public Boolean isEmpty() {
+		return accountModelList.isEmpty();
+	}
+
+	/**
+	 * 指定インデックスの要素を取得する
+	 *
+	 * @param	index	インデックス
+	 * @return			{@link AccountModel}
+	 */
+	public AccountModel get(int index) {
+		return accountModelList.get(index);
+	}
+
+	/**
+	 * Streamに変換する
+	 *
+	 * @return	{@link AccountModel}のStream
+	 */
+	public Stream<AccountModel> stream() {
+		return accountModelList.stream();
+	}
+
+	/**
+	 * Listに変換する
+	 *
+	 * @return	{@link AccountModel}のList
+	 */
+	public List<AccountModel> toList() {
+		return accountModelList;
+	}
+
+	@Override
+	public Iterator<AccountModel> iterator() {
+		return accountModelList.iterator();
+	}
+}

--- a/backend/src/main/java/com/web/gallery/model/AccountModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/AccountModelList.java
@@ -3,23 +3,19 @@ package com.web.gallery.model;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import com.web.gallery.entity.Account;
 
-import lombok.Builder;
-import lombok.NonNull;
-import lombok.Value;
-
 /**
  * AccountModelのコレクションを表すクラス
  */
-@Value
-@Builder
-public class AccountModelList implements Iterable<AccountModel> {
-	/** AccountModelのリスト */
-	@NonNull
-	private List<AccountModel> accountModelList;
+public record AccountModelList(List<AccountModel> accountModelList) implements Iterable<AccountModel> {
+
+	public AccountModelList {
+		Objects.requireNonNull(accountModelList);
+	}
 
 	/**
 	 * AccountModelのリストからAccountModelListを生成する
@@ -28,7 +24,7 @@ public class AccountModelList implements Iterable<AccountModel> {
 	 * @return						{@link AccountModelList}
 	 */
 	public static AccountModelList of(List<AccountModel> accountModelList) {
-		return AccountModelList.builder().accountModelList(accountModelList).build();
+		return new AccountModelList(accountModelList);
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/model/KbnMstModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/KbnMstModelList.java
@@ -10,6 +10,8 @@ import com.web.gallery.entity.KbnMst;
 
 /**
  * KbnMstModelのコレクションを表すクラス
+ *
+ * @param	kbnMstModelList	{@link KbnMstModel}のリスト
  */
 public record KbnMstModelList(List<KbnMstModel> kbnMstModelList) implements Iterable<KbnMstModel> {
 

--- a/backend/src/main/java/com/web/gallery/model/KbnMstModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/KbnMstModelList.java
@@ -1,0 +1,144 @@
+package com.web.gallery.model;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import com.web.gallery.entity.KbnMst;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+/**
+ * KbnMstModelのコレクションを表すクラス
+ */
+@Value
+@Builder
+public class KbnMstModelList implements Iterable<KbnMstModel> {
+	/** KbnMstModelのリスト */
+	@NonNull
+	private List<KbnMstModel> kbnMstModelList;
+
+	/**
+	 * KbnMstModelのリストからKbnMstModelListを生成する
+	 *
+	 * @param	kbnMstModelList	{@link KbnMstModel}のリスト
+	 * @return					{@link KbnMstModelList}
+	 */
+	public static KbnMstModelList of(List<KbnMstModel> kbnMstModelList) {
+		return KbnMstModelList.builder().kbnMstModelList(kbnMstModelList).build();
+	}
+
+	/**
+	 * 空のKbnMstModelListを生成する
+	 *
+	 * @return	{@link KbnMstModelList}
+	 */
+	public static KbnMstModelList empty() {
+		return KbnMstModelList.of(List.of());
+	}
+
+	/**
+	 * KbnMstエンティティのリストからKbnMstModelListを生成する
+	 *
+	 * @param	kbnMstList	{@link KbnMst}のリスト
+	 * @return				{@link KbnMstModelList}
+	 */
+	public static KbnMstModelList from(List<KbnMst> kbnMstList) {
+		return KbnMstModelList.of(kbnMstList.stream().map(KbnMstModel::from).toList());
+	}
+
+	/**
+	 * 並び順の昇順でソートしたKbnMstModelListを生成する
+	 *
+	 * @return	{@link KbnMstModelList}
+	 */
+	public KbnMstModelList sortBySortOrder() {
+		return KbnMstModelList.of(kbnMstModelList.stream()
+				.sorted(Comparator.comparing(kbnMstModel -> kbnMstModel.getSortOrder().value()))
+				.toList());
+	}
+
+	/**
+	 * 区分グループ日本語名でフィルタリングしたKbnMstModelListを生成する
+	 *
+	 * @param	kbnGroupJapaneseName	フィルター条件の区分グループ日本語名
+	 * @return							{@link KbnMstModelList}
+	 */
+	public KbnMstModelList filterByKbnGroupJapaneseName(String kbnGroupJapaneseName) {
+		return KbnMstModelList.of(kbnMstModelList.stream()
+				.filter(kbnMstModel -> kbnMstModel.getKbnGroupJapaneseName().value().equals(kbnGroupJapaneseName))
+				.toList());
+	}
+
+	/**
+	 * 要素数を取得する
+	 *
+	 * @return	要素数
+	 */
+	public Integer size() {
+		return kbnMstModelList.size();
+	}
+
+	/**
+	 * 要素が空かどうかを取得する
+	 *
+	 * @return	要素が空の場合はtrue
+	 */
+	public Boolean isEmpty() {
+		return kbnMstModelList.isEmpty();
+	}
+
+	/**
+	 * 指定インデックスの要素を取得する
+	 *
+	 * @param	index	インデックス
+	 * @return			{@link KbnMstModel}
+	 */
+	public KbnMstModel get(int index) {
+		return kbnMstModelList.get(index);
+	}
+
+	/**
+	 * 先頭の要素を取得する
+	 *
+	 * @return	{@link KbnMstModel}
+	 */
+	public KbnMstModel getFirst() {
+		return kbnMstModelList.getFirst();
+	}
+
+	/**
+	 * 末尾の要素を取得する
+	 *
+	 * @return	{@link KbnMstModel}
+	 */
+	public KbnMstModel getLast() {
+		return kbnMstModelList.getLast();
+	}
+
+	/**
+	 * Streamに変換する
+	 *
+	 * @return	{@link KbnMstModel}のStream
+	 */
+	public Stream<KbnMstModel> stream() {
+		return kbnMstModelList.stream();
+	}
+
+	/**
+	 * Listに変換する
+	 *
+	 * @return	{@link KbnMstModel}のList
+	 */
+	public List<KbnMstModel> toList() {
+		return kbnMstModelList;
+	}
+
+	@Override
+	public Iterator<KbnMstModel> iterator() {
+		return kbnMstModelList.iterator();
+	}
+}

--- a/backend/src/main/java/com/web/gallery/model/KbnMstModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/KbnMstModelList.java
@@ -3,23 +3,19 @@ package com.web.gallery.model;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import com.web.gallery.entity.KbnMst;
 
-import lombok.Builder;
-import lombok.NonNull;
-import lombok.Value;
-
 /**
  * KbnMstModelのコレクションを表すクラス
  */
-@Value
-@Builder
-public class KbnMstModelList implements Iterable<KbnMstModel> {
-	/** KbnMstModelのリスト */
-	@NonNull
-	private List<KbnMstModel> kbnMstModelList;
+public record KbnMstModelList(List<KbnMstModel> kbnMstModelList) implements Iterable<KbnMstModel> {
+
+	public KbnMstModelList {
+		Objects.requireNonNull(kbnMstModelList);
+	}
 
 	/**
 	 * KbnMstModelのリストからKbnMstModelListを生成する
@@ -28,7 +24,7 @@ public class KbnMstModelList implements Iterable<KbnMstModel> {
 	 * @return					{@link KbnMstModelList}
 	 */
 	public static KbnMstModelList of(List<KbnMstModel> kbnMstModelList) {
-		return KbnMstModelList.builder().kbnMstModelList(kbnMstModelList).build();
+		return new KbnMstModelList(kbnMstModelList);
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/model/PhotoDeleteModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoDeleteModelList.java
@@ -1,0 +1,97 @@
+package com.web.gallery.model;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * PhotoDeleteModelのコレクションを表すクラス
+ *
+ * @param	photoDeleteModelList	{@link PhotoDeleteModel}のリスト
+ */
+public record PhotoDeleteModelList(List<PhotoDeleteModel> photoDeleteModelList) implements Iterable<PhotoDeleteModel> {
+
+	public PhotoDeleteModelList {
+		Objects.requireNonNull(photoDeleteModelList);
+	}
+
+	/**
+	 * PhotoDeleteModelのリストからPhotoDeleteModelListを生成する
+	 *
+	 * @param	photoDeleteModelList	{@link PhotoDeleteModel}のリスト
+	 * @return							{@link PhotoDeleteModelList}
+	 */
+	public static PhotoDeleteModelList of(List<PhotoDeleteModel> photoDeleteModelList) {
+		return new PhotoDeleteModelList(photoDeleteModelList);
+	}
+
+	/**
+	 * 空のPhotoDeleteModelListを生成する
+	 *
+	 * @return	{@link PhotoDeleteModelList}
+	 */
+	public static PhotoDeleteModelList empty() {
+		return PhotoDeleteModelList.of(List.of());
+	}
+
+	/**
+	 * 要素数を取得する
+	 *
+	 * @return	要素数
+	 */
+	public Integer size() {
+		return photoDeleteModelList.size();
+	}
+
+	/**
+	 * 要素が空かどうかを取得する
+	 *
+	 * @return	要素が空の場合はtrue
+	 */
+	public Boolean isEmpty() {
+		return photoDeleteModelList.isEmpty();
+	}
+
+	/**
+	 * 指定インデックスの要素を取得する
+	 *
+	 * @param	index	インデックス
+	 * @return			{@link PhotoDeleteModel}
+	 */
+	public PhotoDeleteModel get(int index) {
+		return photoDeleteModelList.get(index);
+	}
+
+	/**
+	 * 先頭の要素を取得する
+	 *
+	 * @return	{@link PhotoDeleteModel}
+	 */
+	public PhotoDeleteModel getFirst() {
+		return photoDeleteModelList.getFirst();
+	}
+
+	/**
+	 * Streamに変換する
+	 *
+	 * @return	{@link PhotoDeleteModel}のStream
+	 */
+	public Stream<PhotoDeleteModel> stream() {
+		return photoDeleteModelList.stream();
+	}
+
+	/**
+	 * Listに変換する
+	 *
+	 * @return	{@link PhotoDeleteModel}のList
+	 */
+	public List<PhotoDeleteModel> toList() {
+		return photoDeleteModelList;
+	}
+
+	@Override
+	public Iterator<PhotoDeleteModel> iterator() {
+		return photoDeleteModelList.iterator();
+	}
+}

--- a/backend/src/main/java/com/web/gallery/model/PhotoDetailModel.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoDetailModel.java
@@ -1,11 +1,9 @@
 package com.web.gallery.model;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import com.web.gallery.constant.Consts;
 import com.web.gallery.controller.request.PhotoSaveRequest;
@@ -105,7 +103,7 @@ public class PhotoDetailModel {
 	private Iso iso;
 
 	/** 写真タグリスト */
-	private List<PhotoTagModel> photoTagModelList;
+	private PhotoTagModelList photoTagModelList;
 
 	/**
 	 * PhotoDetailDtoとタグエンティティリストからPhotoDetailModelを生成する
@@ -115,7 +113,7 @@ public class PhotoDetailModel {
 	 * @return					{@link PhotoDetailModel}
 	 */
 	public static PhotoDetailModel from(PhotoDetailDto dto, List<PhotoTagMst> photoTagMstList) {
-		List<PhotoTagModel> photoTagModelList = photoTagMstList.stream().map(PhotoTagModel::from).toList();
+		PhotoTagModelList photoTagModelList = PhotoTagModelList.from(photoTagMstList);
 		return PhotoDetailModel.builder()
 				.accountNo(dto.getAccountNo())
 				.photoNo(dto.getPhotoNo())
@@ -147,11 +145,11 @@ public class PhotoDetailModel {
 	 * @return			{@link PhotoDetailModel}
 	 */
 	public static PhotoDetailModel from(PhotoSaveRequest request) {
-		List<PhotoTagModel> photoTagModelList = Objects.isNull(request.getPhotoTagRegistRequestList())
-				? new ArrayList<PhotoTagModel>()
-				: request.getPhotoTagRegistRequestList().stream()
+		PhotoTagModelList photoTagModelList = Objects.isNull(request.getPhotoTagRegistRequestList())
+				? PhotoTagModelList.empty()
+				: PhotoTagModelList.of(request.getPhotoTagRegistRequestList().stream()
 						.map(PhotoTagModel::from)
-						.collect(Collectors.toList());
+						.toList());
 		return PhotoDetailModel.builder()
 				.accountNo(new AccountNo(request.getAccountNo()))
 				.photoNo(request.getPhotoNo() != null ? new PhotoNo(request.getPhotoNo()) : null)

--- a/backend/src/main/java/com/web/gallery/model/PhotoDetailModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoDetailModelList.java
@@ -1,0 +1,97 @@
+package com.web.gallery.model;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * PhotoDetailModelのコレクションを表すクラス
+ *
+ * @param	photoDetailModelList	{@link PhotoDetailModel}のリスト
+ */
+public record PhotoDetailModelList(List<PhotoDetailModel> photoDetailModelList) implements Iterable<PhotoDetailModel> {
+
+	public PhotoDetailModelList {
+		Objects.requireNonNull(photoDetailModelList);
+	}
+
+	/**
+	 * PhotoDetailModelのリストからPhotoDetailModelListを生成する
+	 *
+	 * @param	photoDetailModelList	{@link PhotoDetailModel}のリスト
+	 * @return							{@link PhotoDetailModelList}
+	 */
+	public static PhotoDetailModelList of(List<PhotoDetailModel> photoDetailModelList) {
+		return new PhotoDetailModelList(photoDetailModelList);
+	}
+
+	/**
+	 * 空のPhotoDetailModelListを生成する
+	 *
+	 * @return	{@link PhotoDetailModelList}
+	 */
+	public static PhotoDetailModelList empty() {
+		return PhotoDetailModelList.of(List.of());
+	}
+
+	/**
+	 * 要素数を取得する
+	 *
+	 * @return	要素数
+	 */
+	public Integer size() {
+		return photoDetailModelList.size();
+	}
+
+	/**
+	 * 要素が空かどうかを取得する
+	 *
+	 * @return	要素が空の場合はtrue
+	 */
+	public Boolean isEmpty() {
+		return photoDetailModelList.isEmpty();
+	}
+
+	/**
+	 * 指定インデックスの要素を取得する
+	 *
+	 * @param	index	インデックス
+	 * @return			{@link PhotoDetailModel}
+	 */
+	public PhotoDetailModel get(int index) {
+		return photoDetailModelList.get(index);
+	}
+
+	/**
+	 * 先頭の要素を取得する
+	 *
+	 * @return	{@link PhotoDetailModel}
+	 */
+	public PhotoDetailModel getFirst() {
+		return photoDetailModelList.getFirst();
+	}
+
+	/**
+	 * Streamに変換する
+	 *
+	 * @return	{@link PhotoDetailModel}のStream
+	 */
+	public Stream<PhotoDetailModel> stream() {
+		return photoDetailModelList.stream();
+	}
+
+	/**
+	 * Listに変換する
+	 *
+	 * @return	{@link PhotoDetailModel}のList
+	 */
+	public List<PhotoDetailModel> toList() {
+		return photoDetailModelList;
+	}
+
+	@Override
+	public Iterator<PhotoDetailModel> iterator() {
+		return photoDetailModelList.iterator();
+	}
+}

--- a/backend/src/main/java/com/web/gallery/model/PhotoModel.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoModel.java
@@ -1,8 +1,5 @@
 package com.web.gallery.model;
 
-import java.util.List;
-import java.util.Objects;
-
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.Caption;
 import com.web.gallery.domain.photo.FavoriteCount;
@@ -13,6 +10,8 @@ import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.dto.PhotoDto;
 import com.web.gallery.entity.PhotoTagMst;
 import com.web.gallery.enumuration.DirectionEnum;
+
+import java.util.List;
 
 import lombok.Builder;
 import lombok.NonNull;
@@ -60,7 +59,7 @@ public class PhotoModel {
 
 	/** 写真タグリスト */
 	@NonNull
-	private List<PhotoTagModel> photoTagModelList;
+	private PhotoTagModelList photoTagModelList;
 
 	/**
 	 * PhotoDtoとタグエンティティリストからPhotoModelを生成する
@@ -70,12 +69,8 @@ public class PhotoModel {
 	 * @return					{@link PhotoModel}
 	 */
 	public static PhotoModel from(PhotoDto dto, List<PhotoTagMst> photoTagMstList) {
-		List<PhotoTagModel> photoTagModelList = photoTagMstList.stream()
-				.filter(tag ->
-					tag.getAccountNo().value().equals(dto.getAccountNo().value()) &&
-					Objects.equals(tag.getPhotoNo().value(), dto.getPhotoNo().value()))
-				.map(PhotoTagModel::from)
-				.toList();
+		PhotoTagModelList photoTagModelList = PhotoTagModelList.from(photoTagMstList)
+				.filterByPhoto(dto.getAccountNo(), dto.getPhotoNo());
 		return PhotoModel.builder()
 				.accountNo(dto.getAccountNo())
 				.photoNo(dto.getPhotoNo())

--- a/backend/src/main/java/com/web/gallery/model/PhotoModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoModelList.java
@@ -3,25 +3,21 @@ package com.web.gallery.model;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import com.web.gallery.dto.PhotoDto;
 import com.web.gallery.entity.PhotoTagMst;
 import com.web.gallery.enumuration.DirectionEnum;
 
-import lombok.Builder;
-import lombok.NonNull;
-import lombok.Value;
-
 /**
  * PhotoModelのコレクションを表すクラス
  */
-@Value
-@Builder
-public class PhotoModelList implements Iterable<PhotoModel> {
-	/** PhotoModelのリスト */
-	@NonNull
-	private List<PhotoModel> photoModelList;
+public record PhotoModelList(List<PhotoModel> photoModelList) implements Iterable<PhotoModel> {
+
+	public PhotoModelList {
+		Objects.requireNonNull(photoModelList);
+	}
 
 	/**
 	 * PhotoModelのリストからPhotoModelListを生成する
@@ -30,7 +26,7 @@ public class PhotoModelList implements Iterable<PhotoModel> {
 	 * @return					{@link PhotoModelList}
 	 */
 	public static PhotoModelList of(List<PhotoModel> photoModelList) {
-		return PhotoModelList.builder().photoModelList(photoModelList).build();
+		return new PhotoModelList(photoModelList);
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/model/PhotoModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoModelList.java
@@ -12,6 +12,8 @@ import com.web.gallery.enumuration.DirectionEnum;
 
 /**
  * PhotoModelのコレクションを表すクラス
+ *
+ * @param	photoModelList	{@link PhotoModel}のリスト
  */
 public record PhotoModelList(List<PhotoModel> photoModelList) implements Iterable<PhotoModel> {
 

--- a/backend/src/main/java/com/web/gallery/model/PhotoModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoModelList.java
@@ -1,0 +1,170 @@
+package com.web.gallery.model;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import com.web.gallery.dto.PhotoDto;
+import com.web.gallery.entity.PhotoTagMst;
+import com.web.gallery.enumuration.DirectionEnum;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+/**
+ * PhotoModelのコレクションを表すクラス
+ */
+@Value
+@Builder
+public class PhotoModelList implements Iterable<PhotoModel> {
+	/** PhotoModelのリスト */
+	@NonNull
+	private List<PhotoModel> photoModelList;
+
+	/**
+	 * PhotoModelのリストからPhotoModelListを生成する
+	 *
+	 * @param	photoModelList	{@link PhotoModel}のリスト
+	 * @return					{@link PhotoModelList}
+	 */
+	public static PhotoModelList of(List<PhotoModel> photoModelList) {
+		return PhotoModelList.builder().photoModelList(photoModelList).build();
+	}
+
+	/**
+	 * 空のPhotoModelListを生成する
+	 *
+	 * @return	{@link PhotoModelList}
+	 */
+	public static PhotoModelList empty() {
+		return PhotoModelList.of(List.of());
+	}
+
+	/**
+	 * PhotoDtoのリストとタグエンティティリストからPhotoModelListを生成する
+	 *
+	 * @param	photoDtoList	{@link PhotoDto}のリスト
+	 * @param	photoTagMstList	全タグエンティティリスト（内部で該当写真のタグをフィルタリングする）
+	 * @return					{@link PhotoModelList}
+	 */
+	public static PhotoModelList from(List<PhotoDto> photoDtoList, List<PhotoTagMst> photoTagMstList) {
+		return PhotoModelList.of(photoDtoList.stream()
+				.map(photoDto -> PhotoModel.from(photoDto, photoTagMstList))
+				.toList());
+	}
+
+	/**
+	 * 指定のComparatorでソートしたPhotoModelListを生成する
+	 *
+	 * @param	comparator	ソート条件のComparator
+	 * @return				{@link PhotoModelList}
+	 */
+	public PhotoModelList sorted(Comparator<PhotoModel> comparator) {
+		return PhotoModelList.of(photoModelList.stream().sorted(comparator).toList());
+	}
+
+	/**
+	 * 向き区分でフィルタリングしたPhotoModelListを生成する<p>
+	 * 条件がNONEの場合はフィルタリングしない
+	 *
+	 * @param	conditionDirectionKbn	フィルター条件の向き区分
+	 * @return							{@link PhotoModelList}
+	 */
+	public PhotoModelList filterByDirectionKbn(DirectionEnum conditionDirectionKbn) {
+		if (DirectionEnum.NONE.equals(conditionDirectionKbn)) return this;
+
+		return PhotoModelList.of(photoModelList.stream()
+				.filter(photoModel -> photoModel.getDirectionKbn().equals(conditionDirectionKbn))
+				.toList());
+	}
+
+	/**
+	 * お気に入りでフィルタリングしたPhotoModelListを生成する<p>
+	 * isFavoriteOnlyがfalseの場合はフィルタリングしない
+	 *
+	 * @param	isFavoriteOnly	お気に入りに絞るならtrue
+	 * @return					{@link PhotoModelList}
+	 */
+	public PhotoModelList filterByFavorite(Boolean isFavoriteOnly) {
+		if (!isFavoriteOnly) return this;
+
+		return PhotoModelList.of(photoModelList.stream()
+				.filter(photoModel -> photoModel.getIsFavorite().value())
+				.toList());
+	}
+
+	/**
+	 * タグでフィルタリングしたPhotoModelListを生成する<p>
+	 * タグが複数ある場合、すべてのタグを持つ写真にフィルタリングする
+	 *
+	 * @param	tags	フィルター条件のタグのリスト
+	 * @return			{@link PhotoModelList}
+	 */
+	public PhotoModelList filterByTags(List<String> tags) {
+		return PhotoModelList.of(photoModelList.stream()
+				.filter(photoModel -> photoModel.getPhotoTagModelList().containsAllTags(tags))
+				.toList());
+	}
+
+	/**
+	 * 要素数を取得する
+	 *
+	 * @return	要素数
+	 */
+	public Integer size() {
+		return photoModelList.size();
+	}
+
+	/**
+	 * 要素が空かどうかを取得する
+	 *
+	 * @return	要素が空の場合はtrue
+	 */
+	public Boolean isEmpty() {
+		return photoModelList.isEmpty();
+	}
+
+	/**
+	 * 指定インデックスの要素を取得する
+	 *
+	 * @param	index	インデックス
+	 * @return			{@link PhotoModel}
+	 */
+	public PhotoModel get(int index) {
+		return photoModelList.get(index);
+	}
+
+	/**
+	 * 先頭の要素を取得する
+	 *
+	 * @return	{@link PhotoModel}
+	 */
+	public PhotoModel getFirst() {
+		return photoModelList.getFirst();
+	}
+
+	/**
+	 * Streamに変換する
+	 *
+	 * @return	{@link PhotoModel}のStream
+	 */
+	public Stream<PhotoModel> stream() {
+		return photoModelList.stream();
+	}
+
+	/**
+	 * Listに変換する
+	 *
+	 * @return	{@link PhotoModel}のList
+	 */
+	public List<PhotoModel> toList() {
+		return photoModelList;
+	}
+
+	@Override
+	public Iterator<PhotoModel> iterator() {
+		return photoModelList.iterator();
+	}
+}

--- a/backend/src/main/java/com/web/gallery/model/PhotoTagModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoTagModelList.java
@@ -1,0 +1,152 @@
+package com.web.gallery.model;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import com.web.gallery.constant.Consts;
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.photo.PhotoNo;
+import com.web.gallery.entity.PhotoTagMst;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+/**
+ * PhotoTagModelのコレクションを表すクラス
+ */
+@Value
+@Builder
+public class PhotoTagModelList implements Iterable<PhotoTagModel> {
+	/** PhotoTagModelのリスト */
+	@NonNull
+	private List<PhotoTagModel> photoTagModelList;
+
+	/**
+	 * PhotoTagModelのリストからPhotoTagModelListを生成する
+	 *
+	 * @param	photoTagModelList	{@link PhotoTagModel}のリスト
+	 * @return						{@link PhotoTagModelList}
+	 */
+	public static PhotoTagModelList of(List<PhotoTagModel> photoTagModelList) {
+		return PhotoTagModelList.builder().photoTagModelList(photoTagModelList).build();
+	}
+
+	/**
+	 * 空のPhotoTagModelListを生成する
+	 *
+	 * @return	{@link PhotoTagModelList}
+	 */
+	public static PhotoTagModelList empty() {
+		return PhotoTagModelList.of(List.of());
+	}
+
+	/**
+	 * PhotoTagMstエンティティのリストからPhotoTagModelListを生成する<p>
+	 * タグ番号の昇順でソートして生成する
+	 *
+	 * @param	photoTagMstList	{@link PhotoTagMst}のリスト
+	 * @return					{@link PhotoTagModelList}
+	 */
+	public static PhotoTagModelList from(List<PhotoTagMst> photoTagMstList) {
+		return PhotoTagModelList.of(photoTagMstList.stream().map(PhotoTagModel::from).toList()).sortByTagNo();
+	}
+
+	/**
+	 * タグ番号の昇順でソートしたPhotoTagModelListを生成する
+	 *
+	 * @return	{@link PhotoTagModelList}
+	 */
+	public PhotoTagModelList sortByTagNo() {
+		return PhotoTagModelList.of(photoTagModelList.stream()
+				.sorted(Comparator.comparing(photoTagModel -> photoTagModel.getTagNo().value()))
+				.toList());
+	}
+
+	/**
+	 * アカウント番号・写真番号でフィルタリングしたPhotoTagModelListを生成する
+	 *
+	 * @param	accountNo	フィルター条件のアカウント番号
+	 * @param	photoNo		フィルター条件の写真番号
+	 * @return				{@link PhotoTagModelList}
+	 */
+	public PhotoTagModelList filterByPhoto(AccountNo accountNo, PhotoNo photoNo) {
+		return PhotoTagModelList.of(photoTagModelList.stream()
+				.filter(photoTagModel ->
+					photoTagModel.getAccountNo().value().equals(accountNo.value()) &&
+					Objects.equals(photoTagModel.getPhotoNo().value(), photoNo.value()))
+				.toList());
+	}
+
+	/**
+	 * 指定のタグをすべて保持しているかどうかを判定する<p>
+	 * タグが未指定の場合はtrueを返す
+	 *
+	 * @param	tags	判定対象のタグのリスト
+	 * @return			すべてのタグを保持している場合はtrue
+	 */
+	public Boolean containsAllTags(List<String> tags) {
+		if (tags.isEmpty() || Consts.STRING_EMPTY.equals(tags.getFirst())) return true;
+
+		List<String> photoTags = new ArrayList<String>();
+		photoTags.addAll(photoTagModelList.stream().map(photoTagModel -> photoTagModel.getTagJapaneseName().value()).toList());
+		photoTags.addAll(photoTagModelList.stream().map(photoTagModel -> photoTagModel.getTagEnglishName().value()).toList());
+
+		return photoTags.containsAll(tags);
+	}
+
+	/**
+	 * 要素数を取得する
+	 *
+	 * @return	要素数
+	 */
+	public Integer size() {
+		return photoTagModelList.size();
+	}
+
+	/**
+	 * 要素が空かどうかを取得する
+	 *
+	 * @return	要素が空の場合はtrue
+	 */
+	public Boolean isEmpty() {
+		return photoTagModelList.isEmpty();
+	}
+
+	/**
+	 * 指定インデックスの要素を取得する
+	 *
+	 * @param	index	インデックス
+	 * @return			{@link PhotoTagModel}
+	 */
+	public PhotoTagModel get(int index) {
+		return photoTagModelList.get(index);
+	}
+
+	/**
+	 * Streamに変換する
+	 *
+	 * @return	{@link PhotoTagModel}のStream
+	 */
+	public Stream<PhotoTagModel> stream() {
+		return photoTagModelList.stream();
+	}
+
+	/**
+	 * Listに変換する
+	 *
+	 * @return	{@link PhotoTagModel}のList
+	 */
+	public List<PhotoTagModel> toList() {
+		return photoTagModelList;
+	}
+
+	@Override
+	public Iterator<PhotoTagModel> iterator() {
+		return photoTagModelList.iterator();
+	}
+}

--- a/backend/src/main/java/com/web/gallery/model/PhotoTagModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoTagModelList.java
@@ -14,6 +14,8 @@ import com.web.gallery.entity.PhotoTagMst;
 
 /**
  * PhotoTagModelのコレクションを表すクラス
+ *
+ * @param	photoTagModelList	{@link PhotoTagModel}のリスト
  */
 public record PhotoTagModelList(List<PhotoTagModel> photoTagModelList) implements Iterable<PhotoTagModel> {
 

--- a/backend/src/main/java/com/web/gallery/model/PhotoTagModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoTagModelList.java
@@ -12,19 +12,14 @@ import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.entity.PhotoTagMst;
 
-import lombok.Builder;
-import lombok.NonNull;
-import lombok.Value;
-
 /**
  * PhotoTagModelのコレクションを表すクラス
  */
-@Value
-@Builder
-public class PhotoTagModelList implements Iterable<PhotoTagModel> {
-	/** PhotoTagModelのリスト */
-	@NonNull
-	private List<PhotoTagModel> photoTagModelList;
+public record PhotoTagModelList(List<PhotoTagModel> photoTagModelList) implements Iterable<PhotoTagModel> {
+
+	public PhotoTagModelList {
+		Objects.requireNonNull(photoTagModelList);
+	}
 
 	/**
 	 * PhotoTagModelのリストからPhotoTagModelListを生成する
@@ -33,7 +28,7 @@ public class PhotoTagModelList implements Iterable<PhotoTagModel> {
 	 * @return						{@link PhotoTagModelList}
 	 */
 	public static PhotoTagModelList of(List<PhotoTagModel> photoTagModelList) {
-		return PhotoTagModelList.builder().photoTagModelList(photoTagModelList).build();
+		return new PhotoTagModelList(photoTagModelList);
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/repository/AccountRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/AccountRepository.java
@@ -1,10 +1,9 @@
 package com.web.gallery.repository;
 
-import java.util.List;
-
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.AccountModel;
+import com.web.gallery.model.AccountModelList;
 
 /**
  * アカウントデータを永続化するRepositoryクラス
@@ -64,16 +63,16 @@ public interface AccountRepository {
 	/**
 	 * アカウントの一覧を取得する
 	 *
-	 * @return	{@link AccountModel}
+	 * @return	{@link AccountModelList}
 	 */
-	List<AccountModel> getAccountList();
+	AccountModelList getAccountList();
 
 	/**
 	 * 削除済みを含む全アカウントの一覧を取得する
 	 *
-	 * @return	{@link AccountModel}
+	 * @return	{@link AccountModelList}
 	 */
-	List<AccountModel> getAccountListAll();
+	AccountModelList getAccountListAll();
 
 	/**
 	 * Accountテーブルから該当するレコードを物理削除する

--- a/backend/src/main/java/com/web/gallery/repository/KbnMstRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/KbnMstRepository.java
@@ -1,8 +1,6 @@
 package com.web.gallery.repository;
 
-import java.util.List;
-
-import com.web.gallery.model.KbnMstModel;
+import com.web.gallery.model.KbnMstModelList;
 
 /**
  * 区分マスタデータを永続化するRepositoryクラス
@@ -10,9 +8,9 @@ import com.web.gallery.model.KbnMstModel;
 public interface KbnMstRepository {
 	/**
 	 * 区分クラスコードに該当する区分マスタの一覧を取得する
-	 * 
+	 *
 	 * @param	kbnClassCode	区分クラスコード
-	 * @return					{@link KbnMstModel}
+	 * @return					{@link KbnMstModelList}
 	 */
-	List<KbnMstModel> get(String kbnClassCode);
+	KbnMstModelList get(String kbnClassCode);
 }

--- a/backend/src/main/java/com/web/gallery/repository/PhotoDetailRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/PhotoDetailRepository.java
@@ -1,12 +1,10 @@
 package com.web.gallery.repository;
 
-import java.util.List;
-
 import com.web.gallery.exception.PhotoNotFoundException;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
 import com.web.gallery.model.PhotoGetModel;
-import com.web.gallery.model.PhotoModel;
+import com.web.gallery.model.PhotoModelList;
 
 /**
  * 写真のメタデータを含めた詳細情報を永続化するRepositoryクラス
@@ -14,11 +12,11 @@ import com.web.gallery.model.PhotoModel;
 public interface PhotoDetailRepository {
 	/**
 	 * 該当アカウントの写真の一覧を取得する
-	 * 
+	 *
 	 * @param	photoGetModel	{@link PhotoGetModel}
-	 * @return						{@link PhotoModel}
+	 * @return						{@link PhotoModelList}
 	 */
-	List<PhotoModel> getPhotoList(PhotoGetModel photoGetModel);
+	PhotoModelList getPhotoList(PhotoGetModel photoGetModel);
 	
 	/**
 	 * 写真のメタデータを含めた詳細情報を取得する

--- a/backend/src/main/java/com/web/gallery/repository/impl/AccountRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/AccountRepositoryImpl.java
@@ -12,6 +12,7 @@ import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.mapper.AccountMapper;
 import com.web.gallery.model.AccountModel;
+import com.web.gallery.model.AccountModelList;
 import com.web.gallery.repository.AccountRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -122,23 +123,23 @@ public class AccountRepositoryImpl implements AccountRepository {
 	/**
 	 * アカウントの一覧を取得する
 	 *
-	 * @return	{@link AccountModel}
+	 * @return	{@link AccountModelList}
 	 */
 	@Override
-	public List<AccountModel> getAccountList() {
+	public AccountModelList getAccountList() {
 		List<Account> accountList = accountMapper.select(Account.conditionForList());
-		return accountList.stream().map(AccountModel::from).toList();
+		return AccountModelList.from(accountList);
 	}
 
 	/**
 	 * 削除済みを含む全アカウントの一覧を取得する
 	 *
-	 * @return	{@link AccountModel}
+	 * @return	{@link AccountModelList}
 	 */
 	@Override
-	public List<AccountModel> getAccountListAll() {
+	public AccountModelList getAccountListAll() {
 		List<Account> accountList = accountMapper.select(Account.conditionForAdminList());
-		return accountList.stream().map(AccountModel::from).toList();
+		return AccountModelList.from(accountList);
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/repository/impl/KbnMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/KbnMstRepositoryImpl.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import com.web.gallery.entity.KbnMst;
 import com.web.gallery.mapper.KbnMstMapper;
-import com.web.gallery.model.KbnMstModel;
+import com.web.gallery.model.KbnMstModelList;
 import com.web.gallery.repository.KbnMstRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -19,17 +19,17 @@ import lombok.RequiredArgsConstructor;
 public class KbnMstRepositoryImpl implements KbnMstRepository {
 
 	private final KbnMstMapper kbnMstMapper;
-	
+
 	/**
 	 * 区分クラスコードに該当する区分マスタの一覧を取得する
-	 * 
+	 *
 	 * @param	kbnClassCode	区分クラスコード
-	 * @return					{@link KbnMstModel}
+	 * @return					{@link KbnMstModelList}
 	 */
 	@Override
-	public List<KbnMstModel> get(String kbnClassCode) {
+	public KbnMstModelList get(String kbnClassCode) {
 		List<KbnMst> kbnMstList = kbnMstMapper.select(KbnMst.condition(kbnClassCode));
 
-		return kbnMstList.stream().map(KbnMstModel::from).toList();
+		return KbnMstModelList.from(kbnMstList);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImpl.java
@@ -18,7 +18,7 @@ import com.web.gallery.mapper.PhotoTagMstMapper;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
 import com.web.gallery.model.PhotoGetModel;
-import com.web.gallery.model.PhotoModel;
+import com.web.gallery.model.PhotoModelList;
 import com.web.gallery.repository.PhotoDetailRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -40,18 +40,16 @@ public class PhotoDetailRepositoryImpl implements PhotoDetailRepository {
 	 * 該当アカウントの写真の一覧を取得する
 	 *
 	 * @param	photoGetModel	{@link PhotoGetModel}
-	 * @return						{@link PhotoModel}
+	 * @return						{@link PhotoModelList}
 	 */
 	@Override
-	public List<PhotoModel> getPhotoList(PhotoGetModel photoGetModel) {
+	public PhotoModelList getPhotoList(PhotoGetModel photoGetModel) {
 		List<PhotoDto> photoDtoList = photoDetailMapper.getPhotoList(PhotoListGetDto.from(photoGetModel));
 
 		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(
 				PhotoTagMst.condition(photoGetModel));
 
-		return photoDtoList.stream()
-				.map(photoDto -> PhotoModel.from(photoDto, photoTagMstList))
-				.toList();
+		return PhotoModelList.from(photoDtoList, photoTagMstList);
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/service/KbnMstService.java
+++ b/backend/src/main/java/com/web/gallery/service/KbnMstService.java
@@ -1,8 +1,6 @@
 package com.web.gallery.service;
 
-import java.util.List;
-
-import com.web.gallery.model.KbnMstModel;
+import com.web.gallery.model.KbnMstModelList;
 
 /**
  * 区分マスタに関するビジネスロジックを行うServiceクラス
@@ -10,8 +8,8 @@ import com.web.gallery.model.KbnMstModel;
 public interface KbnMstService {
 	/**
 	 * 都道府県の区分マスタを取得する
-	 * 
-	 * @return	{@link KbnMstModel}
+	 *
+	 * @return	{@link KbnMstModelList}
 	 */
-	List<KbnMstModel> getPrefectureList();
+	KbnMstModelList getPrefectureList();
 }

--- a/backend/src/main/java/com/web/gallery/service/PhotoService.java
+++ b/backend/src/main/java/com/web/gallery/service/PhotoService.java
@@ -1,14 +1,13 @@
 package com.web.gallery.service;
 
-import java.util.List;
-
 import com.web.gallery.exception.FileDuplicateException;
 import com.web.gallery.exception.PhotoNotFoundException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
-import com.web.gallery.model.PhotoDeleteModel;
+import com.web.gallery.model.PhotoDeleteModelList;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
+import com.web.gallery.model.PhotoDetailModelList;
 import com.web.gallery.model.PhotoListGetModel;
 import com.web.gallery.model.PhotoModelList;
 
@@ -37,22 +36,22 @@ public interface PhotoService {
 	 * 写真を登録・更新する
 	 * 
 	 * @param	accountId				アカウントID
-	 * @param	photoDetailModelList	{@link PhotoDetailModel}
+	 * @param	photoDetailModelList	{@link PhotoDetailModelList}
 	 * @throws	FileDuplicateException 	同じファイル名のファイルが既に保存済みの場合
 	 * @throws	RegistFailureException	登録に失敗した場合
 	 * @throws	UpdateFailureException	更新に失敗した場合
 	 * @return							登録・更新した写真番号
 	 */
-	Long savePhotos(String accountId, List<PhotoDetailModel> photoDetailModelList) throws FileDuplicateException, RegistFailureException, UpdateFailureException;
-	
+	Long savePhotos(String accountId, PhotoDetailModelList photoDetailModelList) throws FileDuplicateException, RegistFailureException, UpdateFailureException;
+
 	/**
 	 * 写真を削除する
-	 * 
+	 *
 	 * @param	accountId				アカウントID
-	 * @param	photoDeleteModelList	{@link PhotoDeleteModel}
+	 * @param	photoDeleteModelList	{@link PhotoDeleteModelList}
 	 * @throws	UpdateFailureException	削除に失敗した場合
 	 */
-	void deletePhotos(String accountId, List<PhotoDeleteModel> photoDeleteModelList) throws UpdateFailureException;
+	void deletePhotos(String accountId, PhotoDeleteModelList photoDeleteModelList) throws UpdateFailureException;
 	
 	/**
 	 * 該当アカウントが写真の登録枚数の上限に達しているかチェックする

--- a/backend/src/main/java/com/web/gallery/service/PhotoService.java
+++ b/backend/src/main/java/com/web/gallery/service/PhotoService.java
@@ -10,7 +10,7 @@ import com.web.gallery.model.PhotoDeleteModel;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
 import com.web.gallery.model.PhotoListGetModel;
-import com.web.gallery.model.PhotoModel;
+import com.web.gallery.model.PhotoModelList;
 
 /**
  * 写真に関するビジネスロジックを行うServiceクラス
@@ -18,11 +18,11 @@ import com.web.gallery.model.PhotoModel;
 public interface PhotoService {
 	/**
 	 * 写真一覧を取得する
-	 * 
+	 *
 	 * @param	photoListGetModel	{@link PhotoListGetModel}
-	 * @return						{@link PhotoModel}
+	 * @return						{@link PhotoModelList}
 	 */
-	List<PhotoModel> getPhotoList(PhotoListGetModel photoListGetModel);
+	PhotoModelList getPhotoList(PhotoListGetModel photoListGetModel);
 	
 	/**
 	 * 写真のメタデータを含めた詳細情報を取得する

--- a/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
@@ -1,7 +1,5 @@
 package com.web.gallery.service.impl;
 
-import java.util.Comparator;
-import java.util.List;
 import java.util.Objects;
 
 import org.springframework.context.event.EventListener;
@@ -27,6 +25,7 @@ import com.web.gallery.mapper.PhotoFavoriteMapper;
 import com.web.gallery.mapper.PhotoMstMapper;
 import com.web.gallery.mapper.PhotoTagMstMapper;
 import com.web.gallery.model.AccountModel;
+import com.web.gallery.model.AccountModelList;
 import com.web.gallery.repository.AccountRepository;
 import com.web.gallery.repository.FileRepository;
 
@@ -110,21 +109,21 @@ public class AccountServiceImpl implements UserDetailsService {
 	/**
 	 * アカウントの一覧を取得する
 	 *
-	 * @return	{@link AccountModel}
+	 * @return	{@link AccountModelList}
 	 */
 	@Transactional(readOnly = true)
-	public List<AccountModel> getAccountList() {
-		return accountRepository.getAccountList().stream().sorted(Comparator.comparing(m -> m.getAccountId().value())).toList();
+	public AccountModelList getAccountList() {
+		return accountRepository.getAccountList().sortByAccountId();
 	}
 
 	/**
 	 * 管理者用：削除済みを含む全アカウントの一覧を取得する
 	 *
-	 * @return	{@link AccountModel}
+	 * @return	{@link AccountModelList}
 	 */
 	@Transactional(readOnly = true)
-	public List<AccountModel> getAccountListForAdmin() {
-		return accountRepository.getAccountListAll().stream().sorted(Comparator.comparing(m -> m.getAccountId().value())).toList();
+	public AccountModelList getAccountListForAdmin() {
+		return accountRepository.getAccountListAll().sortByAccountId();
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/service/impl/KbnMstServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/KbnMstServiceImpl.java
@@ -1,12 +1,10 @@
 package com.web.gallery.service.impl;
 
-import java.util.List;
-
 import com.web.gallery.constant.Consts;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.web.gallery.model.KbnMstModel;
+import com.web.gallery.model.KbnMstModelList;
 import com.web.gallery.repository.KbnMstRepository;
 import com.web.gallery.service.KbnMstService;
 
@@ -20,15 +18,15 @@ import lombok.RequiredArgsConstructor;
 public class KbnMstServiceImpl implements KbnMstService {
 
 	private final KbnMstRepository kbnMstRepository;
-	
+
 	/**
 	 * 都道府県の区分マスタを取得する
-	 * 
-	 * @return	{@link KbnMstModel}
+	 *
+	 * @return	{@link KbnMstModelList}
 	 */
 	@Override
 	@Transactional(readOnly = true)
-	public List<KbnMstModel> getPrefectureList() {
+	public KbnMstModelList getPrefectureList() {
 		return kbnMstRepository.get(Consts.PREFECTURE);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -16,11 +15,9 @@ import org.springframework.transaction.annotation.Transactional;
 import com.web.gallery.config.PhotoConfig;
 import com.web.gallery.domain.photo.ImageFile;
 import com.web.gallery.domain.photo.ImageFilePath;
-import com.web.gallery.constant.Consts;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.domain.photo.TagNo;
-import com.web.gallery.enumuration.DirectionEnum;
 import com.web.gallery.enumuration.ErrorEnum;
 import com.web.gallery.enumuration.SortPhotoEnum;
 import com.web.gallery.exception.FileDuplicateException;
@@ -36,8 +33,10 @@ import com.web.gallery.model.PhotoGetModel;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.model.PhotoListGetModel;
 import com.web.gallery.model.PhotoModel;
+import com.web.gallery.model.PhotoModelList;
 import com.web.gallery.model.PhotoTagDeleteModel;
 import com.web.gallery.model.PhotoTagModel;
+import com.web.gallery.model.PhotoTagModelList;
 import com.web.gallery.repository.AccountRepository;
 import com.web.gallery.repository.FileRepository;
 import com.web.gallery.repository.PhotoDetailRepository;
@@ -69,26 +68,22 @@ public class PhotoServiceImpl implements PhotoService {
 	 * 写真一覧を取得する
 	 *
 	 * @param	photoListGetModel	{@link PhotoListGetModel}
-	 * @return						{@link PhotoModel}
+	 * @return						{@link PhotoModelList}
 	 */
 	@Override
 	@Transactional(readOnly = true)
-	public List<PhotoModel> getPhotoList(PhotoListGetModel photoListGetModel) {
+	public PhotoModelList getPhotoList(PhotoListGetModel photoListGetModel) {
 		AccountModel accountModel = accountRepository.getByAccountId(photoListGetModel.getPhotoAccountId().value());
 
-		List<PhotoModel> photoModelList
+		PhotoModelList photoModelList
 			= photoDetailRepository.getPhotoList(
 					PhotoGetModel.of(photoListGetModel.getAccountNo(), accountModel.getAccountNo()));
 
-		return photoModelList.stream()
-					.filter(photoModel ->
-						filteringByDirectionKbn(photoModel.getDirectionKbn(), photoListGetModel.getDirectionKbn()))
-					.filter(photoModel ->
-						filteringByIsFavorite(photoModel.getIsFavorite().value(), photoListGetModel.getIsFavoriteOnly().value()))
-					.filter(photoModel ->
-						filteringByTag(photoModel.getPhotoTagModelList(), photoListGetModel.getTagList()))
-					.sorted(getComparator(photoListGetModel.getSortBy()))
-					.toList();
+		return photoModelList
+					.filterByDirectionKbn(photoListGetModel.getDirectionKbn())
+					.filterByFavorite(photoListGetModel.getIsFavoriteOnly().value())
+					.filterByTags(photoListGetModel.getTagList())
+					.sorted(getComparator(photoListGetModel.getSortBy()));
 	}
 
 	/**
@@ -224,55 +219,13 @@ public class PhotoServiceImpl implements PhotoService {
 	}
 
 	/**
-	 * 写真の向きでフィルタリングする
-	 *
-	 * @param	targetDirectionKbn	フィルター対象の向き区分
-	 * @param	conditionDirectionKbn	フィルター条件の向き区分
-	 * @return	フィルタリングして除外する場合はfalse
-	 */
-	private Boolean filteringByDirectionKbn(DirectionEnum targetDirectionKbn, DirectionEnum conditionDirectionKbn) {
-		if(DirectionEnum.NONE.equals(conditionDirectionKbn)) return true;
-		else return targetDirectionKbn.equals(conditionDirectionKbn);
-	}
-
-	/**
-	 * お気に入りでフィルタリングする
-	 *
-	 * @param	isFavorite		写真がお気に入りならtrue
-	 * @param	isFavoriteOnly	お気に入りに絞るならtrue
-	 * @return					フィルタリングして除外する場合はfalse
-	 */
-	private Boolean filteringByIsFavorite(Boolean isFavorite, Boolean isFavoriteOnly) {
-		if(!isFavoriteOnly) return true;
-		else return isFavorite;
-	}
-
-	/**
-	 * タグでフィルタリングする<p>
-	 * タグが複数ある場合、すべてのタグを持つ写真にフィルタリングする
-	 *
-	 * @param	photoTagModelList	{@link PhotoTagModel}
-	 * @param	tags				フィルター条件のタグのリスト
-	 * @return						フィルタリングして除外する場合はfalse
-	 */
-	private Boolean filteringByTag(List<PhotoTagModel> photoTagModelList, List<String> tags) {
-		if(tags.size() == 0 || Consts.STRING_EMPTY.equals(tags.getFirst())) return true;
-
-		List<String> photoTags = new ArrayList<String>();
-		photoTags.addAll(photoTagModelList.stream().map(photoTagModel -> photoTagModel.getTagJapaneseName().value()).toList());
-		photoTags.addAll(photoTagModelList.stream().map(photoTagModel -> photoTagModel.getTagEnglishName().value()).toList());
-
-		return photoTags.containsAll(tags);
-	}
-
-	/**
 	 * 写真タグを登録する
 	 *
-	 * @param	photoTagModelList		{@link PhotoTagModel}
+	 * @param	photoTagModelList		{@link PhotoTagModelList}
 	 * @param	newPhotoNo				新規採番された写真番号
 	 * @throws	RegistFailureException	登録に失敗した場合
 	 */
-	private void registPhotoTags(List<PhotoTagModel> photoTagModelList, Long newPhotoNo) throws RegistFailureException {
+	private void registPhotoTags(PhotoTagModelList photoTagModelList, Long newPhotoNo) throws RegistFailureException {
 		if(Objects.isNull(photoTagModelList)) return;
 
 		int tagNo = 1;

--- a/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Objects;
 
 import org.springframework.stereotype.Service;
@@ -26,8 +25,10 @@ import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.FileModel;
 import com.web.gallery.model.PhotoDeleteModel;
+import com.web.gallery.model.PhotoDeleteModelList;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
+import com.web.gallery.model.PhotoDetailModelList;
 import com.web.gallery.model.PhotoFavoriteDeleteModel;
 import com.web.gallery.model.PhotoGetModel;
 import com.web.gallery.model.AccountModel;
@@ -102,14 +103,14 @@ public class PhotoServiceImpl implements PhotoService {
 	/**
 	 * 写真を登録・更新する
 	 *
-	 * @param	photoDetailModelList	{@link PhotoDetailModel}
+	 * @param	photoDetailModelList	{@link PhotoDetailModelList}
 	 * @throws	FileDuplicateException 	同じファイル名のファイルが既に保存済みの場合
 	 * @throws	RegistFailureException	登録に失敗した場合
 	 * @throws	UpdateFailureException	更新に失敗した場合
 	 */
 	@Override
 	@Transactional
-	public Long savePhotos(String accountId, List<PhotoDetailModel> photoDetailModelList) throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+	public Long savePhotos(String accountId, PhotoDetailModelList photoDetailModelList) throws FileDuplicateException, RegistFailureException, UpdateFailureException {
 		if(Objects.isNull(photoDetailModelList)) return null;
 		if(photoDetailModelList.isEmpty()) return null;
 
@@ -142,12 +143,12 @@ public class PhotoServiceImpl implements PhotoService {
 	 * 写真を削除する
 	 *
 	 * @param	accountId				アカウントID
-	 * @param	photoDeleteModelList	{@link PhotoDeleteModel}
+	 * @param	photoDeleteModelList	{@link PhotoDeleteModelList}
 	 * @throws	UpdateFailureException	削除に失敗した場合
 	 */
 	@Override
 	@Transactional
-	public void deletePhotos(String accountId, List<PhotoDeleteModel> photoDeleteModelList) throws UpdateFailureException {
+	public void deletePhotos(String accountId, PhotoDeleteModelList photoDeleteModelList) throws UpdateFailureException {
 		String filePath = photoConfig.getOutputPath() + accountId + "/";
 
 		for(PhotoDeleteModel photoDeleteModel : photoDeleteModelList) {

--- a/backend/src/test/java/com/web/gallery/controller/AccountRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/AccountRestControllerTest.java
@@ -8,7 +8,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +48,7 @@ import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.helper.SessionHelper;
 import com.web.gallery.model.AccountModel;
+import com.web.gallery.model.AccountModelList;
 import com.web.gallery.service.impl.AccountServiceImpl;
 
 @ActiveProfiles("test")
@@ -91,10 +91,10 @@ public class AccountRestControllerTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント一覧を取得できること")
 		void getAccountList_success() throws Exception {
-			List<AccountModel> accountModels = List.of(
+			AccountModelList accountModels = AccountModelList.of(List.of(
 					AccountModel.builder().accountId(new AccountId("aaaaaaaa")).accountName(new AccountName("AAAAAAAA")).build(),
 					AccountModel.builder().accountId(new AccountId("bbbbbbbb")).accountName(new AccountName("BBBBBBBB")).build()
-			);
+			));
 
 			doReturn(accountModels).when(accountServiceImpl).getAccountList();
 
@@ -110,7 +110,7 @@ public class AccountRestControllerTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが0件の場合は空リストを返すこと")
 		void getAccountList_empty() throws Exception {
-			doReturn(Collections.emptyList()).when(accountServiceImpl).getAccountList();
+			doReturn(AccountModelList.empty()).when(accountServiceImpl).getAccountList();
 
 			mockMvc.perform(get("/api/v1/accounts"))
 				.andExpect(status().isOk())

--- a/backend/src/test/java/com/web/gallery/controller/AdminAccountRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/AdminAccountRestControllerTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +36,7 @@ import com.web.gallery.enumuration.AuthorityEnum;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.helper.SessionHelper;
 import com.web.gallery.model.AccountModel;
+import com.web.gallery.model.AccountModelList;
 import com.web.gallery.service.impl.AccountServiceImpl;
 
 @ActiveProfiles("test")
@@ -75,7 +75,7 @@ public class AdminAccountRestControllerTest {
 		void getAdminAccountList_success() throws Exception {
 			doReturn(AuthorityEnum.ADMINISTRATOR).when(sessionHelper).getAuthorityKbn();
 
-			List<AccountModel> accountModels = List.of(
+			AccountModelList accountModels = AccountModelList.of(List.of(
 					AccountModel.builder()
 							.accountNo(new AccountNo(1L))
 							.accountId(new AccountId("aaaaaaaa"))
@@ -94,7 +94,7 @@ public class AdminAccountRestControllerTest {
 							.lastLoginDatetime(new LastLoginDatetime(OffsetDateTime.of(2024, 1, 2, 0, 0, 0, 0, ZoneOffset.ofHours(9))))
 							.loginFailureCount(new LoginFailureCount(5))
 							.build()
-			);
+			));
 
 			doReturn(accountModels).when(accountServiceImpl).getAccountListForAdmin();
 
@@ -117,7 +117,7 @@ public class AdminAccountRestControllerTest {
 		@DisplayName("正常系：アカウントが0件の場合は空リストを返すこと")
 		void getAdminAccountList_empty() throws Exception {
 			doReturn(AuthorityEnum.ADMINISTRATOR).when(sessionHelper).getAuthorityKbn();
-			doReturn(Collections.emptyList()).when(accountServiceImpl).getAccountListForAdmin();
+			doReturn(AccountModelList.empty()).when(accountServiceImpl).getAccountListForAdmin();
 
 			mockMvc.perform(get("/api/v1/admin/accounts"))
 				.andExpect(status().isOk())

--- a/backend/src/test/java/com/web/gallery/controller/KbnMstRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/KbnMstRestControllerTest.java
@@ -4,7 +4,6 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +36,7 @@ import com.web.gallery.domain.common.KbnJapaneseName;
 import com.web.gallery.domain.common.SortOrder;
 import com.web.gallery.helper.KbnHelper;
 import com.web.gallery.model.KbnMstModel;
+import com.web.gallery.model.KbnMstModelList;
 import com.web.gallery.service.KbnMstService;
 
 @ActiveProfiles("test")
@@ -66,7 +66,6 @@ public class KbnMstRestControllerTest {
 		@Order(1)
 		@DisplayName("正常系：都道府県一覧を取得できること")
 		void getPrefectures_success() throws Exception {
-			List<KbnMstModel> prefectureList = new ArrayList<>();
 			KbnMstModel hokkaido = KbnMstModel.builder()
 					.kbnClassCode(new KbnClassCode("prefecture"))
 					.kbnCode(new KbnCode("Hokkaido"))
@@ -107,13 +106,11 @@ public class KbnMstRestControllerTest {
 					.explanation(new Explanation(""))
 					.build();
 
-			prefectureList.add(hokkaido);
-			prefectureList.add(aomori);
-			prefectureList.add(tokyo);
+			KbnMstModelList prefectureList = KbnMstModelList.of(List.of(hokkaido, aomori, tokyo));
 
-			Map<String, List<KbnMstModel>> groupedMap = new LinkedHashMap<>();
-			groupedMap.put("北海道・東北地方", List.of(hokkaido, aomori));
-			groupedMap.put("関東地方", List.of(tokyo));
+			Map<String, KbnMstModelList> groupedMap = new LinkedHashMap<>();
+			groupedMap.put("北海道・東北地方", KbnMstModelList.of(List.of(hokkaido, aomori)));
+			groupedMap.put("関東地方", KbnMstModelList.of(List.of(tokyo)));
 
 			doReturn(prefectureList).when(kbnMstService).getPrefectureList();
 			doReturn(groupedMap).when(kbnHelper).convertToLinkedHashMap(prefectureList);
@@ -134,8 +131,8 @@ public class KbnMstRestControllerTest {
 		@Order(2)
 		@DisplayName("正常系：空のリストの場合は空配列を返すこと")
 		void getPrefectures_empty() throws Exception {
-			List<KbnMstModel> emptyList = new ArrayList<>();
-			Map<String, List<KbnMstModel>> emptyMap = new LinkedHashMap<>();
+			KbnMstModelList emptyList = KbnMstModelList.empty();
+			Map<String, KbnMstModelList> emptyMap = new LinkedHashMap<>();
 
 			doReturn(emptyList).when(kbnMstService).getPrefectureList();
 			doReturn(emptyMap).when(kbnHelper).convertToLinkedHashMap(emptyList);

--- a/backend/src/test/java/com/web/gallery/controller/PhotoRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/PhotoRestControllerTest.java
@@ -56,7 +56,8 @@ import com.web.gallery.model.PhotoDeleteModel;
 import com.web.gallery.model.PhotoDetailModel;
 import com.web.gallery.model.PhotoListGetModel;
 import com.web.gallery.model.PhotoModel;
-import com.web.gallery.model.PhotoTagModel;
+import com.web.gallery.model.PhotoModelList;
+import com.web.gallery.model.PhotoTagModelList;
 import com.web.gallery.service.impl.PhotoServiceImpl;
 
 @ActiveProfiles("test")
@@ -93,7 +94,7 @@ public class PhotoRestControllerTest {
 	@Order(1)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	class getPhotoList {
-		private List<PhotoModel> createPhotoModelList() {
+		private PhotoModelList createPhotoModelList() {
 			List<PhotoModel> photoList = new ArrayList<PhotoModel>();
 			photoList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -104,7 +105,7 @@ public class PhotoRestControllerTest {
 					.imageFilePath(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC111.jpg"))
 					.caption(new Caption("キャプション1"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -115,7 +116,7 @@ public class PhotoRestControllerTest {
 					.imageFilePath(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC222.jpg"))
 					.caption(new Caption("キャプション2"))
 					.directionKbn(DirectionEnum.HORIZONTAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -126,7 +127,7 @@ public class PhotoRestControllerTest {
 					.imageFilePath(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC333.jpg"))
 					.caption(new Caption("キャプション3"))
 					.directionKbn(DirectionEnum.HORIZONTAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -137,7 +138,7 @@ public class PhotoRestControllerTest {
 					.imageFilePath(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC444.jpg"))
 					.caption(new Caption("キャプション4"))
 					.directionKbn(DirectionEnum.HORIZONTAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -148,7 +149,7 @@ public class PhotoRestControllerTest {
 					.imageFilePath(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC555.jpg"))
 					.caption(new Caption("キャプション5"))
 					.directionKbn(DirectionEnum.HORIZONTAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -159,7 +160,7 @@ public class PhotoRestControllerTest {
 					.imageFilePath(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC666.jpg"))
 					.caption(new Caption("キャプション6"))
 					.directionKbn(DirectionEnum.HORIZONTAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -170,10 +171,10 @@ public class PhotoRestControllerTest {
 					.imageFilePath(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC777.jpg"))
 					.caption(new Caption("キャプション7"))
 					.directionKbn(DirectionEnum.HORIZONTAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 
-			return photoList;
+			return PhotoModelList.of(photoList);
 		}
 
 		@Test
@@ -182,7 +183,7 @@ public class PhotoRestControllerTest {
 		void getPhotoList_with_null_parameter() throws Exception {
 			doReturn(1L).when(sessionHelper).getAccountNo();
 
-			List<PhotoModel> photoList = createPhotoModelList();
+			PhotoModelList photoList = createPhotoModelList();
 			ArgumentCaptor<PhotoListGetModel> photoListGetModelCaptor = ArgumentCaptor.forClass(PhotoListGetModel.class);
 			doReturn(photoList).when(photoServiceImpl).getPhotoList(photoListGetModelCaptor.capture());
 
@@ -226,7 +227,7 @@ public class PhotoRestControllerTest {
 		void getPhotoList_with_halfspace_tag() throws Exception {
 			doReturn(1L).when(sessionHelper).getAccountNo();
 
-			List<PhotoModel> photoList = createPhotoModelList().subList(0, 4);
+			PhotoModelList photoList = PhotoModelList.of(createPhotoModelList().toList().subList(0, 4));
 			ArgumentCaptor<PhotoListGetModel> photoListGetModelCaptor = ArgumentCaptor.forClass(PhotoListGetModel.class);
 			doReturn(photoList).when(photoServiceImpl).getPhotoList(photoListGetModelCaptor.capture());
 
@@ -264,7 +265,7 @@ public class PhotoRestControllerTest {
 		void getPhotoList_with_fullspace_tag() throws Exception {
 			doReturn(1L).when(sessionHelper).getAccountNo();
 
-			List<PhotoModel> photoList = createPhotoModelList().subList(0, 4);
+			PhotoModelList photoList = PhotoModelList.of(createPhotoModelList().toList().subList(0, 4));
 			ArgumentCaptor<PhotoListGetModel> photoListGetModelCaptor = ArgumentCaptor.forClass(PhotoListGetModel.class);
 			doReturn(photoList).when(photoServiceImpl).getPhotoList(photoListGetModelCaptor.capture());
 
@@ -302,7 +303,7 @@ public class PhotoRestControllerTest {
 		void getPhotoList_not_found_photo() throws Exception {
 			doReturn(1L).when(sessionHelper).getAccountNo();
 
-			List<PhotoModel> photoList = new ArrayList<PhotoModel>();
+			PhotoModelList photoList = PhotoModelList.empty();
 			ArgumentCaptor<PhotoListGetModel> photoListGetModelCaptor = ArgumentCaptor.forClass(PhotoListGetModel.class);
 			doReturn(photoList).when(photoServiceImpl).getPhotoList(photoListGetModelCaptor.capture());
 
@@ -378,7 +379,7 @@ public class PhotoRestControllerTest {
 			assertNull(photoDetailModelList.getFirst().getFValue());
 			assertNull(photoDetailModelList.getFirst().getShutterSpeed());
 			assertNull(photoDetailModelList.getFirst().getIso());
-			assertEquals(new ArrayList<PhotoDetailModel>(), photoDetailModelList.getFirst().getPhotoTagModelList());
+			assertTrue(photoDetailModelList.getFirst().getPhotoTagModelList().isEmpty());
 
 			assertEquals("aaaaaaaa", photoAcountIdCaptor.getValue());
 		}
@@ -612,7 +613,7 @@ public class PhotoRestControllerTest {
 			assertNull(photoDetailModelList.getFirst().getFValue());
 			assertNull(photoDetailModelList.getFirst().getShutterSpeed());
 			assertNull(photoDetailModelList.getFirst().getIso());
-			assertEquals(new ArrayList<PhotoDetailModel>(), photoDetailModelList.getFirst().getPhotoTagModelList());
+			assertTrue(photoDetailModelList.getFirst().getPhotoTagModelList().isEmpty());
 
 			assertEquals("aaaaaaaa", photoAcountIdCaptor.getValue());
 		}
@@ -667,7 +668,7 @@ public class PhotoRestControllerTest {
 			assertNull(photoDetailModelList.getFirst().getFValue());
 			assertNull(photoDetailModelList.getFirst().getShutterSpeed());
 			assertNull(photoDetailModelList.getFirst().getIso());
-			assertEquals(new ArrayList<PhotoDetailModel>(), photoDetailModelList.getFirst().getPhotoTagModelList());
+			assertTrue(photoDetailModelList.getFirst().getPhotoTagModelList().isEmpty());
 
 			assertEquals("aaaaaaaa", photoAcountIdCaptor.getValue());
 		}
@@ -722,7 +723,7 @@ public class PhotoRestControllerTest {
 			assertNull(photoDetailModelList.getFirst().getFValue());
 			assertNull(photoDetailModelList.getFirst().getShutterSpeed());
 			assertNull(photoDetailModelList.getFirst().getIso());
-			assertEquals(new ArrayList<PhotoDetailModel>(), photoDetailModelList.getFirst().getPhotoTagModelList());
+			assertTrue(photoDetailModelList.getFirst().getPhotoTagModelList().isEmpty());
 
 			assertEquals("aaaaaaaa", photoAcountIdCaptor.getValue());
 		}
@@ -820,7 +821,7 @@ public class PhotoRestControllerTest {
 	@Order(4)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	class createPhotoListGetResponse {
-		private List<PhotoModel> createPhotoList() {
+		private PhotoModelList createPhotoList() {
 			List<PhotoModel> photoList = new ArrayList<PhotoModel>();
 			photoList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -831,7 +832,7 @@ public class PhotoRestControllerTest {
 					.imageFilePath(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC111.jpg"))
 					.caption(new Caption("キャプション1"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -842,7 +843,7 @@ public class PhotoRestControllerTest {
 					.imageFilePath(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC222.jpg"))
 					.caption(new Caption("キャプション2"))
 					.directionKbn(DirectionEnum.HORIZONTAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -853,7 +854,7 @@ public class PhotoRestControllerTest {
 					.imageFilePath(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC333.jpg"))
 					.caption(new Caption("キャプション3"))
 					.directionKbn(DirectionEnum.HORIZONTAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -864,7 +865,7 @@ public class PhotoRestControllerTest {
 					.imageFilePath(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC444.jpg"))
 					.caption(new Caption("キャプション4"))
 					.directionKbn(DirectionEnum.HORIZONTAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -875,7 +876,7 @@ public class PhotoRestControllerTest {
 					.imageFilePath(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC555.jpg"))
 					.caption(new Caption("キャプション5"))
 					.directionKbn(DirectionEnum.HORIZONTAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -886,7 +887,7 @@ public class PhotoRestControllerTest {
 					.imageFilePath(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC666.jpg"))
 					.caption(new Caption("キャプション6"))
 					.directionKbn(DirectionEnum.HORIZONTAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -897,10 +898,10 @@ public class PhotoRestControllerTest {
 					.imageFilePath(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC777.jpg"))
 					.caption(new Caption("キャプション7"))
 					.directionKbn(DirectionEnum.HORIZONTAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 
-			return photoList;
+			return PhotoModelList.of(photoList);
 		}
 
 		@Test
@@ -909,7 +910,7 @@ public class PhotoRestControllerTest {
 		void createPhotoListGetResponse_pageNo_1_lastPage() {
 			Integer pageNo = 1;
 			Integer photoCountPerPage = 3;
-			List<PhotoModel> photoList = createPhotoList().subList(0, 1);
+			PhotoModelList photoList = PhotoModelList.of(createPhotoList().toList().subList(0, 1));
 
 			PhotoListGetResponse actual = PhotoListGetResponse.from(photoList, pageNo, photoCountPerPage);
 			assertEquals(1, actual.getPhotoList().size());
@@ -928,7 +929,7 @@ public class PhotoRestControllerTest {
 		void createPhotoListGetResponse_pageNo_1() {
 			Integer pageNo = 1;
 			Integer photoCountPerPage = 3;
-			List<PhotoModel> photoList = createPhotoList().subList(0, 4);
+			PhotoModelList photoList = PhotoModelList.of(createPhotoList().toList().subList(0, 4));
 
 			PhotoListGetResponse actual = PhotoListGetResponse.from(photoList, pageNo, photoCountPerPage);
 			assertEquals(3, actual.getPhotoList().size());
@@ -959,7 +960,7 @@ public class PhotoRestControllerTest {
 		void createPhotoListGetResponse_pageNo_2_lastPage() {
 			Integer pageNo = 2;
 			Integer photoCountPerPage = 3;
-			List<PhotoModel> photoList = createPhotoList().subList(0, 4);
+			PhotoModelList photoList = PhotoModelList.of(createPhotoList().toList().subList(0, 4));
 
 			PhotoListGetResponse actual = PhotoListGetResponse.from(photoList, pageNo, photoCountPerPage);
 			assertEquals(1, actual.getPhotoList().size());
@@ -978,7 +979,7 @@ public class PhotoRestControllerTest {
 		void createPhotoListGetResponse_pageNo_2() {
 			Integer pageNo = 2;
 			Integer photoCountPerPage = 3;
-			List<PhotoModel> photoList = createPhotoList();
+			PhotoModelList photoList = createPhotoList();
 
 			PhotoListGetResponse actual = PhotoListGetResponse.from(photoList, pageNo, photoCountPerPage);
 			assertEquals(3, actual.getPhotoList().size());

--- a/backend/src/test/java/com/web/gallery/controller/PhotoRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/PhotoRestControllerTest.java
@@ -53,7 +53,9 @@ import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.helper.SessionHelper;
 import com.web.gallery.model.PhotoDeleteModel;
+import com.web.gallery.model.PhotoDeleteModelList;
 import com.web.gallery.model.PhotoDetailModel;
+import com.web.gallery.model.PhotoDetailModelList;
 import com.web.gallery.model.PhotoListGetModel;
 import com.web.gallery.model.PhotoModel;
 import com.web.gallery.model.PhotoModelList;
@@ -344,7 +346,7 @@ public class PhotoRestControllerTest {
 			doReturn(1L).when(sessionHelper).getAccountNo();
 			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1L);
 
-			ArgumentCaptor<List<PhotoDetailModel>> photoDetailModelCaptor = ArgumentCaptor.forClass(List.class);
+			ArgumentCaptor<PhotoDetailModelList> photoDetailModelCaptor = ArgumentCaptor.forClass(PhotoDetailModelList.class);
 			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
 			doReturn(1L).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
 
@@ -358,7 +360,7 @@ public class PhotoRestControllerTest {
 				.andExpect(jsonPath("$.isSuccess").value(true))
 				.andExpect(jsonPath("$.message").value("写真登録が完了しました。"));
 
-			List<PhotoDetailModel> photoDetailModelList = photoDetailModelCaptor.getValue();
+			PhotoDetailModelList photoDetailModelList = photoDetailModelCaptor.getValue();
 			assertEquals(1, photoDetailModelList.size());
 			assertEquals(new AccountNo(1L), photoDetailModelList.getFirst().getAccountNo());
 			assertNull(photoDetailModelList.getFirst().getPhotoNo());
@@ -403,7 +405,7 @@ public class PhotoRestControllerTest {
 
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 
-			ArgumentCaptor<List<PhotoDetailModel>> photoDetailModelCaptor = ArgumentCaptor.forClass(List.class);
+			ArgumentCaptor<PhotoDetailModelList> photoDetailModelCaptor = ArgumentCaptor.forClass(PhotoDetailModelList.class);
 			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
 			doReturn(1L).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
 
@@ -444,7 +446,7 @@ public class PhotoRestControllerTest {
 			verify(sessionHelper, times(0)).getAccountNo();
 			verify(photoServiceImpl, times(0)).isReachedUpperLimit(1L);
 
-			List<PhotoDetailModel> photoDetailModelList = photoDetailModelCaptor.getValue();
+			PhotoDetailModelList photoDetailModelList = photoDetailModelCaptor.getValue();
 			assertEquals(1, photoDetailModelList.size());
 			assertEquals(new AccountNo(1L), photoDetailModelList.getFirst().getAccountNo());
 			assertEquals(1L, photoDetailModelList.getFirst().getPhotoNo().value());
@@ -489,7 +491,7 @@ public class PhotoRestControllerTest {
 				.andExpect(status().isForbidden());
 
 			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Long.class));
-			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(List.class));
+			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(PhotoDetailModelList.class));
 		}
 
 		@Test
@@ -506,7 +508,7 @@ public class PhotoRestControllerTest {
 					.param("directionKbn", "VERTICAL"))
 				.andExpect(status().isBadRequest());
 
-			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(List.class));
+			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(PhotoDetailModelList.class));
 		}
 
 		@Test
@@ -523,7 +525,7 @@ public class PhotoRestControllerTest {
 					.param("directionKbn", "VERTICAL"))
 				.andExpect(status().isBadRequest());
 
-			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(List.class));
+			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(PhotoDetailModelList.class));
 		}
 
 		@Test
@@ -541,7 +543,7 @@ public class PhotoRestControllerTest {
 					.param("directionKbn", "VERTICAL"))
 				.andExpect(status().isBadRequest());
 
-			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(List.class));
+			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(PhotoDetailModelList.class));
 		}
 
 		@Test
@@ -560,7 +562,7 @@ public class PhotoRestControllerTest {
 					.param("focalLength", "-1"))
 				.andExpect(status().isBadRequest());
 
-			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(List.class));
+			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(PhotoDetailModelList.class));
 		}
 
 		@Test
@@ -577,7 +579,7 @@ public class PhotoRestControllerTest {
 
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 
-			ArgumentCaptor<List<PhotoDetailModel>> photoDetailModelCaptor = ArgumentCaptor.forClass(List.class);
+			ArgumentCaptor<PhotoDetailModelList> photoDetailModelCaptor = ArgumentCaptor.forClass(PhotoDetailModelList.class);
 			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
 			doThrow(FileDuplicateException.class).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
 
@@ -592,7 +594,7 @@ public class PhotoRestControllerTest {
 			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Long.class));
 			verify(sessionHelper, times(0)).getAccountNo();
 
-			List<PhotoDetailModel> photoDetailModelList = photoDetailModelCaptor.getValue();
+			PhotoDetailModelList photoDetailModelList = photoDetailModelCaptor.getValue();
 			assertEquals(1, photoDetailModelList.size());
 			assertEquals(new AccountNo(1L), photoDetailModelList.getFirst().getAccountNo());
 			assertEquals(1L, photoDetailModelList.getFirst().getPhotoNo().value());
@@ -632,7 +634,7 @@ public class PhotoRestControllerTest {
 
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 
-			ArgumentCaptor<List<PhotoDetailModel>> photoDetailModelCaptor = ArgumentCaptor.forClass(List.class);
+			ArgumentCaptor<PhotoDetailModelList> photoDetailModelCaptor = ArgumentCaptor.forClass(PhotoDetailModelList.class);
 			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
 			doThrow(RegistFailureException.class).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
 
@@ -647,7 +649,7 @@ public class PhotoRestControllerTest {
 			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Long.class));
 			verify(sessionHelper, times(0)).getAccountNo();
 
-			List<PhotoDetailModel> photoDetailModelList = photoDetailModelCaptor.getValue();
+			PhotoDetailModelList photoDetailModelList = photoDetailModelCaptor.getValue();
 			assertEquals(1, photoDetailModelList.size());
 			assertEquals(new AccountNo(1L), photoDetailModelList.getFirst().getAccountNo());
 			assertEquals(1L, photoDetailModelList.getFirst().getPhotoNo().value());
@@ -687,7 +689,7 @@ public class PhotoRestControllerTest {
 
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 
-			ArgumentCaptor<List<PhotoDetailModel>> photoDetailModelCaptor = ArgumentCaptor.forClass(List.class);
+			ArgumentCaptor<PhotoDetailModelList> photoDetailModelCaptor = ArgumentCaptor.forClass(PhotoDetailModelList.class);
 			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
 			doThrow(UpdateFailureException.class).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
 
@@ -702,7 +704,7 @@ public class PhotoRestControllerTest {
 			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Long.class));
 			verify(sessionHelper, times(0)).getAccountNo();
 
-			List<PhotoDetailModel> photoDetailModelList = photoDetailModelCaptor.getValue();
+			PhotoDetailModelList photoDetailModelList = photoDetailModelCaptor.getValue();
 			assertEquals(1, photoDetailModelList.size());
 			assertEquals(new AccountNo(1L), photoDetailModelList.getFirst().getAccountNo());
 			assertEquals(1L, photoDetailModelList.getFirst().getPhotoNo().value());
@@ -742,7 +744,7 @@ public class PhotoRestControllerTest {
 
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 
-			ArgumentCaptor<List<PhotoDeleteModel>> photoDeleteModelCaptor = ArgumentCaptor.forClass(List.class);
+			ArgumentCaptor<PhotoDeleteModelList> photoDeleteModelCaptor = ArgumentCaptor.forClass(PhotoDeleteModelList.class);
 			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
 			doNothing().when(photoServiceImpl).deletePhotos(photoAcountIdCaptor.capture(), photoDeleteModelCaptor.capture());
 
@@ -754,7 +756,7 @@ public class PhotoRestControllerTest {
 				.andExpect(jsonPath("$.isSuccess").value(true))
 				.andExpect(jsonPath("$.message").value("写真削除が完了しました。"));
 
-			List<PhotoDeleteModel> photoDeleteModelList = photoDeleteModelCaptor.getValue();
+			PhotoDeleteModelList photoDeleteModelList = photoDeleteModelCaptor.getValue();
 			assertEquals(1, photoDeleteModelList.size());
 			assertEquals(new AccountNo(1L), photoDeleteModelList.getFirst().getAccountNo());
 			assertEquals(1L, photoDeleteModelList.getFirst().getPhotoNo().value());
@@ -799,7 +801,7 @@ public class PhotoRestControllerTest {
 
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 
-			ArgumentCaptor<List<PhotoDeleteModel>> photoDeleteModelCaptor = ArgumentCaptor.forClass(List.class);
+			ArgumentCaptor<PhotoDeleteModelList> photoDeleteModelCaptor = ArgumentCaptor.forClass(PhotoDeleteModelList.class);
 			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
 			doThrow(UpdateFailureException.class).when(photoServiceImpl).deletePhotos(photoAcountIdCaptor.capture(), photoDeleteModelCaptor.capture());
 
@@ -808,7 +810,7 @@ public class PhotoRestControllerTest {
 					.content(readJsonFile("delete_photo.json")))
 				.andExpect(status().isConflict());
 
-			List<PhotoDeleteModel> photoDeleteModelList = photoDeleteModelCaptor.getValue();
+			PhotoDeleteModelList photoDeleteModelList = photoDeleteModelCaptor.getValue();
 			assertEquals(1, photoDeleteModelList.size());
 			assertEquals(new AccountNo(1L), photoDeleteModelList.getFirst().getAccountNo());
 			assertEquals(1L, photoDeleteModelList.getFirst().getPhotoNo().value());

--- a/backend/src/test/java/com/web/gallery/helper/KbnHelperTest.java
+++ b/backend/src/test/java/com/web/gallery/helper/KbnHelperTest.java
@@ -2,7 +2,6 @@ package com.web.gallery.helper;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +27,7 @@ import com.web.gallery.domain.common.KbnGroupJapaneseName;
 import com.web.gallery.domain.common.KbnJapaneseName;
 import com.web.gallery.domain.common.SortOrder;
 import com.web.gallery.model.KbnMstModel;
+import com.web.gallery.model.KbnMstModelList;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -43,64 +43,64 @@ public class KbnHelperTest {
 		@Order(1)
 		@DisplayName("正常系：区分グループなし")
 		void convertToLinkedHashMap_not_kbnGroup() {
-			List<KbnMstModel> kbnMstModelList = new ArrayList<KbnMstModel>();
-			kbnMstModelList.add(KbnMstModel.builder()
-					.kbnClassCode(new KbnClassCode("prefecture"))
-					.kbnCode(new KbnCode("Aomori"))
-					.sortOrder(new SortOrder(2))
-					.kbnGroupCode(new KbnGroupCode(""))
-					.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
-					.kbnGroupJapaneseName(new KbnGroupJapaneseName(""))
-					.kbnJapaneseName(new KbnJapaneseName("青森"))
-					.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
-					.kbnGroupEnglishName(new KbnGroupEnglishName(""))
-					.kbnEnglishName(new KbnEnglishName("Aomori"))
-					.explanation(new Explanation("青森は本州最北"))
-					.build());
-			kbnMstModelList.add(KbnMstModel.builder()
-					.kbnClassCode(new KbnClassCode("prefecture"))
-					.kbnCode(new KbnCode("Hokkaido"))
-					.sortOrder(new SortOrder(1))
-					.kbnGroupCode(new KbnGroupCode(""))
-					.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
-					.kbnGroupJapaneseName(new KbnGroupJapaneseName(""))
-					.kbnJapaneseName(new KbnJapaneseName("北海道"))
-					.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
-					.kbnGroupEnglishName(new KbnGroupEnglishName(""))
-					.kbnEnglishName(new KbnEnglishName("Hokkaido"))
-					.explanation(new Explanation("北海道はでっかいどう"))
-					.build());
-			kbnMstModelList.add(KbnMstModel.builder()
-					.kbnClassCode(new KbnClassCode("prefecture"))
-					.kbnCode(new KbnCode("Okinawa"))
-					.sortOrder(new SortOrder(47))
-					.kbnGroupCode(new KbnGroupCode(""))
-					.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
-					.kbnGroupJapaneseName(new KbnGroupJapaneseName(""))
-					.kbnJapaneseName(new KbnJapaneseName("沖縄"))
-					.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
-					.kbnGroupEnglishName(new KbnGroupEnglishName(""))
-					.kbnEnglishName(new KbnEnglishName("Okinawa"))
-					.explanation(new Explanation("沖縄は南国"))
-					.build());
-			kbnMstModelList.add(KbnMstModel.builder()
-					.kbnClassCode(new KbnClassCode("prefecture"))
-					.kbnCode(new KbnCode("Kagoshima"))
-					.sortOrder(new SortOrder(46))
-					.kbnGroupCode(new KbnGroupCode(""))
-					.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
-					.kbnGroupJapaneseName(new KbnGroupJapaneseName(""))
-					.kbnJapaneseName(new KbnJapaneseName("鹿児島"))
-					.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
-					.kbnGroupEnglishName(new KbnGroupEnglishName(""))
-					.kbnEnglishName(new KbnEnglishName("Kagoshima"))
-					.explanation(new Explanation("鹿児島は九州最南"))
-					.build());
-			
-			Map<String, List<KbnMstModel>> actual
+			KbnMstModelList kbnMstModelList = KbnMstModelList.of(List.of(
+					KbnMstModel.builder()
+							.kbnClassCode(new KbnClassCode("prefecture"))
+							.kbnCode(new KbnCode("Aomori"))
+							.sortOrder(new SortOrder(2))
+							.kbnGroupCode(new KbnGroupCode(""))
+							.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
+							.kbnGroupJapaneseName(new KbnGroupJapaneseName(""))
+							.kbnJapaneseName(new KbnJapaneseName("青森"))
+							.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
+							.kbnGroupEnglishName(new KbnGroupEnglishName(""))
+							.kbnEnglishName(new KbnEnglishName("Aomori"))
+							.explanation(new Explanation("青森は本州最北"))
+							.build(),
+					KbnMstModel.builder()
+							.kbnClassCode(new KbnClassCode("prefecture"))
+							.kbnCode(new KbnCode("Hokkaido"))
+							.sortOrder(new SortOrder(1))
+							.kbnGroupCode(new KbnGroupCode(""))
+							.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
+							.kbnGroupJapaneseName(new KbnGroupJapaneseName(""))
+							.kbnJapaneseName(new KbnJapaneseName("北海道"))
+							.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
+							.kbnGroupEnglishName(new KbnGroupEnglishName(""))
+							.kbnEnglishName(new KbnEnglishName("Hokkaido"))
+							.explanation(new Explanation("北海道はでっかいどう"))
+							.build(),
+					KbnMstModel.builder()
+							.kbnClassCode(new KbnClassCode("prefecture"))
+							.kbnCode(new KbnCode("Okinawa"))
+							.sortOrder(new SortOrder(47))
+							.kbnGroupCode(new KbnGroupCode(""))
+							.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
+							.kbnGroupJapaneseName(new KbnGroupJapaneseName(""))
+							.kbnJapaneseName(new KbnJapaneseName("沖縄"))
+							.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
+							.kbnGroupEnglishName(new KbnGroupEnglishName(""))
+							.kbnEnglishName(new KbnEnglishName("Okinawa"))
+							.explanation(new Explanation("沖縄は南国"))
+							.build(),
+					KbnMstModel.builder()
+							.kbnClassCode(new KbnClassCode("prefecture"))
+							.kbnCode(new KbnCode("Kagoshima"))
+							.sortOrder(new SortOrder(46))
+							.kbnGroupCode(new KbnGroupCode(""))
+							.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
+							.kbnGroupJapaneseName(new KbnGroupJapaneseName(""))
+							.kbnJapaneseName(new KbnJapaneseName("鹿児島"))
+							.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
+							.kbnGroupEnglishName(new KbnGroupEnglishName(""))
+							.kbnEnglishName(new KbnEnglishName("Kagoshima"))
+							.explanation(new Explanation("鹿児島は九州最南"))
+							.build()));
+
+			Map<String, KbnMstModelList> actual
 				= kbnHepler.convertToLinkedHashMap(kbnMstModelList);
-			
-			List<KbnMstModel> kbnMstModelList1 = actual.get("");
+
+			KbnMstModelList kbnMstModelList1 = actual.get("");
 			assertEquals(4, kbnMstModelList1.size());
 			assertEquals("Hokkaido", kbnMstModelList1.get(0).getKbnCode().value());
 			assertEquals("Aomori", kbnMstModelList1.get(1).getKbnCode().value());
@@ -112,68 +112,68 @@ public class KbnHelperTest {
 		@Order(2)
 		@DisplayName("正常系：区分グループあり")
 		void convertToLinkedHashMap_with_kbnGroup() {
-			List<KbnMstModel> kbnMstModelList = new ArrayList<KbnMstModel>();
-			kbnMstModelList.add(KbnMstModel.builder()
-					.kbnClassCode(new KbnClassCode("prefecture"))
-					.kbnCode(new KbnCode("Aomori"))
-					.sortOrder(new SortOrder(2))
-					.kbnGroupCode(new KbnGroupCode("Hokkaido_Tohoku"))
-					.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
-					.kbnGroupJapaneseName(new KbnGroupJapaneseName("北海道・東北"))
-					.kbnJapaneseName(new KbnJapaneseName("青森"))
-					.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
-					.kbnGroupEnglishName(new KbnGroupEnglishName("Hokkaido_Tohoku"))
-					.kbnEnglishName(new KbnEnglishName("Aomori"))
-					.explanation(new Explanation("青森は本州最北"))
-					.build());
-			kbnMstModelList.add(KbnMstModel.builder()
-					.kbnClassCode(new KbnClassCode("prefecture"))
-					.kbnCode(new KbnCode("Hokkaido"))
-					.sortOrder(new SortOrder(1))
-					.kbnGroupCode(new KbnGroupCode("Hokkaido_Tohoku"))
-					.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
-					.kbnGroupJapaneseName(new KbnGroupJapaneseName("北海道・東北"))
-					.kbnJapaneseName(new KbnJapaneseName("北海道"))
-					.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
-					.kbnGroupEnglishName(new KbnGroupEnglishName("Hokkaido_Tohoku"))
-					.kbnEnglishName(new KbnEnglishName("Hokkaido"))
-					.explanation(new Explanation("北海道はでっかいどう"))
-					.build());
-			kbnMstModelList.add(KbnMstModel.builder()
-					.kbnClassCode(new KbnClassCode("prefecture"))
-					.kbnCode(new KbnCode("Okinawa"))
-					.sortOrder(new SortOrder(47))
-					.kbnGroupCode(new KbnGroupCode("Kyushu_Okinawa"))
-					.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
-					.kbnGroupJapaneseName(new KbnGroupJapaneseName("九州・沖縄"))
-					.kbnJapaneseName(new KbnJapaneseName("沖縄"))
-					.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
-					.kbnGroupEnglishName(new KbnGroupEnglishName("Kyushu_Okinawa"))
-					.kbnEnglishName(new KbnEnglishName("Okinawa"))
-					.explanation(new Explanation("沖縄は南国"))
-					.build());
-			kbnMstModelList.add(KbnMstModel.builder()
-					.kbnClassCode(new KbnClassCode("prefecture"))
-					.kbnCode(new KbnCode("Kagoshima"))
-					.sortOrder(new SortOrder(46))
-					.kbnGroupCode(new KbnGroupCode("Kyushu_Okinawa"))
-					.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
-					.kbnGroupJapaneseName(new KbnGroupJapaneseName("九州・沖縄"))
-					.kbnJapaneseName(new KbnJapaneseName("鹿児島"))
-					.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
-					.kbnGroupEnglishName(new KbnGroupEnglishName("Kyushu_Okinawa"))
-					.kbnEnglishName(new KbnEnglishName("Kagoshima"))
-					.explanation(new Explanation("鹿児島は九州最南"))
-					.build());
-			
-			Map<String, List<KbnMstModel>> actual
+			KbnMstModelList kbnMstModelList = KbnMstModelList.of(List.of(
+					KbnMstModel.builder()
+							.kbnClassCode(new KbnClassCode("prefecture"))
+							.kbnCode(new KbnCode("Aomori"))
+							.sortOrder(new SortOrder(2))
+							.kbnGroupCode(new KbnGroupCode("Hokkaido_Tohoku"))
+							.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
+							.kbnGroupJapaneseName(new KbnGroupJapaneseName("北海道・東北"))
+							.kbnJapaneseName(new KbnJapaneseName("青森"))
+							.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
+							.kbnGroupEnglishName(new KbnGroupEnglishName("Hokkaido_Tohoku"))
+							.kbnEnglishName(new KbnEnglishName("Aomori"))
+							.explanation(new Explanation("青森は本州最北"))
+							.build(),
+					KbnMstModel.builder()
+							.kbnClassCode(new KbnClassCode("prefecture"))
+							.kbnCode(new KbnCode("Hokkaido"))
+							.sortOrder(new SortOrder(1))
+							.kbnGroupCode(new KbnGroupCode("Hokkaido_Tohoku"))
+							.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
+							.kbnGroupJapaneseName(new KbnGroupJapaneseName("北海道・東北"))
+							.kbnJapaneseName(new KbnJapaneseName("北海道"))
+							.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
+							.kbnGroupEnglishName(new KbnGroupEnglishName("Hokkaido_Tohoku"))
+							.kbnEnglishName(new KbnEnglishName("Hokkaido"))
+							.explanation(new Explanation("北海道はでっかいどう"))
+							.build(),
+					KbnMstModel.builder()
+							.kbnClassCode(new KbnClassCode("prefecture"))
+							.kbnCode(new KbnCode("Okinawa"))
+							.sortOrder(new SortOrder(47))
+							.kbnGroupCode(new KbnGroupCode("Kyushu_Okinawa"))
+							.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
+							.kbnGroupJapaneseName(new KbnGroupJapaneseName("九州・沖縄"))
+							.kbnJapaneseName(new KbnJapaneseName("沖縄"))
+							.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
+							.kbnGroupEnglishName(new KbnGroupEnglishName("Kyushu_Okinawa"))
+							.kbnEnglishName(new KbnEnglishName("Okinawa"))
+							.explanation(new Explanation("沖縄は南国"))
+							.build(),
+					KbnMstModel.builder()
+							.kbnClassCode(new KbnClassCode("prefecture"))
+							.kbnCode(new KbnCode("Kagoshima"))
+							.sortOrder(new SortOrder(46))
+							.kbnGroupCode(new KbnGroupCode("Kyushu_Okinawa"))
+							.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
+							.kbnGroupJapaneseName(new KbnGroupJapaneseName("九州・沖縄"))
+							.kbnJapaneseName(new KbnJapaneseName("鹿児島"))
+							.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
+							.kbnGroupEnglishName(new KbnGroupEnglishName("Kyushu_Okinawa"))
+							.kbnEnglishName(new KbnEnglishName("Kagoshima"))
+							.explanation(new Explanation("鹿児島は九州最南"))
+							.build()));
+
+			Map<String, KbnMstModelList> actual
 				= kbnHepler.convertToLinkedHashMap(kbnMstModelList);
-			
-			List<KbnMstModel> kbnMstModelList1 = actual.get("北海道・東北");
+
+			KbnMstModelList kbnMstModelList1 = actual.get("北海道・東北");
 			assertEquals(2, kbnMstModelList1.size());
 			assertEquals("Hokkaido", kbnMstModelList1.get(0).getKbnCode().value());
 			assertEquals("Aomori", kbnMstModelList1.get(1).getKbnCode().value());
-			List<KbnMstModel> kbnMstModelList2 = actual.get("九州・沖縄");
+			KbnMstModelList kbnMstModelList2 = actual.get("九州・沖縄");
 			assertEquals(2, kbnMstModelList2.size());
 			assertEquals("Kagoshima", kbnMstModelList2.get(0).getKbnCode().value());
 			assertEquals("Okinawa", kbnMstModelList2.get(1).getKbnCode().value());

--- a/backend/src/test/java/com/web/gallery/model/AccountModelListTest.java
+++ b/backend/src/test/java/com/web/gallery/model/AccountModelListTest.java
@@ -1,0 +1,39 @@
+package com.web.gallery.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.web.gallery.domain.account.AccountId;
+import com.web.gallery.domain.common.IsDeleted;
+
+@ActiveProfiles("test")
+public class AccountModelListTest {
+
+	@Nested
+	@Order(1)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class filterByIsDeleted {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：削除フラグに一致するアカウントのみに絞り込まれること")
+		void filterByIsDeleted_success() {
+			AccountModelList accountModelList = AccountModelList.of(List.of(
+					AccountModel.builder().accountId(new AccountId("aaaaaaaa")).isDeleted(new IsDeleted(true)).build(),
+					AccountModel.builder().accountId(new AccountId("bbbbbbbb")).isDeleted(new IsDeleted(false)).build()));
+
+			AccountModelList actual = accountModelList.filterByIsDeleted(false);
+
+			assertEquals(1, actual.size());
+			assertEquals(new AccountId("bbbbbbbb"), actual.get(0).getAccountId());
+		}
+	}
+}

--- a/backend/src/test/java/com/web/gallery/model/PhotoModelListTest.java
+++ b/backend/src/test/java/com/web/gallery/model/PhotoModelListTest.java
@@ -1,0 +1,106 @@
+package com.web.gallery.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.photo.Caption;
+import com.web.gallery.domain.photo.FavoriteCount;
+import com.web.gallery.domain.photo.ImageFilePath;
+import com.web.gallery.domain.photo.IsFavorite;
+import com.web.gallery.domain.photo.PhotoAt;
+import com.web.gallery.domain.photo.PhotoNo;
+import com.web.gallery.enumuration.DirectionEnum;
+
+@ActiveProfiles("test")
+public class PhotoModelListTest {
+
+	private PhotoModel createPhotoModel(Long photoNo, DirectionEnum directionKbn, Boolean isFavorite) {
+		return PhotoModel.builder()
+				.accountNo(new AccountNo(1L))
+				.photoNo(new PhotoNo(photoNo))
+				.favoriteCount(new FavoriteCount(1))
+				.isFavorite(new IsFavorite(isFavorite))
+				.photoAt(new PhotoAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
+				.imageFilePath(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC" + photoNo + ".jpg"))
+				.caption(new Caption("キャプション" + photoNo))
+				.directionKbn(directionKbn)
+				.photoTagModelList(PhotoTagModelList.empty())
+				.build();
+	}
+
+	@Nested
+	@Order(1)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class filterByDirectionKbn {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：抽出条件が未指定の場合はフィルタリングしないこと")
+		void filterByDirectionKbn_not_condition() {
+			PhotoModelList photoModelList = PhotoModelList.of(List.of(
+					createPhotoModel(1L, DirectionEnum.VERTICAL, false),
+					createPhotoModel(2L, DirectionEnum.HORIZONTAL, false)));
+
+			PhotoModelList actual = photoModelList.filterByDirectionKbn(DirectionEnum.NONE);
+
+			assertEquals(2, actual.size());
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("正常系：抽出条件と一致するものだけに絞り込まれること")
+		void filterByDirectionKbn_match_condition() {
+			PhotoModelList photoModelList = PhotoModelList.of(List.of(
+					createPhotoModel(1L, DirectionEnum.VERTICAL, false),
+					createPhotoModel(2L, DirectionEnum.HORIZONTAL, false)));
+
+			PhotoModelList actual = photoModelList.filterByDirectionKbn(DirectionEnum.VERTICAL);
+
+			assertEquals(1, actual.size());
+			assertEquals(new PhotoNo(1L), actual.get(0).getPhotoNo());
+		}
+	}
+
+	@Nested
+	@Order(2)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class filterByFavorite {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：お気に入りのみが指定されていない場合はフィルタリングしないこと")
+		void filterByFavorite_not_condition() {
+			PhotoModelList photoModelList = PhotoModelList.of(List.of(
+					createPhotoModel(1L, DirectionEnum.VERTICAL, true),
+					createPhotoModel(2L, DirectionEnum.VERTICAL, false)));
+
+			PhotoModelList actual = photoModelList.filterByFavorite(false);
+
+			assertEquals(2, actual.size());
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("正常系：お気に入りのみが指定されている場合はお気に入りの写真のみに絞り込まれること")
+		void filterByFavorite_match_condition() {
+			PhotoModelList photoModelList = PhotoModelList.of(List.of(
+					createPhotoModel(1L, DirectionEnum.VERTICAL, true),
+					createPhotoModel(2L, DirectionEnum.VERTICAL, false)));
+
+			PhotoModelList actual = photoModelList.filterByFavorite(true);
+
+			assertEquals(1, actual.size());
+			assertEquals(new PhotoNo(1L), actual.get(0).getPhotoNo());
+		}
+	}
+}

--- a/backend/src/test/java/com/web/gallery/model/PhotoTagModelListTest.java
+++ b/backend/src/test/java/com/web/gallery/model/PhotoTagModelListTest.java
@@ -1,0 +1,146 @@
+package com.web.gallery.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.photo.PhotoNo;
+import com.web.gallery.domain.photo.TagEnglishName;
+import com.web.gallery.domain.photo.TagJapaneseName;
+import com.web.gallery.domain.photo.TagNo;
+
+@ActiveProfiles("test")
+public class PhotoTagModelListTest {
+
+	@Nested
+	@Order(1)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class containsAllTags {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：tagsが0件の場合")
+		void containsAllTags_tags_empty() {
+			assertTrue(PhotoTagModelList.empty().containsAllTags(new ArrayList<String>()));
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("正常系：tagsの1件目が''の場合")
+		void containsAllTags_tags_blank() {
+			List<String> tags = new ArrayList<String>();
+			tags.add("");
+			assertTrue(PhotoTagModelList.empty().containsAllTags(tags));
+		}
+
+		@Test
+		@Order(3)
+		@DisplayName("正常系：tagsのすべてが含まれる場合")
+		void containsAllTags_contain_all_tag() {
+			PhotoTagModelList photoTagModelList = PhotoTagModelList.of(List.of(
+					PhotoTagModel.builder()
+							.accountNo(new AccountNo(1L))
+							.photoNo(new PhotoNo(1L))
+							.tagNo(new TagNo(1L))
+							.tagJapaneseName(new TagJapaneseName("太陽"))
+							.tagEnglishName(new TagEnglishName("sun"))
+							.build(),
+					PhotoTagModel.builder()
+							.accountNo(new AccountNo(1L))
+							.photoNo(new PhotoNo(1L))
+							.tagNo(new TagNo(1L))
+							.tagJapaneseName(new TagJapaneseName("月"))
+							.tagEnglishName(new TagEnglishName("moon"))
+							.build(),
+					PhotoTagModel.builder()
+							.accountNo(new AccountNo(1L))
+							.photoNo(new PhotoNo(1L))
+							.tagNo(new TagNo(1L))
+							.tagJapaneseName(new TagJapaneseName("海"))
+							.tagEnglishName(new TagEnglishName("sea"))
+							.build()));
+
+			List<String> tags = new ArrayList<String>();
+			tags.add("太陽");
+			tags.add("sun");
+			tags.add("sea");
+
+			assertTrue(photoTagModelList.containsAllTags(tags));
+		}
+
+		@Test
+		@Order(4)
+		@DisplayName("正常系：tagsのすべてが含まれない場合")
+		void containsAllTags_not_contain_all_tag() {
+			PhotoTagModelList photoTagModelList = PhotoTagModelList.of(List.of(
+					PhotoTagModel.builder()
+							.accountNo(new AccountNo(1L))
+							.photoNo(new PhotoNo(1L))
+							.tagNo(new TagNo(1L))
+							.tagJapaneseName(new TagJapaneseName("太陽"))
+							.tagEnglishName(new TagEnglishName("sun"))
+							.build(),
+					PhotoTagModel.builder()
+							.accountNo(new AccountNo(1L))
+							.photoNo(new PhotoNo(1L))
+							.tagNo(new TagNo(1L))
+							.tagJapaneseName(new TagJapaneseName("月"))
+							.tagEnglishName(new TagEnglishName("moon"))
+							.build(),
+					PhotoTagModel.builder()
+							.accountNo(new AccountNo(1L))
+							.photoNo(new PhotoNo(1L))
+							.tagNo(new TagNo(1L))
+							.tagJapaneseName(new TagJapaneseName("海"))
+							.tagEnglishName(new TagEnglishName("sea"))
+							.build()));
+
+			List<String> tags = new ArrayList<String>();
+			tags.add("太陽");
+			tags.add("sum");
+			tags.add("wood");
+
+			assertFalse(photoTagModelList.containsAllTags(tags));
+		}
+	}
+
+	@Nested
+	@Order(2)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class filterByPhoto {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：該当写真のタグのみに絞り込まれること")
+		void filterByPhoto_success() {
+			PhotoTagModelList photoTagModelList = PhotoTagModelList.of(List.of(
+					PhotoTagModel.builder()
+							.accountNo(new AccountNo(1L))
+							.photoNo(new PhotoNo(1L))
+							.tagNo(new TagNo(1L))
+							.tagJapaneseName(new TagJapaneseName("太陽"))
+							.tagEnglishName(new TagEnglishName("sun"))
+							.build(),
+					PhotoTagModel.builder()
+							.accountNo(new AccountNo(1L))
+							.photoNo(new PhotoNo(2L))
+							.tagNo(new TagNo(1L))
+							.tagJapaneseName(new TagJapaneseName("海"))
+							.tagEnglishName(new TagEnglishName("sea"))
+							.build()));
+
+			PhotoTagModelList actual = photoTagModelList.filterByPhoto(new AccountNo(1L), new PhotoNo(1L));
+
+			assertEquals(1, actual.size());
+			assertEquals(new PhotoNo(1L), actual.get(0).getPhotoNo());
+		}
+	}
+}

--- a/backend/src/test/java/com/web/gallery/repository/impl/AccountRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/AccountRepositoryImplTest.java
@@ -48,6 +48,7 @@ import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.mapper.AccountMapper;
 import com.web.gallery.model.AccountModel;
+import com.web.gallery.model.AccountModelList;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
@@ -683,7 +684,7 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(accountList).when(accountMapper).select(accountCaptor.capture());
 
-			List<AccountModel> actual = accountRepositoryImpl.getAccountList();
+			AccountModelList actual = accountRepositoryImpl.getAccountList();
 
 			Account account = accountCaptor.getValue();
 			assertFalse(account.getIsDeleted().value());
@@ -726,8 +727,8 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(expected).when(accountMapper).select(accountCaptor.capture());
 
-			List<AccountModel> actual = accountRepositoryImpl.getAccountList();
-			assertEquals(expected, actual);
+			AccountModelList actual = accountRepositoryImpl.getAccountList();
+			assertEquals(expected.size(), actual.size());
 
 			Account account = accountCaptor.getValue();
 			assertFalse(account.getIsDeleted().value());

--- a/backend/src/test/java/com/web/gallery/repository/impl/KbnMstRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/KbnMstRepositoryImplTest.java
@@ -32,7 +32,7 @@ import com.web.gallery.domain.common.KbnGroupEnglishName;
 import com.web.gallery.domain.common.KbnEnglishName;
 import com.web.gallery.domain.common.Explanation;
 import com.web.gallery.mapper.KbnMstMapper;
-import com.web.gallery.model.KbnMstModel;
+import com.web.gallery.model.KbnMstModelList;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
@@ -84,7 +84,7 @@ public class KbnMstRepositoryImplTest {
 			ArgumentCaptor<KbnMst> kbnMstCaptor = ArgumentCaptor.forClass(KbnMst.class);
 			doReturn(expected).when(kbnMstMapper).select(kbnMstCaptor.capture());
 			
-			List<KbnMstModel> actual = kbnMstRepositoryImpl.get(kbnClassCode);
+			KbnMstModelList actual = kbnMstRepositoryImpl.get(kbnClassCode);
 			
 			KbnMst kbnMstCapture = kbnMstCaptor.getValue();
 			assertEquals(new KbnClassCode(kbnClassCode), kbnMstCapture.getKbnClassCode());
@@ -113,7 +113,7 @@ public class KbnMstRepositoryImplTest {
 			ArgumentCaptor<KbnMst> kbnMstCaptor = ArgumentCaptor.forClass(KbnMst.class);
 			doReturn(expected).when(kbnMstMapper).select(kbnMstCaptor.capture());
 			
-			List<KbnMstModel> actual = kbnMstRepositoryImpl.get(kbnClassCode);
+			KbnMstModelList actual = kbnMstRepositoryImpl.get(kbnClassCode);
 
 			KbnMst kbnMstCapture = kbnMstCaptor.getValue();
 			assertEquals(new KbnClassCode(kbnClassCode), kbnMstCapture.getKbnClassCode());

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImplTest.java
@@ -56,7 +56,7 @@ import com.web.gallery.mapper.PhotoTagMstMapper;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
 import com.web.gallery.model.PhotoGetModel;
-import com.web.gallery.model.PhotoModel;
+import com.web.gallery.model.PhotoModelList;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
@@ -93,11 +93,9 @@ public class PhotoDetailRepositoryImplTest {
 			ArgumentCaptor<PhotoTagMst> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMst.class);
 			doReturn(photoTagMstList).when(photoTagMstMapper).select(photoTagMstCaptor.capture());
 
-			List<PhotoModel> expected = new ArrayList<PhotoModel>();
+			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
 
-			List<PhotoModel> actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
-
-			assertEquals(expected, actual);
+			assertTrue(actual.isEmpty());
 
 			PhotoListGetDto photoListGetDtoCapture = photoListGetDtoCaptor.getValue();
 			assertEquals(1L, photoListGetDtoCapture.getAccountNo().value());
@@ -147,7 +145,7 @@ public class PhotoDetailRepositoryImplTest {
 			ArgumentCaptor<PhotoTagMst> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMst.class);
 			doReturn(photoTagMstList).when(photoTagMstMapper).select(photoTagMstCaptor.capture());
 
-			List<PhotoModel> actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
+			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
 
 			assertEquals(new AccountNo(1L), actual.get(0).getAccountNo());
 			assertEquals(1L, actual.get(0).getPhotoNo().value());
@@ -229,7 +227,7 @@ public class PhotoDetailRepositoryImplTest {
 			ArgumentCaptor<PhotoTagMst> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMst.class);
 			doReturn(photoTagMstList).when(photoTagMstMapper).select(photoTagMstCaptor.capture());
 
-			List<PhotoModel> actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
+			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
 
 			assertEquals(new AccountNo(1L), actual.get(0).getAccountNo());
 			assertEquals(1L, actual.get(0).getPhotoNo().value());

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/AccountRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/AccountRepositoryImplIntegrationTest.java
@@ -42,6 +42,7 @@ import com.web.gallery.enumuration.SexEnum;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.AccountModel;
+import com.web.gallery.model.AccountModelList;
 import com.web.gallery.repository.impl.AccountRepositoryImpl;
 
 @ActiveProfiles("test")
@@ -541,7 +542,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@Sql("/sql/common/cleanup.sql")
 		@Sql("/sql/repository/AccountRepositoryImplIntegrationTest.sql")
 		void getAccountList_found_some_accounts() {
-			List<AccountModel> actual = accountRepositoryImpl.getAccountList();
+			AccountModelList actual = accountRepositoryImpl.getAccountList();
 			assertEquals(11, actual.size());
 		}
 		
@@ -549,7 +550,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが0件")
 		void getAccountList_not_found() {
-			List<AccountModel> actual = accountRepositoryImpl.getAccountList();
+			AccountModelList actual = accountRepositoryImpl.getAccountList();
 			assertEquals(0, actual.size());
 		}
 	}

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/KbnMstRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/KbnMstRepositoryImplIntegrationTest.java
@@ -2,8 +2,6 @@ package com.web.gallery.repository.impl.integration;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
@@ -18,7 +16,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.web.gallery.domain.common.KbnCode;
-import com.web.gallery.model.KbnMstModel;
+import com.web.gallery.model.KbnMstModelList;
 import com.web.gallery.repository.impl.KbnMstRepositoryImpl;
 
 @ActiveProfiles("test")
@@ -38,7 +36,7 @@ public class KbnMstRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：区分マスタが取得できた場合")
 		void get_found() {
-			List<KbnMstModel> actual = kbnMstRepositoryImpl.get("sex");
+			KbnMstModelList actual = kbnMstRepositoryImpl.get("sex");
 			assertEquals(2, actual.size());
 			assertEquals(new KbnCode("man"), actual.get(0).getKbnCode());
 			assertEquals(new KbnCode("woman"), actual.get(1).getKbnCode());
@@ -48,7 +46,7 @@ public class KbnMstRepositoryImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：区分マスタが取得できなかった場合")
 		void get_not_found() {
-			List<KbnMstModel> actual = kbnMstRepositoryImpl.get("test");
+			KbnMstModelList actual = kbnMstRepositoryImpl.get("test");
 			assertEquals(0, actual.size());
 		}
 	}

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoDetailRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoDetailRepositoryImplIntegrationTest.java
@@ -45,7 +45,7 @@ import com.web.gallery.exception.PhotoNotFoundException;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
 import com.web.gallery.model.PhotoGetModel;
-import com.web.gallery.model.PhotoModel;
+import com.web.gallery.model.PhotoModelList;
 import com.web.gallery.repository.impl.PhotoDetailRepositoryImpl;
 
 @ActiveProfiles("test")
@@ -69,7 +69,7 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 					.accountNo(new AccountNo(1L))
 					.photoAccountNo(new AccountNo(3L))
 					.build();
-			List<PhotoModel> actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
+			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
 			assertEquals(0, actual.size());
 		}
 		
@@ -82,7 +82,7 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 					.photoAccountNo(new AccountNo(2L))
 					.build();
 
-			List<PhotoModel> actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
+			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
 
 			assertEquals(2, actual.size());
 			assertEquals(new AccountNo(2L), actual.get(0).getAccountNo());
@@ -102,7 +102,7 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 					.photoAccountNo(new AccountNo(1L))
 					.build();
 			
-			List<PhotoModel> actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
+			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
 			
 			assertEquals(2, actual.size());
 			

--- a/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
@@ -50,6 +50,7 @@ import com.web.gallery.mapper.PhotoFavoriteMapper;
 import com.web.gallery.mapper.PhotoMstMapper;
 import com.web.gallery.mapper.PhotoTagMstMapper;
 import com.web.gallery.model.AccountModel;
+import com.web.gallery.model.AccountModelList;
 import com.web.gallery.repository.FileRepository;
 import com.web.gallery.repository.impl.AccountRepositoryImpl;
 
@@ -240,14 +241,14 @@ public class AccountServiceImplTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントが存在する場合")
 		void getAccountList_found() {
-			List<AccountModel> accountModelList = new ArrayList<AccountModel>();
-			accountModelList.add(AccountModel.builder().accountId(new AccountId("cccccccc")).build());
-			accountModelList.add(AccountModel.builder().accountId(new AccountId("bbbbbbbb")).build());
-			accountModelList.add(AccountModel.builder().accountId(new AccountId("aaaaaaaa")).build());
+			AccountModelList accountModelList = AccountModelList.of(List.of(
+					AccountModel.builder().accountId(new AccountId("cccccccc")).build(),
+					AccountModel.builder().accountId(new AccountId("bbbbbbbb")).build(),
+					AccountModel.builder().accountId(new AccountId("aaaaaaaa")).build()));
 
 			doReturn(accountModelList).when(accountRepositoryImpl).getAccountList();
 
-			List<AccountModel> actual = accountServiceImpl.getAccountList();
+			AccountModelList actual = accountServiceImpl.getAccountList();
 			assertEquals(accountModelList.size(), actual.size());
 			assertEquals(new AccountId("aaaaaaaa"), actual.get(0).getAccountId());
 			assertEquals(new AccountId("bbbbbbbb"), actual.get(1).getAccountId());
@@ -258,11 +259,11 @@ public class AccountServiceImplTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが存在しない場合")
 		void getAccountList_not_found() {
-			List<AccountModel> accountModelList = new ArrayList<AccountModel>();
-			
+			AccountModelList accountModelList = AccountModelList.empty();
+
 			doReturn(accountModelList).when(accountRepositoryImpl).getAccountList();
-			
-			List<AccountModel> actual = accountServiceImpl.getAccountList();
+
+			AccountModelList actual = accountServiceImpl.getAccountList();
 			assertEquals(0, actual.size());
 		}
 	}
@@ -275,14 +276,14 @@ public class AccountServiceImplTest {
 		@Order(1)
 		@DisplayName("正常系：全アカウントを取得（削除済み含む）してソートされること")
 		void getAccountListForAdmin_found() {
-			List<AccountModel> accountModelList = new ArrayList<AccountModel>();
-			accountModelList.add(AccountModel.builder().accountId(new AccountId("cccccccc")).isDeleted(new IsDeleted(true)).build());
-			accountModelList.add(AccountModel.builder().accountId(new AccountId("bbbbbbbb")).isDeleted(new IsDeleted(false)).build());
-			accountModelList.add(AccountModel.builder().accountId(new AccountId("aaaaaaaa")).isDeleted(new IsDeleted(false)).build());
+			AccountModelList accountModelList = AccountModelList.of(List.of(
+					AccountModel.builder().accountId(new AccountId("cccccccc")).isDeleted(new IsDeleted(true)).build(),
+					AccountModel.builder().accountId(new AccountId("bbbbbbbb")).isDeleted(new IsDeleted(false)).build(),
+					AccountModel.builder().accountId(new AccountId("aaaaaaaa")).isDeleted(new IsDeleted(false)).build()));
 
 			doReturn(accountModelList).when(accountRepositoryImpl).getAccountListAll();
 
-			List<AccountModel> actual = accountServiceImpl.getAccountListForAdmin();
+			AccountModelList actual = accountServiceImpl.getAccountListForAdmin();
 			assertEquals(3, actual.size());
 			assertEquals(new AccountId("aaaaaaaa"), actual.get(0).getAccountId());
 			assertEquals(new AccountId("bbbbbbbb"), actual.get(1).getAccountId());
@@ -293,9 +294,9 @@ public class AccountServiceImplTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが存在しない場合")
 		void getAccountListForAdmin_not_found() {
-			doReturn(new ArrayList<AccountModel>()).when(accountRepositoryImpl).getAccountListAll();
+			doReturn(AccountModelList.empty()).when(accountRepositoryImpl).getAccountListAll();
 
-			List<AccountModel> actual = accountServiceImpl.getAccountListForAdmin();
+			AccountModelList actual = accountServiceImpl.getAccountListForAdmin();
 			assertEquals(0, actual.size());
 		}
 	}

--- a/backend/src/test/java/com/web/gallery/service/impl/KbnMstServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/KbnMstServiceImplTest.java
@@ -3,7 +3,6 @@ package com.web.gallery.service.impl;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -30,6 +29,7 @@ import com.web.gallery.domain.common.KbnGroupJapaneseName;
 import com.web.gallery.domain.common.KbnJapaneseName;
 import com.web.gallery.domain.common.SortOrder;
 import com.web.gallery.model.KbnMstModel;
+import com.web.gallery.model.KbnMstModelList;
 import com.web.gallery.repository.impl.KbnMstRepositoryImpl;
 
 @ActiveProfiles("test")
@@ -49,42 +49,42 @@ public class KbnMstServiceImplTest {
 		@Order(1)
 		@DisplayName("正常系：区分マスタが存在する場合")
 		void getPrefectureList_found() {
-			List<KbnMstModel> kbnMstModelList = new ArrayList<KbnMstModel>();
-			kbnMstModelList.add(KbnMstModel.builder()
-					.kbnClassCode(new KbnClassCode("prefecture"))
-					.kbnCode(new KbnCode("Hokkaido"))
-					.sortOrder(new SortOrder(1))
-					.kbnGroupCode(new KbnGroupCode("Hokkaido_Tohoku"))
-					.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
-					.kbnGroupJapaneseName(new KbnGroupJapaneseName("北海道・東北"))
-					.kbnJapaneseName(new KbnJapaneseName("北海道"))
-					.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
-					.kbnGroupEnglishName(new KbnGroupEnglishName("Hokkaido_Tohoku"))
-					.kbnEnglishName(new KbnEnglishName("Hokkaido"))
-					.explanation(new Explanation("北海道はでっかいどう"))
-					.build());
-			kbnMstModelList.add(KbnMstModel.builder()
-					.kbnClassCode(new KbnClassCode("prefecture"))
-					.kbnCode(new KbnCode("Okinawa"))
-					.sortOrder(new SortOrder(47))
-					.kbnGroupCode(new KbnGroupCode("Kyushu_Okinawa"))
-					.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
-					.kbnGroupJapaneseName(new KbnGroupJapaneseName("九州・沖縄"))
-					.kbnJapaneseName(new KbnJapaneseName("沖縄"))
-					.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
-					.kbnGroupEnglishName(new KbnGroupEnglishName("Kyushu_Okinawa"))
-					.kbnEnglishName(new KbnEnglishName("Okinawa"))
-					.explanation(new Explanation("沖縄は南国"))
-					.build());
+			KbnMstModelList kbnMstModelList = KbnMstModelList.of(List.of(
+					KbnMstModel.builder()
+							.kbnClassCode(new KbnClassCode("prefecture"))
+							.kbnCode(new KbnCode("Hokkaido"))
+							.sortOrder(new SortOrder(1))
+							.kbnGroupCode(new KbnGroupCode("Hokkaido_Tohoku"))
+							.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
+							.kbnGroupJapaneseName(new KbnGroupJapaneseName("北海道・東北"))
+							.kbnJapaneseName(new KbnJapaneseName("北海道"))
+							.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
+							.kbnGroupEnglishName(new KbnGroupEnglishName("Hokkaido_Tohoku"))
+							.kbnEnglishName(new KbnEnglishName("Hokkaido"))
+							.explanation(new Explanation("北海道はでっかいどう"))
+							.build(),
+					KbnMstModel.builder()
+							.kbnClassCode(new KbnClassCode("prefecture"))
+							.kbnCode(new KbnCode("Okinawa"))
+							.sortOrder(new SortOrder(47))
+							.kbnGroupCode(new KbnGroupCode("Kyushu_Okinawa"))
+							.kbnClassJapaneseName(new KbnClassJapaneseName("都道府県"))
+							.kbnGroupJapaneseName(new KbnGroupJapaneseName("九州・沖縄"))
+							.kbnJapaneseName(new KbnJapaneseName("沖縄"))
+							.kbnClassEnglishName(new KbnClassEnglishName("prefecture"))
+							.kbnGroupEnglishName(new KbnGroupEnglishName("Kyushu_Okinawa"))
+							.kbnEnglishName(new KbnEnglishName("Okinawa"))
+							.explanation(new Explanation("沖縄は南国"))
+							.build()));
 			doReturn(kbnMstModelList).when(kbnMstRepositoryImpl).get("prefecture");
 			assertEquals(kbnMstModelList, kbnMstServiceImpl.getPrefectureList());
 		}
-		
+
 		@Test
 		@Order(2)
 		@DisplayName("正常系：区分マスタが存在しない場合")
 		void getPrefectureList_not_found() {
-			List<KbnMstModel> kbnMstModelList = new ArrayList<KbnMstModel>();
+			KbnMstModelList kbnMstModelList = KbnMstModelList.empty();
 			doReturn(kbnMstModelList).when(kbnMstRepositoryImpl).get("prefecture");
 			assertEquals(kbnMstModelList, kbnMstServiceImpl.getPrefectureList());
 		}

--- a/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
@@ -67,8 +67,10 @@ import com.web.gallery.model.PhotoFavoriteDeleteModel;
 import com.web.gallery.model.PhotoGetModel;
 import com.web.gallery.model.PhotoListGetModel;
 import com.web.gallery.model.PhotoModel;
+import com.web.gallery.model.PhotoModelList;
 import com.web.gallery.model.PhotoTagDeleteModel;
 import com.web.gallery.model.PhotoTagModel;
+import com.web.gallery.model.PhotoTagModelList;
 import com.web.gallery.repository.impl.AccountRepositoryImpl;
 import com.web.gallery.repository.impl.FileRepositoryImpl;
 import com.web.gallery.repository.impl.PhotoDetailRepositoryImpl;
@@ -107,7 +109,7 @@ public class PhotoServiceImplTest {
 	@Order(1)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	class getPhotoList {
-		List<PhotoModel> createPhotoModelList() {
+		PhotoModelList createPhotoModelList() {
 			List<PhotoModel> photoModelList = new ArrayList<PhotoModel>();
 			
 			List<PhotoTagModel> photoTagModelList1 = new ArrayList<PhotoTagModel>();
@@ -134,7 +136,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("DSC111.jpg"))
 					.caption(new Caption("キャプション1"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(photoTagModelList1)
+					.photoTagModelList(PhotoTagModelList.of(photoTagModelList1))
 					.build();
 			photoModelList.add(photoModel1);
 			
@@ -162,7 +164,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("DSC222.jpg"))
 					.caption(new Caption("キャプション2"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(photoTagModelList2)
+					.photoTagModelList(PhotoTagModelList.of(photoTagModelList2))
 					.build();
 			photoModelList.add(photoModel2);
 			
@@ -190,7 +192,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("DSC333.jpg"))
 					.caption(new Caption("キャプション3"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(photoTagModelList3)
+					.photoTagModelList(PhotoTagModelList.of(photoTagModelList3))
 					.build();
 			photoModelList.add(photoModel3);
 			
@@ -211,7 +213,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("DSC444.jpg"))
 					.caption(new Caption("キャプション4"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(photoTagModelList4)
+					.photoTagModelList(PhotoTagModelList.of(photoTagModelList4))
 					.build();
 			photoModelList.add(photoModel4);
 			
@@ -232,7 +234,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("DSC444.jpg"))
 					.caption(new Caption("キャプション4"))
 					.directionKbn(DirectionEnum.HORIZONTAL)
-					.photoTagModelList(photoTagModelList5)
+					.photoTagModelList(PhotoTagModelList.of(photoTagModelList5))
 					.build();
 			photoModelList.add(photoModel5);
 			
@@ -245,11 +247,11 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("DSC666.jpg"))
 					.caption(new Caption("キャプション6"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build();
 			photoModelList.add(photoModel6);
-			
-			return photoModelList;
+
+			return PhotoModelList.of(photoModelList);
 		}
 		
 		@Test
@@ -263,7 +265,7 @@ public class PhotoServiceImplTest {
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(accountId);
 			
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
-			doReturn(new ArrayList<PhotoModel>()).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
+			doReturn(PhotoModelList.empty()).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
 			
 			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
 					.accountNo(new AccountNo(2L))
@@ -274,8 +276,8 @@ public class PhotoServiceImplTest {
 					.sortBy(SortPhotoEnum.PHOTO_AT)
 					.build();
 			
-			List<PhotoModel> actual = photoServiceImpl.getPhotoList(photoListGetModel);
-			assertEquals(new ArrayList<PhotoModel>(), actual);
+			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
+			assertTrue(actual.isEmpty());
 			verify(accountRepositoryImpl).getByAccountId(accountId);
 			verify(photoDetailRepositoryImpl).getPhotoList(any(PhotoGetModel.class));
 			
@@ -306,7 +308,7 @@ public class PhotoServiceImplTest {
 					.sortBy(SortPhotoEnum.PHOTO_AT)
 					.build();
 			
-			List<PhotoModel> actual = photoServiceImpl.getPhotoList(photoListGetModel);
+			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
 			assertEquals(3, actual.size());
 			assertEquals(3L, actual.get(0).getPhotoNo().value());
 			assertEquals(2L, actual.get(1).getPhotoNo().value());
@@ -342,7 +344,7 @@ public class PhotoServiceImplTest {
 					.sortBy(SortPhotoEnum.FAVORITE)
 					.build();
 			
-			List<PhotoModel> actual = photoServiceImpl.getPhotoList(photoListGetModel);
+			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
 			assertEquals(3, actual.size());
 			assertEquals(2L, actual.get(0).getPhotoNo().value());
 			assertEquals(3L, actual.get(1).getPhotoNo().value());
@@ -378,7 +380,7 @@ public class PhotoServiceImplTest {
 					.sortBy(SortPhotoEnum.SEASON)
 					.build();
 			
-			List<PhotoModel> actual = photoServiceImpl.getPhotoList(photoListGetModel);
+			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
 			assertEquals(3, actual.size());
 			assertEquals(1L, actual.get(0).getPhotoNo().value());
 			assertEquals(2L, actual.get(1).getPhotoNo().value());
@@ -469,7 +471,7 @@ public class PhotoServiceImplTest {
 					.fValue(new FValue(BigDecimal.valueOf(2.8)))
 					.shutterSpeed(new ShutterSpeed(BigDecimal.valueOf(0.01)))
 					.iso(new Iso(100))
-					.photoTagModelList(photoTagModelList)
+					.photoTagModelList(PhotoTagModelList.of(photoTagModelList))
 					.build();
 		}
 		
@@ -522,7 +524,7 @@ public class PhotoServiceImplTest {
 					.fValue(new FValue(BigDecimal.valueOf(2.8)))
 					.shutterSpeed(new ShutterSpeed(BigDecimal.valueOf(0.01)))
 					.iso(new Iso(100))
-					.photoTagModelList(photoTagModelList)
+					.photoTagModelList(PhotoTagModelList.of(photoTagModelList))
 					.build();
 		}
 		
@@ -1131,7 +1133,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC111.jpg"))
 					.caption(new Caption("キャプション1"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1142,7 +1144,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC222.jpg"))
 					.caption(new Caption("キャプション2"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1153,7 +1155,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC333.jpg"))
 					.caption(new Caption("キャプション3"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1164,7 +1166,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC444.jpg"))
 					.caption(new Caption("キャプション4"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1175,7 +1177,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC555.jpg"))
 					.caption(new Caption("キャプション5"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			
 			List<PhotoModel> actualData = photoModelList.stream().sorted(actual).toList();
@@ -1206,7 +1208,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC111.jpg"))
 					.caption(new Caption("キャプション1"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1217,7 +1219,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC222.jpg"))
 					.caption(new Caption("キャプション2"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1228,7 +1230,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC333.jpg"))
 					.caption(new Caption("キャプション3"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1239,7 +1241,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC444.jpg"))
 					.caption(new Caption("キャプション4"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1250,7 +1252,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC555.jpg"))
 					.caption(new Caption("キャプション5"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			
 			List<PhotoModel> actualData = photoModelList.stream().sorted(actual).toList();
@@ -1281,7 +1283,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC111.jpg"))
 					.caption(new Caption("キャプション1"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1292,7 +1294,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC222.jpg"))
 					.caption(new Caption("キャプション2"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1303,7 +1305,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC333.jpg"))
 					.caption(new Caption("キャプション3"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1314,7 +1316,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC444.jpg"))
 					.caption(new Caption("キャプション4"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1325,7 +1327,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC555.jpg"))
 					.caption(new Caption("キャプション5"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			
 			List<PhotoModel> actualData = photoModelList.stream().sorted(actual).toList();
@@ -1356,7 +1358,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC111.jpg"))
 					.caption(new Caption("キャプション1"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1367,7 +1369,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC222.jpg"))
 					.caption(new Caption("キャプション2"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1378,7 +1380,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC333.jpg"))
 					.caption(new Caption("キャプション3"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1389,7 +1391,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC444.jpg"))
 					.caption(new Caption("キャプション4"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1400,7 +1402,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC555.jpg"))
 					.caption(new Caption("キャプション5"))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(new ArrayList<PhotoTagModel>())
+					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
 			
 			List<PhotoModel> actualData = photoModelList.stream().sorted(actual).toList();
@@ -1415,207 +1417,41 @@ public class PhotoServiceImplTest {
 	@Nested
 	@Order(7)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-	class filteringByDirectionKbn {
-		@Test
-		@Order(1)
-		@DisplayName("正常系：抽出条件が未指定の場合")
-		void filteringByDirectionKbn_not_condition() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
-			Method filteringByDirectionKbn = PhotoServiceImpl.class.getDeclaredMethod("filteringByDirectionKbn", DirectionEnum.class, DirectionEnum.class);
-			filteringByDirectionKbn.setAccessible(true);
-			assertTrue((Boolean) filteringByDirectionKbn.invoke(photoServiceImpl, DirectionEnum.NONE, DirectionEnum.NONE));
-		}
-		
-		@Test
-		@Order(2)
-		@DisplayName("正常系：抽出条件が指定されていて、条件と一致の場合")
-		void filteringByDirectionKbn_match_condition() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
-			Method filteringByDirectionKbn = PhotoServiceImpl.class.getDeclaredMethod("filteringByDirectionKbn", DirectionEnum.class, DirectionEnum.class);
-			filteringByDirectionKbn.setAccessible(true);
-			assertTrue((Boolean) filteringByDirectionKbn.invoke(photoServiceImpl, DirectionEnum.VERTICAL, DirectionEnum.VERTICAL));
-		}
-		
-		@Test
-		@Order(3)
-		@DisplayName("正常系：抽出条件が指定されていて、条件と不一致の場合")
-		void filteringByDirectionKbn_mismatch_condition() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
-			Method filteringByDirectionKbn = PhotoServiceImpl.class.getDeclaredMethod("filteringByDirectionKbn", DirectionEnum.class, DirectionEnum.class);
-			filteringByDirectionKbn.setAccessible(true);
-			assertFalse((Boolean) filteringByDirectionKbn.invoke(photoServiceImpl, DirectionEnum.VERTICAL, DirectionEnum.HORIZONTAL));
-		}
-	}
-	
-	@Nested
-	@Order(8)
-	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-	class filteringByIsFavorite {
-		@Test
-		@Order(1)
-		@DisplayName("正常系：お気に入りのみが未指定の場合")
-		void filteringByIsFavorite_not_condition() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
-			Method filteringByIsFavorite = PhotoServiceImpl.class.getDeclaredMethod("filteringByIsFavorite", Boolean.class, Boolean.class);
-			filteringByIsFavorite.setAccessible(true);
-			assertTrue((Boolean) filteringByIsFavorite.invoke(photoServiceImpl, true, false));
-		}
-		
-		@Test
-		@Order(2)
-		@DisplayName("正常系：お気に入りのみが指定されていて、写真がお気に入りの場合")
-		void filteringByIsFavorite_match_condition() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
-			Method filteringByIsFavorite = PhotoServiceImpl.class.getDeclaredMethod("filteringByIsFavorite", Boolean.class, Boolean.class);
-			filteringByIsFavorite.setAccessible(true);
-			assertTrue((Boolean) filteringByIsFavorite.invoke(photoServiceImpl, true, true));
-		}
-		
-		@Test
-		@Order(3)
-		@DisplayName("正常系：お気に入りのみが指定されていて、写真がお気に入りでない場合")
-		void filteringByIsFavorite_mismatch_condition() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
-			Method filteringByIsFavorite = PhotoServiceImpl.class.getDeclaredMethod("filteringByIsFavorite", Boolean.class, Boolean.class);
-			filteringByIsFavorite.setAccessible(true);
-			assertFalse((Boolean) filteringByIsFavorite.invoke(photoServiceImpl, false, true));
-		}
-	}
-	
-	@Nested
-	@Order(9)
-	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-	class filteringByTag {
-		@Test
-		@Order(1)
-		@DisplayName("正常系：tagsが0件の場合")
-		void filteringByTag_tags_empty() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
-			Method filteringByTag = PhotoServiceImpl.class.getDeclaredMethod("filteringByTag", List.class, List.class);
-			filteringByTag.setAccessible(true);
-			assertTrue((Boolean) filteringByTag.invoke(photoServiceImpl, new ArrayList<PhotoTagModel>(), new ArrayList<String>()));
-		}
-		
-		@Test
-		@Order(2)
-		@DisplayName("正常系：tagsの1件目が''の場合")
-		void filteringByTag_tags_blank() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
-			Method filteringByTag = PhotoServiceImpl.class.getDeclaredMethod("filteringByTag", List.class, List.class);
-			filteringByTag.setAccessible(true);
-			
-			List<String> tags = new ArrayList<String>();
-			tags.add("");
-			assertTrue((Boolean) filteringByTag.invoke(photoServiceImpl, new ArrayList<PhotoTagModel>(), tags));
-		}
-		
-		@Test
-		@Order(3)
-		@DisplayName("正常系：tagsのすべてが含まれる場合")
-		void filteringByTag_contain_all_tag() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
-			Method filteringByTag = PhotoServiceImpl.class.getDeclaredMethod("filteringByTag", List.class, List.class);
-			filteringByTag.setAccessible(true);
-			
-			List<PhotoTagModel> photoTagModelList = new ArrayList<PhotoTagModel>();
-			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(1L))
-					.tagNo(new TagNo(1L))
-					.tagJapaneseName(new TagJapaneseName("太陽"))
-					.tagEnglishName(new TagEnglishName("sun"))
-					.build());
-			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(1L))
-					.tagNo(new TagNo(1L))
-					.tagJapaneseName(new TagJapaneseName("月"))
-					.tagEnglishName(new TagEnglishName("moon"))
-					.build());
-			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(1L))
-					.tagNo(new TagNo(1L))
-					.tagJapaneseName(new TagJapaneseName("海"))
-					.tagEnglishName(new TagEnglishName("sea"))
-					.build());
-
-			List<String> tags = new ArrayList<String>();
-			tags.add("太陽");
-			tags.add("sun");
-			tags.add("sea");
-			
-			assertTrue((Boolean) filteringByTag.invoke(photoServiceImpl, photoTagModelList, tags));
-		}
-		
-		@Test
-		@Order(4)
-		@DisplayName("正常系：tagsのすべてが含まれない場合")
-		void filteringByTag_not_contain_all_tag() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
-			Method filteringByTag = PhotoServiceImpl.class.getDeclaredMethod("filteringByTag", List.class, List.class);
-			filteringByTag.setAccessible(true);
-			
-			List<PhotoTagModel> photoTagModelList = new ArrayList<PhotoTagModel>();
-			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(1L))
-					.tagNo(new TagNo(1L))
-					.tagJapaneseName(new TagJapaneseName("太陽"))
-					.tagEnglishName(new TagEnglishName("sun"))
-					.build());
-			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(1L))
-					.tagNo(new TagNo(1L))
-					.tagJapaneseName(new TagJapaneseName("月"))
-					.tagEnglishName(new TagEnglishName("moon"))
-					.build());
-			photoTagModelList.add(PhotoTagModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(1L))
-					.tagNo(new TagNo(1L))
-					.tagJapaneseName(new TagJapaneseName("海"))
-					.tagEnglishName(new TagEnglishName("sea"))
-					.build());
-
-			List<String> tags = new ArrayList<String>();
-			tags.add("太陽");
-			tags.add("sum");
-			tags.add("wood");
-			
-			assertFalse((Boolean) filteringByTag.invoke(photoServiceImpl, photoTagModelList, tags));
-		}
-	}
-	
-	@Nested
-	@Order(10)
-	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	class registPhotoTags {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：photoTagModelListがnullの場合")
 		void registPhotoTags_photoTagModelList_is_null() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, RegistFailureException {
-			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", List.class, Long.class);
+			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", PhotoTagModelList.class, Long.class);
 			registPhotoTags.setAccessible(true);
-			
+
 			registPhotoTags.invoke(photoServiceImpl, null, null);
-			
+
 			verify(photoTagMstRepositoryImpl, times(0)).regist(any(PhotoTagModel.class));
 		}
-		
+
 		@Test
 		@Order(2)
 		@DisplayName("正常系：photoTagModelListがemptyの場合")
 		void registPhotoTags_photoTagModelList_is_empty() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, RegistFailureException {
-			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", List.class, Long.class);
+			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", PhotoTagModelList.class, Long.class);
 			registPhotoTags.setAccessible(true);
-			
-			registPhotoTags.invoke(photoServiceImpl, new ArrayList<PhotoTagModel>(), null);
-			
+
+			registPhotoTags.invoke(photoServiceImpl, PhotoTagModelList.empty(), null);
+
 			verify(photoTagMstRepositoryImpl, times(0)).regist(any(PhotoTagModel.class));
 		}
-		
+
 		@Test
 		@Order(3)
 		@DisplayName("正常系：newPhotoNoがnullの場合")
 		void registPhotoTags_newPhotoNo_is_null() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, RegistFailureException {
-			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", List.class, Long.class);
+			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", PhotoTagModelList.class, Long.class);
 			registPhotoTags.setAccessible(true);
-			
+
 			ArgumentCaptor<PhotoTagModel> photoTagModelCaptor = ArgumentCaptor.forClass(PhotoTagModel.class);
 			doNothing().when(photoTagMstRepositoryImpl).regist(photoTagModelCaptor.capture());
-			
+
 			List<PhotoTagModel> photoTagModelList = new ArrayList<PhotoTagModel>();
 			photoTagModelList.add(PhotoTagModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1631,11 +1467,11 @@ public class PhotoServiceImplTest {
 					.tagJapaneseName(new TagJapaneseName("海"))
 					.tagEnglishName(new TagEnglishName("sea"))
 					.build());
-			
-			registPhotoTags.invoke(photoServiceImpl, photoTagModelList, null);
-			
+
+			registPhotoTags.invoke(photoServiceImpl, PhotoTagModelList.of(photoTagModelList), null);
+
 			verify(photoTagMstRepositoryImpl, times(2)).regist(any(PhotoTagModel.class));
-			
+
 			List<PhotoTagModel> photoTagModelCaptureList = photoTagModelCaptor.getAllValues();
 			assertEquals(new AccountNo(1L), photoTagModelCaptureList.get(0).getAccountNo());
 			assertEquals(1L, photoTagModelCaptureList.get(0).getPhotoNo().value());
@@ -1648,17 +1484,17 @@ public class PhotoServiceImplTest {
 			assertEquals("海", photoTagModelCaptureList.get(1).getTagJapaneseName().value());
 			assertEquals("sea", photoTagModelCaptureList.get(1).getTagEnglishName().value());
 		}
-		
+
 		@Test
 		@Order(4)
 		@DisplayName("正常系：newPhotoNoがnullでない場合")
 		void registPhotoTags_newPhotoNo_is_not_null() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, RegistFailureException {
-			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", List.class, Long.class);
+			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", PhotoTagModelList.class, Long.class);
 			registPhotoTags.setAccessible(true);
-			
+
 			ArgumentCaptor<PhotoTagModel> photoTagModelCaptor = ArgumentCaptor.forClass(PhotoTagModel.class);
 			doNothing().when(photoTagMstRepositoryImpl).regist(photoTagModelCaptor.capture());
-			
+
 			List<PhotoTagModel> photoTagModelList = new ArrayList<PhotoTagModel>();
 			photoTagModelList.add(PhotoTagModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1674,11 +1510,11 @@ public class PhotoServiceImplTest {
 					.tagJapaneseName(new TagJapaneseName("海"))
 					.tagEnglishName(new TagEnglishName("sea"))
 					.build());
-			
-			registPhotoTags.invoke(photoServiceImpl, photoTagModelList, 3L);
-			
+
+			registPhotoTags.invoke(photoServiceImpl, PhotoTagModelList.of(photoTagModelList), 3L);
+
 			verify(photoTagMstRepositoryImpl, times(2)).regist(any(PhotoTagModel.class));
-			
+
 			List<PhotoTagModel> photoTagModelCaptureList = photoTagModelCaptor.getAllValues();
 			assertEquals(new AccountNo(1L), photoTagModelCaptureList.get(0).getAccountNo());
 			assertEquals(3L, photoTagModelCaptureList.get(0).getPhotoNo().value());
@@ -1691,16 +1527,16 @@ public class PhotoServiceImplTest {
 			assertEquals("海", photoTagModelCaptureList.get(1).getTagJapaneseName().value());
 			assertEquals("sea", photoTagModelCaptureList.get(1).getTagEnglishName().value());
 		}
-		
+
 		@Test
 		@Order(5)
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
 		void registPhotoTags_RegistFailureException() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, RegistFailureException {
-			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", List.class, Long.class);
+			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", PhotoTagModelList.class, Long.class);
 			registPhotoTags.setAccessible(true);
-			
+
 			doThrow(new RegistFailureException(ErrorEnum.FAIL_TO_REGIST_PHOTO_TAG)).when(photoTagMstRepositoryImpl).regist(any(PhotoTagModel.class));
-			
+
 			List<PhotoTagModel> photoTagModelList = new ArrayList<PhotoTagModel>();
 			photoTagModelList.add(PhotoTagModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1716,9 +1552,9 @@ public class PhotoServiceImplTest {
 					.tagJapaneseName(new TagJapaneseName("海"))
 					.tagEnglishName(new TagEnglishName("sea"))
 					.build());
-			
+
 			try {
-				registPhotoTags.invoke(photoServiceImpl, photoTagModelList, null);
+				registPhotoTags.invoke(photoServiceImpl, PhotoTagModelList.of(photoTagModelList), null);
 				assertTrue(false);
 			}
 			catch(InvocationTargetException e) {

--- a/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
@@ -61,8 +61,10 @@ import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.FileModel;
 import com.web.gallery.model.PhotoDeleteModel;
+import com.web.gallery.model.PhotoDeleteModelList;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
+import com.web.gallery.model.PhotoDetailModelList;
 import com.web.gallery.model.PhotoFavoriteDeleteModel;
 import com.web.gallery.model.PhotoGetModel;
 import com.web.gallery.model.PhotoListGetModel;
@@ -568,7 +570,7 @@ public class PhotoServiceImplTest {
 		@DisplayName("正常系：photoDetailModelListがemptyの場合、終了")
 		void savePhotos_photoDetailModelList_is_empty() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
-			Long actual = photoServiceImpl.savePhotos("aaaaaaaa", photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos("aaaaaaaa", PhotoDetailModelList.of(photoDetailModelList));
 			assertNull(actual);
 			verify(photoMstRepositoryImpl, times(0)).getNewPhotoNo(any(Long.class));
 			verify(photoMstRepositoryImpl, times(0)).isExistPhoto(any(PhotoDetailModel.class));
@@ -605,7 +607,7 @@ public class PhotoServiceImplTest {
 			doReturn(false).when(photoMstRepositoryImpl).isExistPhoto(photoDetailModel2);
 			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel2, filePath + accountId + "/DSC222.jpg", 6L);
 			
-			Long actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
 
 			assertEquals(5, actual);
 			verify(photoMstRepositoryImpl, times(2)).isExistPhoto(any(PhotoDetailModel.class));
@@ -661,7 +663,7 @@ public class PhotoServiceImplTest {
 			photoDetailModelList.add(photoDetailModel2);
 			doNothing().when(photoMstRepositoryImpl).update(photoDetailModel2);
 			
-			Long actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
 
 			assertEquals(3, actual);
 			verify(photoMstRepositoryImpl, times(0)).isExistPhoto(any(PhotoDetailModel.class));
@@ -715,7 +717,7 @@ public class PhotoServiceImplTest {
 			photoDetailModelList.add(photoDetailModel2);
 			doNothing().when(photoMstRepositoryImpl).update(photoDetailModel2);
 			
-			Long actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
 
 			assertEquals(3, actual);
 			verify(photoMstRepositoryImpl, times(1)).isExistPhoto(any(PhotoDetailModel.class));
@@ -758,7 +760,7 @@ public class PhotoServiceImplTest {
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			assertThrows(FileDuplicateException.class, () -> photoServiceImpl.savePhotos(accountId, photoDetailModelList));
+			assertThrows(FileDuplicateException.class, () -> photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList)));
 			
 			verify(photoMstRepositoryImpl, times(1)).isExistPhoto(any(PhotoDetailModel.class));
 			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
@@ -789,7 +791,7 @@ public class PhotoServiceImplTest {
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			assertThrows(RegistFailureException.class, () -> photoServiceImpl.savePhotos(accountId, photoDetailModelList));
+			assertThrows(RegistFailureException.class, () -> photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList)));
 			
 			verify(photoMstRepositoryImpl, times(1)).isExistPhoto(any(PhotoDetailModel.class));
 			verify(photoMstRepositoryImpl, times(1)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
@@ -823,7 +825,7 @@ public class PhotoServiceImplTest {
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			assertThrows(RegistFailureException.class, () -> photoServiceImpl.savePhotos(accountId, photoDetailModelList));
+			assertThrows(RegistFailureException.class, () -> photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList)));
 			
 			verify(photoMstRepositoryImpl, times(1)).isExistPhoto(any(PhotoDetailModel.class));
 			verify(photoMstRepositoryImpl, times(1)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
@@ -866,7 +868,7 @@ public class PhotoServiceImplTest {
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			assertThrows(RegistFailureException.class, () -> photoServiceImpl.savePhotos(accountId, photoDetailModelList));
+			assertThrows(RegistFailureException.class, () -> photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList)));
 			
 			verify(photoMstRepositoryImpl, times(0)).isExistPhoto(any(PhotoDetailModel.class));
 			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
@@ -903,7 +905,7 @@ public class PhotoServiceImplTest {
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			assertThrows(UpdateFailureException.class, () -> photoServiceImpl.savePhotos(accountId, photoDetailModelList));
+			assertThrows(UpdateFailureException.class, () -> photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList)));
 			
 			verify(photoMstRepositoryImpl, times(0)).isExistPhoto(any(PhotoDetailModel.class));
 			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
@@ -924,7 +926,7 @@ public class PhotoServiceImplTest {
 		void deletePhotos_photoDeleteModelList_empty() throws UpdateFailureException {
 			doReturn("https://localhost:8080/image/").when(photoConfig).getOutputPath();
 			
-			photoServiceImpl.deletePhotos("aaaaaaaa", new ArrayList<PhotoDeleteModel>());
+			photoServiceImpl.deletePhotos("aaaaaaaa", PhotoDeleteModelList.empty());
 			verify(photoFavoriteRepositoryImpl, times(0)).clear(any(PhotoFavoriteDeleteModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).clear(any(PhotoTagDeleteModel.class));
 			verify(photoMstRepositoryImpl, times(0)).delete(any(PhotoDeleteModel.class));
@@ -961,7 +963,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("DSC222.jpg"))
 					.build());
 			
-			photoServiceImpl.deletePhotos("aaaaaaaa", photoDeleteModelList);
+			photoServiceImpl.deletePhotos("aaaaaaaa", PhotoDeleteModelList.of(photoDeleteModelList));
 			verify(photoFavoriteRepositoryImpl, times(2)).clear(any(PhotoFavoriteDeleteModel.class));
 			verify(photoTagMstRepositoryImpl, times(2)).clear(any(PhotoTagDeleteModel.class));
 			verify(photoMstRepositoryImpl, times(2)).delete(any(PhotoDeleteModel.class));
@@ -1011,7 +1013,7 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC111.jpg"))
 					.build());
 			
-			assertThrows(UpdateFailureException.class, () -> photoServiceImpl.deletePhotos("aaaaaaaa", photoDeleteModelList));
+			assertThrows(UpdateFailureException.class, () -> photoServiceImpl.deletePhotos("aaaaaaaa", PhotoDeleteModelList.of(photoDeleteModelList)));
 
 			verify(photoFavoriteRepositoryImpl, times(1)).clear(any(PhotoFavoriteDeleteModel.class));
 			verify(photoMstRepositoryImpl, times(1)).delete(any(PhotoDeleteModel.class));

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/AccountServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/AccountServiceImplIntegrationTest.java
@@ -52,6 +52,7 @@ import com.web.gallery.enumuration.SexEnum;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.AccountModel;
+import com.web.gallery.model.AccountModelList;
 import com.web.gallery.service.impl.AccountServiceImpl;
 
 @ActiveProfiles("test")
@@ -311,7 +312,7 @@ public class AccountServiceImplIntegrationTest {
 		@Sql("/sql/common/cleanup.sql")
 		@Sql("/sql/service/AccountServiceImplIntegrationTest.sql")
 		void getAccountList_found() {
-			List<AccountModel> actual = accountServiceImpl.getAccountList();
+			AccountModelList actual = accountServiceImpl.getAccountList();
 			
 			assertEquals(11, actual.size());
 			assertEquals("aaaaaaaa", actual.get(0).getAccountId().value());
@@ -331,7 +332,7 @@ public class AccountServiceImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが存在しない場合")
 		void getAccountList_not_found() {
-			List<AccountModel> actual = accountServiceImpl.getAccountList();
+			AccountModelList actual = accountServiceImpl.getAccountList();
 			assertEquals(0, actual.size());
 		}
 	}

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/KbnMstServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/KbnMstServiceImplIntegrationTest.java
@@ -2,9 +2,6 @@ package com.web.gallery.service.impl.integration;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Comparator;
-import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
@@ -19,7 +16,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.web.gallery.domain.common.KbnCode;
-import com.web.gallery.model.KbnMstModel;
+import com.web.gallery.model.KbnMstModelList;
 import com.web.gallery.service.impl.KbnMstServiceImpl;
 
 @ActiveProfiles("test")
@@ -39,10 +36,10 @@ public class KbnMstServiceImplIntegrationTest {
 		@Sql("/sql/common/cleanup.sql")
 		@Sql("/sql/service/KbnMstServiceImplIntegrationTest.sql")
 		void getPrefectureList_found() {
-			List<KbnMstModel> actual = kbnMstServiceImpl.getPrefectureList();
+			KbnMstModelList actual = kbnMstServiceImpl.getPrefectureList();
 			assertEquals(47, actual.size());
-			
-			List<KbnMstModel> actualSorded = actual.stream().sorted(Comparator.comparing(m -> m.getSortOrder().value())).toList();
+
+			KbnMstModelList actualSorded = actual.sortBySortOrder();
 			assertEquals(new KbnCode("Hokkaido"), actualSorded.get(0).getKbnCode());
 			assertEquals(new KbnCode("Aomori"), actualSorded.get(1).getKbnCode());
 			assertEquals(new KbnCode("Iwate"), actualSorded.get(2).getKbnCode());
@@ -97,7 +94,7 @@ public class KbnMstServiceImplIntegrationTest {
 		@DisplayName("正常系：区分マスタが存在しない場合")
 		@Sql("/sql/common/cleanup.sql")
 		void getPrefectureList_not_found() {
-			List<KbnMstModel> actual = kbnMstServiceImpl.getPrefectureList();
+			KbnMstModelList actual = kbnMstServiceImpl.getPrefectureList();
 			assertEquals(0, actual.size());
 		}
 	}

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoServiceImplIntegrationTest.java
@@ -66,8 +66,9 @@ import com.web.gallery.model.PhotoDeleteModel;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
 import com.web.gallery.model.PhotoListGetModel;
-import com.web.gallery.model.PhotoModel;
+import com.web.gallery.model.PhotoModelList;
 import com.web.gallery.model.PhotoTagModel;
+import com.web.gallery.model.PhotoTagModelList;
 import com.web.gallery.service.impl.PhotoServiceImpl;
 
 @ActiveProfiles("test")
@@ -101,8 +102,8 @@ public class PhotoServiceImplIntegrationTest {
 					.sortBy(SortPhotoEnum.PHOTO_AT)
 					.build();
 			
-			List<PhotoModel> actual = photoServiceImpl.getPhotoList(photoListGetModel);
-			assertEquals(new ArrayList<PhotoModel>(), actual);
+			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
+			assertTrue(actual.isEmpty());
 		}
 		
 		@Test
@@ -120,7 +121,7 @@ public class PhotoServiceImplIntegrationTest {
 					.sortBy(SortPhotoEnum.PHOTO_AT)
 					.build();
 			
-			List<PhotoModel> actual = photoServiceImpl.getPhotoList(photoListGetModel);
+			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
 			
 			// List<PhotoModel>の数チェック
 			assertEquals(10, actual.size());
@@ -163,7 +164,7 @@ public class PhotoServiceImplIntegrationTest {
 					.sortBy(SortPhotoEnum.FAVORITE)
 					.build();
 			
-			List<PhotoModel> actual = photoServiceImpl.getPhotoList(photoListGetModel);
+			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
 			
 			// List<PhotoModel>の数チェック
 			assertEquals(10, actual.size());
@@ -214,7 +215,7 @@ public class PhotoServiceImplIntegrationTest {
 					.sortBy(SortPhotoEnum.SEASON)
 					.build();
 			
-			List<PhotoModel> actual = photoServiceImpl.getPhotoList(photoListGetModel);
+			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
 			
 			// List<PhotoModel>の数チェック
 			assertEquals(10, actual.size());
@@ -257,7 +258,7 @@ public class PhotoServiceImplIntegrationTest {
 					.sortBy(SortPhotoEnum.PHOTO_AT)
 					.build();
 			
-			List<PhotoModel> actual = photoServiceImpl.getPhotoList(photoListGetModel);
+			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
 			
 			// List<PhotoModel>の数チェック
 			assertEquals(3, actual.size());
@@ -293,7 +294,7 @@ public class PhotoServiceImplIntegrationTest {
 					.sortBy(SortPhotoEnum.PHOTO_AT)
 					.build();
 			
-			List<PhotoModel> actual = photoServiceImpl.getPhotoList(photoListGetModel);
+			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
 			
 			// List<PhotoModel>の数チェック
 			assertEquals(2, actual.size());
@@ -338,7 +339,7 @@ public class PhotoServiceImplIntegrationTest {
 					.sortBy(SortPhotoEnum.PHOTO_AT)
 					.build();
 			
-			List<PhotoModel> actual = photoServiceImpl.getPhotoList(photoListGetModel);
+			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
 			
 			// List<PhotoModel>の数チェック
 			assertEquals(1, actual.size());
@@ -463,7 +464,7 @@ public class PhotoServiceImplIntegrationTest {
 					.fValue(new FValue(BigDecimal.valueOf(2.8)))
 					.shutterSpeed(new ShutterSpeed(BigDecimal.valueOf(0.01)))
 					.iso(new Iso(100))
-					.photoTagModelList(photoTagModelList)
+					.photoTagModelList(PhotoTagModelList.of(photoTagModelList))
 					.build();
 		}
 		
@@ -516,7 +517,7 @@ public class PhotoServiceImplIntegrationTest {
 					.fValue(new FValue(BigDecimal.valueOf(2.8)))
 					.shutterSpeed(new ShutterSpeed(BigDecimal.valueOf(0.01)))
 					.iso(new Iso(100))
-					.photoTagModelList(photoTagModelList)
+					.photoTagModelList(PhotoTagModelList.of(photoTagModelList))
 					.build();
 		}
 		

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoServiceImplIntegrationTest.java
@@ -63,8 +63,10 @@ import com.web.gallery.exception.PhotoNotFoundException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.PhotoDeleteModel;
+import com.web.gallery.model.PhotoDeleteModelList;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
+import com.web.gallery.model.PhotoDetailModelList;
 import com.web.gallery.model.PhotoListGetModel;
 import com.web.gallery.model.PhotoModelList;
 import com.web.gallery.model.PhotoTagModel;
@@ -602,7 +604,7 @@ public class PhotoServiceImplIntegrationTest {
 			String accountId = "aaaaaaaa";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			List<PhotoMst> beforeSaveData = getPhotoMstData(accountId);
-			Long actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
 			assertNull(actual);
 			List<PhotoMst> afterData = getPhotoMstData(accountId);
 			assertEquals(beforeSaveData.size(), afterData.size());
@@ -622,7 +624,7 @@ public class PhotoServiceImplIntegrationTest {
 			PhotoDetailModel photoDetailModel2 = createNewPhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			Long actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
 
 			assertEquals(11, actual);
 			List<PhotoMst> actualData = getPhotoMstData(accountId).stream().filter(photoMst -> photoMst.getPhotoNo().value() > 10).toList();
@@ -687,7 +689,7 @@ public class PhotoServiceImplIntegrationTest {
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			Long actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
 
 			assertEquals(3, actual);
 			List<PhotoMst> actualData1 = getPhotoMstData(accountId).stream().filter(photoMst -> photoMst.getPhotoNo().value()==2).toList();
@@ -753,7 +755,7 @@ public class PhotoServiceImplIntegrationTest {
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			Long actual = photoServiceImpl.savePhotos(accountId, photoDetailModelList);
+			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
 
 			assertEquals(3, actual);
 			List<PhotoMst> actualData = getPhotoMstData(accountId).stream().filter(photoMst -> photoMst.getPhotoNo().value() > 10).toList();
@@ -838,7 +840,7 @@ public class PhotoServiceImplIntegrationTest {
 			PhotoDetailModel photoDetailModel2 = createNewPhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			assertThrows(FileDuplicateException.class, () -> photoServiceImpl.savePhotos(accountId, photoDetailModelList));
+			assertThrows(FileDuplicateException.class, () -> photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList)));
 		}
 	}
 	
@@ -852,7 +854,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：photoDeleteModelListが0件の場合、終了")
 		void deletePhotos_photoDeleteModelList_empty() throws UpdateFailureException {
-			photoServiceImpl.deletePhotos("aaaaaaaa", new ArrayList<PhotoDeleteModel>());
+			photoServiceImpl.deletePhotos("aaaaaaaa", PhotoDeleteModelList.empty());
 			
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no = (SELECT account_no FROM common.account where account_id='aaaaaaaa')", (rs, rowNum) ->
@@ -896,7 +898,7 @@ public class PhotoServiceImplIntegrationTest {
 					.imageFilePath(new ImageFilePath("DSC12.jpg"))
 					.build());
 			
-			photoServiceImpl.deletePhotos("aaaaaaaa", photoDeleteModelList);
+			photoServiceImpl.deletePhotos("aaaaaaaa", PhotoDeleteModelList.of(photoDeleteModelList));
 			
 			List<PhotoMst> actualPhotoMstData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no=1 and photo_no in (1, 2)", (rs, rowNum) ->
@@ -1008,7 +1010,7 @@ public class PhotoServiceImplIntegrationTest {
 					.imageFilePath(new ImageFilePath("DSC99.jpg"))
 					.build());
 			
-			assertThrows(UpdateFailureException.class, () -> photoServiceImpl.deletePhotos("aaaaaaaa", photoDeleteModelList));
+			assertThrows(UpdateFailureException.class, () -> photoServiceImpl.deletePhotos("aaaaaaaa", PhotoDeleteModelList.of(photoDeleteModelList)));
 		}
 	}
 	


### PR DESCRIPTION
# 概要

## 背景

List<AccountModel>・List<KbnMstModel>・List<PhotoModel>・List<PhotoTagModel>という
生のリスト型がRepository/Service/Controller層に散在し、ソートやフィルタリングの
ロジックがService層・Helper層に個別に実装されていた。

## 変更内容

- AccountModelList・KbnMstModelList・PhotoModelList・PhotoTagModelListの4つの
  コレクションクラスを新設し、生のList<T>を置き換えた
- 各クラスにソート機能（sortByAccountId等）・フィルター機能（filterByIsDeleted等）・
  ファクトリメソッド（of/from/empty）を実装
- PhotoServiceImplに散在していた写真の向き・お気に入り・タグによるフィルタリング
  ロジックをPhotoModelList/PhotoTagModelListに移動
- KbnHelperのグルーピングロジックをKbnMstModelListのソート・フィルターメソッドで再実装
- .claude/rules/model.mdにXxxModelListの命名規則・設計規約を追記
- 既存の単体テスト・統合テストを新APIに合わせて修正し、移動したロジックの
  テストカバレッジをmodel/配下の新規テストで維持

# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認

# 懸念事項

backendのみの変更のため、frontendの起動確認は未実施。