### PR TITLE
refactor: AccountServiceImplのMapper直接呼び出しをRepository経由に修正

### DIFF
--- a/backend/src/main/java/com/web/gallery/repository/PhotoFavoriteRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/PhotoFavoriteRepository.java
@@ -1,5 +1,6 @@
 package com.web.gallery.repository;
 
+import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.PhotoFavoriteDeleteModel;
@@ -27,8 +28,22 @@ public interface PhotoFavoriteRepository {
 	
 	/**
 	 * 該当写真の写真お気に入りを全件削除する
-	 * 
+	 *
 	 * @param	favoriteDeleteModel	{@link PhotoFavoriteDeleteModel}
 	 */
 	void clear(PhotoFavoriteDeleteModel favoriteDeleteModel);
+
+	/**
+	 * アカウント番号で自分が登録した写真お気に入りを全件削除する
+	 *
+	 * @param	accountNo	アカウント番号
+	 */
+	void deleteByAccountNo(AccountNo accountNo);
+
+	/**
+	 * アカウント番号で自分の写真に対する他人の写真お気に入りを全件削除する
+	 *
+	 * @param	favoritePhotoAccountNo	お気に入り写真アカウント番号
+	 */
+	void deleteByFavoritePhotoAccountNo(AccountNo favoritePhotoAccountNo);
 }

--- a/backend/src/main/java/com/web/gallery/repository/PhotoMstRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/PhotoMstRepository.java
@@ -1,5 +1,6 @@
 package com.web.gallery.repository;
 
+import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.PhotoDeleteModel;
@@ -53,9 +54,16 @@ public interface PhotoMstRepository {
 	
 	/**
 	 * アカウントに登録されている写真の件数を取得する
-	 * 
+	 *
 	 * @param	accountNo	アカウント番号
 	 * @return				登録件数
 	 */
 	Integer count(Long accountNo);
+
+	/**
+	 * アカウント番号で写真マスタを物理削除する
+	 *
+	 * @param	accountNo	アカウント番号
+	 */
+	void deleteByAccountNo(AccountNo accountNo);
 }

--- a/backend/src/main/java/com/web/gallery/repository/PhotoTagMstRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/PhotoTagMstRepository.java
@@ -1,5 +1,6 @@
 package com.web.gallery.repository;
 
+import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.model.PhotoTagDeleteModel;
 import com.web.gallery.model.PhotoTagModel;
@@ -18,8 +19,15 @@ public interface PhotoTagMstRepository {
 	
 	/**
 	 * 該当写真の写真タグを全件削除する
-	 * 
+	 *
 	 * @param	photoTagDeleteModel	{@link PhotoTagDeleteModel}
 	 */
 	void clear(PhotoTagDeleteModel photoTagDeleteModel);
+
+	/**
+	 * アカウント番号で写真タグを全件削除する
+	 *
+	 * @param	accountNo	アカウント番号
+	 */
+	void deleteByAccountNo(AccountNo accountNo);
 }

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoFavoriteRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoFavoriteRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.web.gallery.repository.impl;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Repository;
 
+import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.entity.PhotoFavorite;
 import com.web.gallery.enumuration.ErrorEnum;
 import com.web.gallery.exception.RegistFailureException;
@@ -72,5 +73,25 @@ public class PhotoFavoriteRepositoryImpl implements PhotoFavoriteRepository{
 	public void clear(PhotoFavoriteDeleteModel favoriteDeleteModel) {
 		PhotoFavorite photoFavorite = PhotoFavorite.fromForClear(favoriteDeleteModel);
 		photoFavoriteMapper.delete(photoFavorite);
+	}
+
+	/**
+	 * アカウント番号で自分が登録した写真お気に入りを全件削除する
+	 *
+	 * @param	accountNo	アカウント番号
+	 */
+	@Override
+	public void deleteByAccountNo(AccountNo accountNo) {
+		photoFavoriteMapper.delete(PhotoFavorite.conditionByAccountNo(accountNo));
+	}
+
+	/**
+	 * アカウント番号で自分の写真に対する他人の写真お気に入りを全件削除する
+	 *
+	 * @param	favoritePhotoAccountNo	お気に入り写真アカウント番号
+	 */
+	@Override
+	public void deleteByFavoritePhotoAccountNo(AccountNo favoritePhotoAccountNo) {
+		photoFavoriteMapper.delete(PhotoFavorite.conditionByFavoritePhotoAccountNo(favoritePhotoAccountNo));
 	}
 }

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Repository;
 
+import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.entity.PhotoMst;
 import com.web.gallery.enumuration.ErrorEnum;
 import com.web.gallery.exception.RegistFailureException;
@@ -114,5 +115,15 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	@Override
 	public Integer count(Long accountNo) {
 		return photoMstMapper.count(PhotoMst.conditionForCount(accountNo));
+	}
+
+	/**
+	 * アカウント番号で写真マスタを物理削除する
+	 *
+	 * @param	accountNo	アカウント番号
+	 */
+	@Override
+	public void deleteByAccountNo(AccountNo accountNo) {
+		photoMstMapper.delete(PhotoMst.conditionByAccountNo(accountNo));
 	}
 }

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoTagMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoTagMstRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.web.gallery.repository.impl;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Repository;
 
+import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.entity.PhotoTagMst;
 import com.web.gallery.enumuration.ErrorEnum;
 import com.web.gallery.exception.RegistFailureException;
@@ -53,5 +54,15 @@ public class PhotoTagMstRepositoryImpl implements PhotoTagMstRepository {
 	public void clear(PhotoTagDeleteModel photoTagDeleteModel) {
 		PhotoTagMst photoTagMst = PhotoTagMst.from(photoTagDeleteModel);
 		photoTagMstMapper.delete(photoTagMst);
+	}
+
+	/**
+	 * アカウント番号で写真タグを全件削除する
+	 *
+	 * @param	accountNo	アカウント番号
+	 */
+	@Override
+	public void deleteByAccountNo(AccountNo accountNo) {
+		photoTagMstMapper.delete(PhotoTagMst.conditionByAccountNo(accountNo));
 	}
 }

--- a/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
@@ -16,18 +16,15 @@ import com.web.gallery.config.LoginConfig;
 import com.web.gallery.config.PhotoConfig;
 import com.web.gallery.constant.MessageConst;
 import com.web.gallery.domain.account.AccountNo;
-import com.web.gallery.entity.PhotoFavorite;
-import com.web.gallery.entity.PhotoMst;
-import com.web.gallery.entity.PhotoTagMst;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
-import com.web.gallery.mapper.PhotoFavoriteMapper;
-import com.web.gallery.mapper.PhotoMstMapper;
-import com.web.gallery.mapper.PhotoTagMstMapper;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.model.AccountModelList;
 import com.web.gallery.repository.AccountRepository;
 import com.web.gallery.repository.FileRepository;
+import com.web.gallery.repository.PhotoFavoriteRepository;
+import com.web.gallery.repository.PhotoMstRepository;
+import com.web.gallery.repository.PhotoTagMstRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,9 +39,9 @@ public class AccountServiceImpl implements UserDetailsService {
 
 	private final AccountRepository accountRepository;
 	private final FileRepository fileRepository;
-	private final PhotoFavoriteMapper photoFavoriteMapper;
-	private final PhotoTagMstMapper photoTagMstMapper;
-	private final PhotoMstMapper photoMstMapper;
+	private final PhotoFavoriteRepository photoFavoriteRepository;
+	private final PhotoTagMstRepository photoTagMstRepository;
+	private final PhotoMstRepository photoMstRepository;
 	private final LoginConfig loginConfig;
 	private final PhotoConfig photoConfig;
 
@@ -159,16 +156,16 @@ public class AccountServiceImpl implements UserDetailsService {
 		AccountNo accountNoVo = new AccountNo(accountNo);
 
 		// 自分が登録したお気に入りを削除
-		photoFavoriteMapper.delete(PhotoFavorite.conditionByAccountNo(accountNoVo));
+		photoFavoriteRepository.deleteByAccountNo(accountNoVo);
 
 		// 自分の写真に対する他人のお気に入りを削除
-		photoFavoriteMapper.delete(PhotoFavorite.conditionByFavoritePhotoAccountNo(accountNoVo));
+		photoFavoriteRepository.deleteByFavoritePhotoAccountNo(accountNoVo);
 
 		// 写真タグを削除
-		photoTagMstMapper.delete(PhotoTagMst.conditionByAccountNo(accountNoVo));
+		photoTagMstRepository.deleteByAccountNo(accountNoVo);
 
 		// 写真マスタを物理削除
-		photoMstMapper.delete(PhotoMst.conditionByAccountNo(accountNoVo));
+		photoMstRepository.deleteByAccountNo(accountNoVo);
 
 		// アカウントを物理削除
 		accountRepository.delete(accountNo);

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoFavoriteRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoFavoriteRepositoryImplTest.java
@@ -170,4 +170,46 @@ public class PhotoFavoriteRepositoryImplTest {
 			assertNull(photoFavorite.getCreatedAt());
 		}
 	}
+
+	@Nested
+	@Order(4)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class deleteByAccountNo {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウント番号で自分が登録したお気に入りを全件削除する")
+		void deleteByAccountNo_success() {
+			ArgumentCaptor<PhotoFavorite> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavorite.class);
+			doReturn(1).when(photoFavoriteMapper).delete(photoFavoriteCaptor.capture());
+
+			photoFavoriteRepositoryImpl.deleteByAccountNo(new AccountNo(1L));
+
+			verify(photoFavoriteMapper).delete(any(PhotoFavorite.class));
+			PhotoFavorite photoFavorite = photoFavoriteCaptor.getValue();
+			assertEquals(new AccountNo(1L), photoFavorite.getAccountNo());
+			assertNull(photoFavorite.getFavoritePhotoAccountNo());
+			assertNull(photoFavorite.getFavoritePhotoNo());
+		}
+	}
+
+	@Nested
+	@Order(5)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class deleteByFavoritePhotoAccountNo {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウント番号で自分の写真に対する他人のお気に入りを全件削除する")
+		void deleteByFavoritePhotoAccountNo_success() {
+			ArgumentCaptor<PhotoFavorite> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavorite.class);
+			doReturn(1).when(photoFavoriteMapper).delete(photoFavoriteCaptor.capture());
+
+			photoFavoriteRepositoryImpl.deleteByFavoritePhotoAccountNo(new AccountNo(1L));
+
+			verify(photoFavoriteMapper).delete(any(PhotoFavorite.class));
+			PhotoFavorite photoFavorite = photoFavoriteCaptor.getValue();
+			assertNull(photoFavorite.getAccountNo());
+			assertEquals(new AccountNo(1L), photoFavorite.getFavoritePhotoAccountNo());
+			assertNull(photoFavorite.getFavoritePhotoNo());
+		}
+	}
 }

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoMstRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoMstRepositoryImplTest.java
@@ -625,4 +625,24 @@ public class PhotoMstRepositoryImplTest {
 			assertNull(photoMst.getIso());
 		}
 	}
+
+	@Nested
+	@Order(7)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class deleteByAccountNo {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウント番号で写真マスタを物理削除する")
+		void deleteByAccountNo_success() {
+			ArgumentCaptor<PhotoMst> photoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
+			doReturn(1).when(photoMstMapper).delete(photoMstCaptor.capture());
+
+			photoMstRepositoryImpl.deleteByAccountNo(new AccountNo(1L));
+
+			verify(photoMstMapper).delete(any(PhotoMst.class));
+			PhotoMst photoMst = photoMstCaptor.getValue();
+			assertEquals(new AccountNo(1L), photoMst.getAccountNo());
+			assertNull(photoMst.getPhotoNo());
+		}
+	}
 }

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoTagMstRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoTagMstRepositoryImplTest.java
@@ -129,4 +129,25 @@ public class PhotoTagMstRepositoryImplTest {
 			assertNull(photoTagMst.getTagEnglishName());
 		}
 	}
+
+	@Nested
+	@Order(3)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class deleteByAccountNo {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウント番号で写真タグを全件削除する")
+		void deleteByAccountNo_success() {
+			ArgumentCaptor<PhotoTagMst> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMst.class);
+			doReturn(1).when(photoTagMstMapper).delete(photoTagMstCaptor.capture());
+
+			photoTagMstRepositoryImpl.deleteByAccountNo(new AccountNo(1L));
+
+			verify(photoTagMstMapper).delete(any(PhotoTagMst.class));
+			PhotoTagMst photoTagMst = photoTagMstCaptor.getValue();
+			assertEquals(new AccountNo(1L), photoTagMst.getAccountNo());
+			assertNull(photoTagMst.getPhotoNo());
+			assertNull(photoTagMst.getTagNo());
+		}
+	}
 }

--- a/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
@@ -41,17 +41,14 @@ import com.web.gallery.domain.account.LoginFailureCount;
 import com.web.gallery.domain.account.Password;
 import com.web.gallery.domain.account.ResidentPrefectureKbnCode;
 import com.web.gallery.domain.common.IsDeleted;
-import com.web.gallery.entity.PhotoFavorite;
-import com.web.gallery.entity.PhotoMst;
-import com.web.gallery.entity.PhotoTagMst;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
-import com.web.gallery.mapper.PhotoFavoriteMapper;
-import com.web.gallery.mapper.PhotoMstMapper;
-import com.web.gallery.mapper.PhotoTagMstMapper;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.model.AccountModelList;
 import com.web.gallery.repository.FileRepository;
+import com.web.gallery.repository.PhotoFavoriteRepository;
+import com.web.gallery.repository.PhotoMstRepository;
+import com.web.gallery.repository.PhotoTagMstRepository;
 import com.web.gallery.repository.impl.AccountRepositoryImpl;
 
 @ActiveProfiles("test")
@@ -67,13 +64,13 @@ public class AccountServiceImplTest {
 	private FileRepository fileRepository;
 
 	@Mock
-	private PhotoFavoriteMapper photoFavoriteMapper;
+	private PhotoFavoriteRepository photoFavoriteRepository;
 
 	@Mock
-	private PhotoTagMstMapper photoTagMstMapper;
+	private PhotoTagMstRepository photoTagMstRepository;
 
 	@Mock
-	private PhotoMstMapper photoMstMapper;
+	private PhotoMstRepository photoMstRepository;
 
 	@Mock
 	private AccountPrincipal accountPrincipal;
@@ -370,29 +367,26 @@ public class AccountServiceImplTest {
 			Long accountNo = 1L;
 			String accountId = "aaaaaaaa";
 
-			ArgumentCaptor<PhotoFavorite> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavorite.class);
-			doReturn(1).when(photoFavoriteMapper).delete(any(PhotoFavorite.class));
-			doReturn(1).when(photoTagMstMapper).delete(any(PhotoTagMst.class));
-			doReturn(1).when(photoMstMapper).delete(any(PhotoMst.class));
+			doNothing().when(photoFavoriteRepository).deleteByAccountNo(any(AccountNo.class));
+			doNothing().when(photoFavoriteRepository).deleteByFavoritePhotoAccountNo(any(AccountNo.class));
+			doNothing().when(photoTagMstRepository).deleteByAccountNo(any(AccountNo.class));
+			doNothing().when(photoMstRepository).deleteByAccountNo(any(AccountNo.class));
 			doNothing().when(accountRepositoryImpl).delete(accountNo);
 			doReturn("/output/").when(photoConfig).getOutputPath();
 			doNothing().when(fileRepository).delete("/output/" + accountId + "/");
 
 			accountServiceImpl.deleteAccount(accountNo, accountId);
 
-			verify(photoFavoriteMapper, times(2)).delete(photoFavoriteCaptor.capture());
-			List<PhotoFavorite> capturedFavorites = photoFavoriteCaptor.getAllValues();
+			ArgumentCaptor<AccountNo> favoriteCaptor = ArgumentCaptor.forClass(AccountNo.class);
+			verify(photoFavoriteRepository, times(1)).deleteByAccountNo(favoriteCaptor.capture());
+			assertEquals(new AccountNo(accountNo), favoriteCaptor.getValue());
 
-			// 1回目：自分が登録したお気に入りの削除（accountNoで指定）
-			assertEquals(new AccountNo(accountNo), capturedFavorites.get(0).getAccountNo());
-			assertNull(capturedFavorites.get(0).getFavoritePhotoAccountNo());
+			ArgumentCaptor<AccountNo> favoritePhotoCaptor = ArgumentCaptor.forClass(AccountNo.class);
+			verify(photoFavoriteRepository, times(1)).deleteByFavoritePhotoAccountNo(favoritePhotoCaptor.capture());
+			assertEquals(new AccountNo(accountNo), favoritePhotoCaptor.getValue());
 
-			// 2回目：自分の写真に対する他人のお気に入りの削除（favoritePhotoAccountNoで指定）
-			assertNull(capturedFavorites.get(1).getAccountNo());
-			assertEquals(new AccountNo(accountNo), capturedFavorites.get(1).getFavoritePhotoAccountNo());
-
-			verify(photoTagMstMapper, times(1)).delete(any(PhotoTagMst.class));
-			verify(photoMstMapper, times(1)).delete(any(PhotoMst.class));
+			verify(photoTagMstRepository, times(1)).deleteByAccountNo(new AccountNo(accountNo));
+			verify(photoMstRepository, times(1)).deleteByAccountNo(new AccountNo(accountNo));
 			verify(accountRepositoryImpl, times(1)).delete(accountNo);
 			verify(fileRepository, times(1)).delete("/output/" + accountId + "/");
 		}


### PR DESCRIPTION
# 概要

## 背景

AccountServiceImplがPhotoFavoriteMapper/PhotoTagMstMapper/PhotoMstMapperを直接呼び出しており、Controller -> Service -> Repository -> Mapperのレイヤードアーキテクチャに違反していた。

## 変更内容

- PhotoFavoriteRepositoryに`deleteByAccountNo`/`deleteByFavoritePhotoAccountNo`を追加
- PhotoTagMstRepositoryに`deleteByAccountNo`を追加
- PhotoMstRepositoryに`deleteByAccountNo`（物理削除）を追加
- AccountServiceImplの`deleteAccount`メソッドが、上記MapperではなくRepository経由でアクセスするように修正
- 対応するユニットテストを修正・追加

# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認

# 懸念事項

Service⇔Repository間で`AccountNo`（domainオブジェクト）を直接受け渡ししており、厳密には「Service-Repository間はmodel/で転送する」という規約から外れる。ただしこのパターンは既存のPhotoServiceImpl/AuthServiceImplにも見られる先例であり、今回新たに追加した逸脱ではない。