### PR TITLE
refactor: 現在時刻取得をJST固定のClock Bean経由に変更し、plusHours(9)を廃止

### DIFF
--- a/backend/src/main/java/com/web/gallery/config/ClockConfig.java
+++ b/backend/src/main/java/com/web/gallery/config/ClockConfig.java
@@ -1,0 +1,27 @@
+package com.web.gallery.config;
+
+import java.time.Clock;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.web.gallery.constant.Consts;
+
+/**
+ * 現在時刻取得用のClockに関する設定クラス
+ * @author	Kento Kodama
+ * @version	1.0.0
+ * @since	1.0.0
+ */
+@Configuration
+public class ClockConfig {
+	/**
+	 * JST（日本標準時）に固定したClockを生成する
+	 *
+	 * @return	{@link Clock}
+	 */
+	@Bean
+	public Clock clock() {
+		return Clock.system(Consts.JST);
+	}
+}

--- a/backend/src/main/java/com/web/gallery/model/AccountModel.java
+++ b/backend/src/main/java/com/web/gallery/model/AccountModel.java
@@ -1,8 +1,8 @@
 package com.web.gallery.model;
 
+import java.time.Clock;
 import java.time.OffsetDateTime;
 
-import com.web.gallery.constant.Consts;
 import com.web.gallery.controller.request.AccountRegistRequest;
 import com.web.gallery.controller.request.AccountUpdateRequest;
 import com.web.gallery.domain.account.AccountId;
@@ -172,12 +172,13 @@ public class AccountModel {
 	 * 認証成功時のAccountModelを生成する（最終ログイン日時を現在時刻に設定し、ログイン失敗回数を0にリセット）
 	 *
 	 * @param	accountNo	アカウント番号
+	 * @param	clock		現在時刻取得用の{@link Clock}
 	 * @return				{@link AccountModel}
 	 */
-	public static AccountModel forLoginSuccess(AccountNo accountNo) {
+	public static AccountModel forLoginSuccess(AccountNo accountNo, Clock clock) {
 		return AccountModel.builder()
 				.accountNo(accountNo)
-				.lastLoginDatetime(new LastLoginDatetime(OffsetDateTime.now(Consts.JST)))
+				.lastLoginDatetime(new LastLoginDatetime(OffsetDateTime.now(clock)))
 				.loginFailureCount(new LoginFailureCount(0))
 				.build();
 	}

--- a/backend/src/main/java/com/web/gallery/model/PhotoDetailModel.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoDetailModel.java
@@ -119,7 +119,7 @@ public class PhotoDetailModel {
 				.photoNo(dto.getPhotoNo())
 				.isFavorite(dto.getIsFavorite())
 				.photoAt(
-					dto.getPhotoAt().value().isEqual(Consts.MIN_OFFSET_DATE_TIME) ? null : new PhotoAt(dto.getPhotoAt().value().plusHours(9)))
+					dto.getPhotoAt().value().isEqual(Consts.MIN_OFFSET_DATE_TIME) ? null : new PhotoAt(dto.getPhotoAt().value().withOffsetSameInstant(Consts.JST)))
 				.locationNo(dto.getLocationNo())
 				.address(dto.getAddress())
 				.latitude(dto.getLatitude())

--- a/backend/src/main/java/com/web/gallery/model/PhotoModel.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoModel.java
@@ -1,5 +1,6 @@
 package com.web.gallery.model;
 
+import com.web.gallery.constant.Consts;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.Caption;
 import com.web.gallery.domain.photo.FavoriteCount;
@@ -76,7 +77,7 @@ public class PhotoModel {
 				.photoNo(dto.getPhotoNo())
 				.favoriteCount(dto.getFavoriteCount())
 				.isFavorite(dto.getIsFavorite())
-				.photoAt(new PhotoAt(dto.getPhotoAt().value().plusHours(9)))
+				.photoAt(new PhotoAt(dto.getPhotoAt().value().withOffsetSameInstant(Consts.JST)))
 				.imageFilePath(dto.getImageFilePath())
 				.caption(dto.getCaption())
 				.directionKbn(dto.getDirectionKbn())

--- a/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
@@ -1,5 +1,6 @@
 package com.web.gallery.service.impl;
 
+import java.time.Clock;
 import java.util.Objects;
 
 import org.springframework.context.event.EventListener;
@@ -44,6 +45,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	private final PhotoMstRepository photoMstRepository;
 	private final LoginConfig loginConfig;
 	private final PhotoConfig photoConfig;
+	private final Clock clock;
 
 	/**
 	 * アカウントIDからアカウント情報の存在を確認する
@@ -185,7 +187,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	public void handle(AuthenticationSuccessEvent event) throws UpdateFailureException {
 		AccountModel accountModel = accountRepository.getByAccountId(event.getAuthentication().getName());
 
-		accountRepository.updateLoginFailureCount(AccountModel.forLoginSuccess(accountModel.getAccountNo()));
+		accountRepository.updateLoginFailureCount(AccountModel.forLoginSuccess(accountModel.getAccountNo(), clock));
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/service/impl/AuthServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AuthServiceImpl.java
@@ -3,6 +3,7 @@ package com.web.gallery.service.impl;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
 import java.time.OffsetDateTime;
 
 import com.web.gallery.constant.Consts;
@@ -43,6 +44,7 @@ public class AuthServiceImpl implements AuthService {
 	private final RefreshTokenRepository refreshTokenRepository;
 	private final AccountRepository accountRepository;
 	private final AccountServiceImpl accountServiceImpl;
+	private final Clock clock;
 
 	public AuthServiceImpl(
 			@Lazy AuthenticationManager authenticationManager,
@@ -50,13 +52,15 @@ public class AuthServiceImpl implements AuthService {
 			JwtConfig jwtConfig,
 			RefreshTokenRepository refreshTokenRepository,
 			AccountRepository accountRepository,
-			@Lazy AccountServiceImpl accountServiceImpl) {
+			@Lazy AccountServiceImpl accountServiceImpl,
+			Clock clock) {
 		this.authenticationManager = authenticationManager;
 		this.jwtTokenProvider = jwtTokenProvider;
 		this.jwtConfig = jwtConfig;
 		this.refreshTokenRepository = refreshTokenRepository;
 		this.accountRepository = accountRepository;
 		this.accountServiceImpl = accountServiceImpl;
+		this.clock = clock;
 	}
 
 	/**
@@ -85,7 +89,7 @@ public class AuthServiceImpl implements AuthService {
 		refreshTokenRepository.save(RefreshTokenModel.of(
 				new AccountNo(principal.getAccountNo()),
 				new TokenHash(hashToken(refreshToken)),
-				new ExpiresAt(OffsetDateTime.now().plusDays(jwtConfig.getRefreshTokenExpirationDays()))));
+				new ExpiresAt(OffsetDateTime.now(clock).plusDays(jwtConfig.getRefreshTokenExpirationDays()))));
 
 		return AuthTokenModel.of(accessToken, refreshToken,
 				(long) jwtConfig.getAccessTokenExpirationMinutes() * 60);
@@ -108,7 +112,7 @@ public class AuthServiceImpl implements AuthService {
 			throw new IllegalArgumentException("無効なリフレッシュトークンです");
 		}
 
-		if (storedToken.getExpiresAt().value().isBefore(OffsetDateTime.now())) {
+		if (storedToken.getExpiresAt().value().isBefore(OffsetDateTime.now(clock))) {
 			throw new IllegalArgumentException("リフレッシュトークンの有効期限が切れています");
 		}
 

--- a/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 
 import com.web.gallery.config.PhotoConfig;
+import com.web.gallery.constant.Consts;
 import com.web.gallery.domain.photo.ImageFile;
 import com.web.gallery.domain.photo.ImageFilePath;
 import com.web.gallery.domain.account.AccountNo;
@@ -205,8 +206,8 @@ public class PhotoServiceImpl implements PhotoService {
 				return new Comparator<PhotoModel>() {
 					@Override
 					public int compare(PhotoModel photoModelA, PhotoModel photoModelB) {
-						OffsetDateTime photoAtA = photoModelA.getPhotoAt().value().plusHours(9);
-						OffsetDateTime photoAtB = photoModelB.getPhotoAt().value().plusHours(9);
+						OffsetDateTime photoAtA = photoModelA.getPhotoAt().value().withOffsetSameInstant(Consts.JST);
+						OffsetDateTime photoAtB = photoModelB.getPhotoAt().value().withOffsetSameInstant(Consts.JST);
 
 						LocalDate dateA = LocalDate.of(2000, photoAtA.getMonth().getValue(), photoAtA.getDayOfMonth());
 						LocalDate dateB = LocalDate.of(2000, photoAtB.getMonth().getValue(), photoAtB.getDayOfMonth());

--- a/backend/src/test/java/com/web/gallery/controller/integration/AccountRestControllerIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/integration/AccountRestControllerIntegrationTest.java
@@ -250,6 +250,7 @@ public class AccountRestControllerIntegrationTest {
 			String residentPrefectureKbnCode = "Okinawa";
 			String freeMemo = "フリーメモ";
 
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			mockMvc.perform(
 					post("/api/v1/accounts")
 					.contentType(MediaType.APPLICATION_JSON)
@@ -267,7 +268,9 @@ public class AccountRestControllerIntegrationTest {
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(4L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(0L), actualData.getFirst().getCreatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
 			assertEquals(new UpdatedBy(0L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(accountId, actualData.getFirst().getAccountId().value());
 			assertEquals(accountName, actualData.getFirst().getAccountName().value());
@@ -371,6 +374,7 @@ public class AccountRestControllerIntegrationTest {
 			AccountPrincipal accountPrincipal = new AccountPrincipal(sessionAccount, 0);
 			Authentication authentication = new UsernamePasswordAuthenticationToken(accountPrincipal, null, accountPrincipal.getAuthorities());
 
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			mockMvc.perform(
 					put("/api/v1/accounts/" + accountId)
 					.contentType(MediaType.APPLICATION_JSON)
@@ -390,8 +394,9 @@ public class AccountRestControllerIntegrationTest {
 			assertEquals(1, actual.size());
 			assertEquals(new AccountNo(1L), actual.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(1L), actual.getFirst().getCreatedBy());
-			assertNotEquals(new CreatedAt(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actual.getFirst().getCreatedAt());
+			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actual.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(1L), actual.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actual.getFirst().getUpdatedAt().value());
 			assertFalse(actual.getFirst().getIsDeleted().value());
 			assertEquals(accountId, actual.getFirst().getAccountId().value());
 			assertEquals(accountName, actual.getFirst().getAccountName().value());
@@ -424,6 +429,7 @@ public class AccountRestControllerIntegrationTest {
 			AccountPrincipal accountPrincipal = new AccountPrincipal(sessionAccount, 0);
 			Authentication authentication = new UsernamePasswordAuthenticationToken(accountPrincipal, null, accountPrincipal.getAuthorities());
 
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			mockMvc.perform(
 					put("/api/v1/accounts/aaaaaaaa")
 					.contentType(MediaType.APPLICATION_JSON)
@@ -443,8 +449,9 @@ public class AccountRestControllerIntegrationTest {
 			assertEquals(1, actual.size());
 			assertEquals(new AccountNo(1L), actual.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(1L), actual.getFirst().getCreatedBy());
-			assertNotEquals(new CreatedAt(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actual.getFirst().getCreatedAt());
+			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actual.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(1L), actual.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actual.getFirst().getUpdatedAt().value());
 			assertFalse(actual.getFirst().getIsDeleted().value());
 			assertEquals(accountId, actual.getFirst().getAccountId().value());
 			assertEquals(accountName, actual.getFirst().getAccountName().value());
@@ -477,6 +484,7 @@ public class AccountRestControllerIntegrationTest {
 			AccountPrincipal accountPrincipal = new AccountPrincipal(sessionAccount, 0);
 			Authentication authentication = new UsernamePasswordAuthenticationToken(accountPrincipal, null, accountPrincipal.getAuthorities());
 
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			mockMvc.perform(
 					put("/api/v1/accounts/" + accountId)
 					.contentType(MediaType.APPLICATION_JSON)
@@ -496,8 +504,9 @@ public class AccountRestControllerIntegrationTest {
 			assertEquals(1, actual.size());
 			assertEquals(new AccountNo(1L), actual.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(1L), actual.getFirst().getCreatedBy());
-			assertNotEquals(new CreatedAt(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actual.getFirst().getCreatedAt());
+			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actual.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(1L), actual.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actual.getFirst().getUpdatedAt().value());
 			assertFalse(actual.getFirst().getIsDeleted().value());
 			assertEquals(accountId, actual.getFirst().getAccountId().value());
 			assertEquals(accountName, actual.getFirst().getAccountName().value());
@@ -530,6 +539,7 @@ public class AccountRestControllerIntegrationTest {
 			AccountPrincipal accountPrincipal = new AccountPrincipal(sessionAccount, 0);
 			Authentication authentication = new UsernamePasswordAuthenticationToken(accountPrincipal, null, accountPrincipal.getAuthorities());
 
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			mockMvc.perform(
 					put("/api/v1/accounts/aaaaaaaa")
 					.contentType(MediaType.APPLICATION_JSON)
@@ -549,8 +559,9 @@ public class AccountRestControllerIntegrationTest {
 			assertEquals(1, actual.size());
 			assertEquals(new AccountNo(1L), actual.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(1L), actual.getFirst().getCreatedBy());
-			assertNotEquals(new CreatedAt(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actual.getFirst().getCreatedAt());
+			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actual.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(1L), actual.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actual.getFirst().getUpdatedAt().value());
 			assertFalse(actual.getFirst().getIsDeleted().value());
 			assertEquals(accountId, actual.getFirst().getAccountId().value());
 			assertEquals(accountName, actual.getFirst().getAccountName().value());

--- a/backend/src/test/java/com/web/gallery/controller/integration/PhotoFavoriteControllerIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/integration/PhotoFavoriteControllerIntegrationTest.java
@@ -88,6 +88,7 @@ public class PhotoFavoriteControllerIntegrationTest {
 		void addFavorite_success() throws Exception {
 			Authentication authentication = createAuthentication();
 
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			mockMvc.perform(
 					post("/api/v1/photos/favorites")
 					.contentType(MediaType.APPLICATION_JSON)
@@ -115,6 +116,7 @@ public class PhotoFavoriteControllerIntegrationTest {
 			assertEquals(new AccountNo(2L), actualData.getFirst().getFavoritePhotoAccountNo());
 			assertEquals(1L, actualData.getFirst().getFavoritePhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
 		}
 
 		@Test

--- a/backend/src/test/java/com/web/gallery/controller/integration/PhotoRestControllerIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/integration/PhotoRestControllerIntegrationTest.java
@@ -254,7 +254,8 @@ public class PhotoRestControllerIntegrationTest {
 			
 			AccountPrincipal accountPrincipal = new AccountPrincipal(sessionAccount, 0);
 			Authentication authentication = new UsernamePasswordAuthenticationToken(accountPrincipal, null, accountPrincipal.getAuthorities());
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			mockMvc.perform(
 					multipart("/api/v1/accounts/" + photoAccountId + "/photos")
 					.file(multipartFile)
@@ -273,7 +274,7 @@ public class PhotoRestControllerIntegrationTest {
 				.andExpect(jsonPath("$.httpStatus").value(HttpStatus.OK.value()))
 				.andExpect(jsonPath("$.isSuccess").value(true))
 				.andExpect(jsonPath("$.message").value("写真登録が完了しました。"));
-			
+
 			// photo_mst登録チェック
 			List<PhotoMst> actualPhotoMst = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no = 2 and photo_no=4", (rs, rowNum) ->
@@ -297,10 +298,12 @@ public class PhotoRestControllerIntegrationTest {
 						.shutterSpeed(new ShutterSpeed(rs.getBigDecimal("shutter_speed")))
 						.iso(new Iso(rs.getInt("iso")))
 						.build());
-			
+
 			assertEquals(1, actualPhotoMst.size());
 			assertEquals(new AccountNo(2L), actualPhotoMst.getFirst().getAccountNo());
 			assertEquals(4L, actualPhotoMst.getFirst().getPhotoNo().value());
+			assertEquals(transactionNow, actualPhotoMst.getFirst().getCreatedAt().value());
+			assertEquals(transactionNow, actualPhotoMst.getFirst().getUpdatedAt().value());
 			assertFalse(actualPhotoMst.getFirst().getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualPhotoMst.getFirst().getPhotoAt().value().plusHours(9));
 			assertEquals(0L, actualPhotoMst.getFirst().getLocationNo().value());
@@ -350,7 +353,8 @@ public class PhotoRestControllerIntegrationTest {
 			
 			AccountPrincipal accountPrincipal = new AccountPrincipal(sessionAccount, 0);
 			Authentication authentication = new UsernamePasswordAuthenticationToken(accountPrincipal, null, accountPrincipal.getAuthorities());
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			mockMvc.perform(
 					multipart("/api/v1/accounts/" + photoAccountId + "/photos")
 					.file(multipartFile)
@@ -380,7 +384,7 @@ public class PhotoRestControllerIntegrationTest {
 				.andExpect(jsonPath("$.httpStatus").value(HttpStatus.OK.value()))
 				.andExpect(jsonPath("$.isSuccess").value(true))
 				.andExpect(jsonPath("$.message").value("写真登録が完了しました。"));
-			
+
 			// photo_mst登録チェック
 			List<PhotoMst> actualPhotoMst = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no = 2 and photo_no=4", (rs, rowNum) ->
@@ -404,10 +408,12 @@ public class PhotoRestControllerIntegrationTest {
 						.shutterSpeed(new ShutterSpeed(rs.getBigDecimal("shutter_speed")))
 						.iso(new Iso(rs.getInt("iso")))
 						.build());
-			
+
 			assertEquals(1, actualPhotoMst.size());
 			assertEquals(new AccountNo(2L), actualPhotoMst.getFirst().getAccountNo());
 			assertEquals(4L, actualPhotoMst.getFirst().getPhotoNo().value());
+			assertEquals(transactionNow, actualPhotoMst.getFirst().getCreatedAt().value());
+			assertEquals(transactionNow, actualPhotoMst.getFirst().getUpdatedAt().value());
 			assertFalse(actualPhotoMst.getFirst().getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualPhotoMst.getFirst().getPhotoAt().value().plusHours(9));
 			assertEquals(0L, actualPhotoMst.getFirst().getLocationNo().value());
@@ -420,7 +426,7 @@ public class PhotoRestControllerIntegrationTest {
 			assertEquals(0, BigDecimal.valueOf(8.0).compareTo(actualPhotoMst.getFirst().getFValue().value()));
 			assertEquals(0, BigDecimal.valueOf(0.01).compareTo(actualPhotoMst.getFirst().getShutterSpeed().value()));
 			assertEquals(100, actualPhotoMst.getFirst().getIso().value());
-			
+
 			// photo_tag_mst登録チェック
 			List<PhotoTagMst> actualPhotoTagMst = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_tag_mst WHERE account_no=2 and photo_no=4", (rs, rowNum) ->
@@ -434,15 +440,17 @@ public class PhotoRestControllerIntegrationTest {
 								.tagEnglishName(new TagEnglishName(rs.getObject("tag_english_name").toString()))
 								.build());
 			assertEquals(2, actualPhotoTagMst.size());
-			
+
 			assertEquals(new AccountNo(2L), actualPhotoTagMst.get(0).getAccountNo());
 			assertEquals(4L, actualPhotoTagMst.get(0).getPhotoNo().value());
 			assertEquals(1L, actualPhotoTagMst.get(0).getTagNo().value());
+			assertEquals(transactionNow, actualPhotoTagMst.get(0).getCreatedAt().value());
 			assertEquals("太陽", actualPhotoTagMst.get(0).getTagJapaneseName().value());
 			assertEquals("sun", actualPhotoTagMst.get(0).getTagEnglishName().value());
 			assertEquals(new AccountNo(2L), actualPhotoTagMst.get(1).getAccountNo());
 			assertEquals(4L, actualPhotoTagMst.get(1).getPhotoNo().value());
 			assertEquals(2L, actualPhotoTagMst.get(1).getTagNo().value());
+			assertEquals(transactionNow, actualPhotoTagMst.get(1).getCreatedAt().value());
 			assertEquals("青空", actualPhotoTagMst.get(1).getTagJapaneseName().value());
 			assertEquals("bluesky", actualPhotoTagMst.get(1).getTagEnglishName().value());
 		}
@@ -463,7 +471,8 @@ public class PhotoRestControllerIntegrationTest {
 			
 			AccountPrincipal accountPrincipal = new AccountPrincipal(sessionAccount, 0);
 			Authentication authentication = new UsernamePasswordAuthenticationToken(accountPrincipal, null, accountPrincipal.getAuthorities());
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			mockMvc.perform(
 					multipart("/api/v1/accounts/" + photoAccountId + "/photos")
 					.contentType(MediaType.MULTIPART_FORM_DATA)
@@ -495,7 +504,7 @@ public class PhotoRestControllerIntegrationTest {
 				.andExpect(jsonPath("$.httpStatus").value(HttpStatus.OK.value()))
 				.andExpect(jsonPath("$.isSuccess").value(true))
 				.andExpect(jsonPath("$.message").value("写真登録が完了しました。"));
-			
+
 			// photo_mst登録チェック
 			List<PhotoMst> actualPhotoMst = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no = 2 and photo_no=1", (rs, rowNum) ->
@@ -519,10 +528,12 @@ public class PhotoRestControllerIntegrationTest {
 						.shutterSpeed(new ShutterSpeed(rs.getBigDecimal("shutter_speed")))
 						.iso(new Iso(rs.getInt("iso")))
 						.build());
-			
+
 			assertEquals(1, actualPhotoMst.size());
 			assertEquals(new AccountNo(2L), actualPhotoMst.getFirst().getAccountNo());
 			assertEquals(1L, actualPhotoMst.getFirst().getPhotoNo().value());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualPhotoMst.getFirst().getCreatedAt().value());
+			assertEquals(transactionNow, actualPhotoMst.getFirst().getUpdatedAt().value());
 			assertFalse(actualPhotoMst.getFirst().getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualPhotoMst.getFirst().getPhotoAt().value().plusHours(9));
 			assertEquals(0L, actualPhotoMst.getFirst().getLocationNo().value());
@@ -535,8 +546,8 @@ public class PhotoRestControllerIntegrationTest {
 			assertEquals(0, BigDecimal.valueOf(8.0).compareTo(actualPhotoMst.getFirst().getFValue().value()));
 			assertEquals(0, BigDecimal.valueOf(0.01).compareTo(actualPhotoMst.getFirst().getShutterSpeed().value()));
 			assertEquals(100, actualPhotoMst.getFirst().getIso().value());
-			
-			// photo_tag_mst登録チェック
+
+			// photo_tag_mst登録チェック（更新時は既存タグを一旦削除してから再登録するため、いずれも新規登録扱い）
 			List<PhotoTagMst> actualPhotoTagMst = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_tag_mst WHERE account_no=2 and photo_no=1", (rs, rowNum) ->
 							PhotoTagMst.builder()
@@ -549,15 +560,17 @@ public class PhotoRestControllerIntegrationTest {
 								.tagEnglishName(new TagEnglishName(rs.getObject("tag_english_name").toString()))
 								.build());
 			assertEquals(2, actualPhotoTagMst.size());
-			
+
 			assertEquals(new AccountNo(2L), actualPhotoTagMst.get(0).getAccountNo());
 			assertEquals(1L, actualPhotoTagMst.get(0).getPhotoNo().value());
 			assertEquals(1L, actualPhotoTagMst.get(0).getTagNo().value());
+			assertEquals(transactionNow, actualPhotoTagMst.get(0).getCreatedAt().value());
 			assertEquals("太陽", actualPhotoTagMst.get(0).getTagJapaneseName().value());
 			assertEquals("sun", actualPhotoTagMst.get(0).getTagEnglishName().value());
 			assertEquals(new AccountNo(2L), actualPhotoTagMst.get(1).getAccountNo());
 			assertEquals(1L, actualPhotoTagMst.get(1).getPhotoNo().value());
 			assertEquals(2L, actualPhotoTagMst.get(1).getTagNo().value());
+			assertEquals(transactionNow, actualPhotoTagMst.get(1).getCreatedAt().value());
 			assertEquals("青空", actualPhotoTagMst.get(1).getTagJapaneseName().value());
 			assertEquals("bluesky", actualPhotoTagMst.get(1).getTagEnglishName().value());
 		}
@@ -843,6 +856,7 @@ public class PhotoRestControllerIntegrationTest {
 			AccountPrincipal accountPrincipal = new AccountPrincipal(sessionAccount, 0);
 			Authentication authentication = new UsernamePasswordAuthenticationToken(accountPrincipal, null, accountPrincipal.getAuthorities());
 
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			mockMvc.perform(
 					delete("/api/v1/accounts/" + photoAccountId + "/photos")
 					.contentType(MediaType.APPLICATION_JSON)
@@ -855,7 +869,7 @@ public class PhotoRestControllerIntegrationTest {
 				.andExpect(jsonPath("$.httpStatus").value(200))
 				.andExpect(jsonPath("$.isSuccess").value(true))
 				.andExpect(jsonPath("$.message").value("写真削除が完了しました。"));
-			
+
 			// photo_mst削除チェック
 			List<PhotoMst> actualPhotoMst = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no = 1 and photo_no=1", (rs, rowNum) ->
@@ -879,6 +893,8 @@ public class PhotoRestControllerIntegrationTest {
 						.shutterSpeed(new ShutterSpeed(rs.getBigDecimal("shutter_speed")))
 						.iso(new Iso(rs.getInt("iso")))
 						.build());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualPhotoMst.getFirst().getCreatedAt().value());
+			assertEquals(transactionNow, actualPhotoMst.getFirst().getUpdatedAt().value());
 			assertTrue(actualPhotoMst.getFirst().getIsDeleted().value());
 			
 			// photo_tag_mst削除チェック

--- a/backend/src/test/java/com/web/gallery/mapper/AccountMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/AccountMapperTest.java
@@ -795,9 +795,10 @@ public class AccountMapperTest {
 					.loginFailureCount(new LoginFailureCount(0))
 					.build();
 			
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actualCount = accountMapper.insert(insertAccount);
 			assertEquals(1, actualCount);
-			
+
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account", (rs, rowNum) ->
 						Account.builder()
@@ -823,7 +824,9 @@ public class AccountMapperTest {
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("aaaaaaaa"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("AAAAAAAA"), actualData.getFirst().getAccountName());
@@ -875,15 +878,17 @@ public class AccountMapperTest {
 		void update_by_accountNo() {
 			Account conditionAccount = Account.builder().accountNo(new AccountNo(1L)).build();
 			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
-			
+
 			List<Account> actualData = getAccountList("account_no=1");
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(1L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("aaaaaaaa"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("AAAAAAAA"), actualData.getFirst().getAccountName());
@@ -904,15 +909,17 @@ public class AccountMapperTest {
 		void update_by_isDeleted() {
 			Account conditionAccount = Account.builder().isDeleted(new IsDeleted(true)).build();
 			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
-			
+
 			List<Account> actualData = getAccountList("is_deleted=true");
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(9L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(9L), actualData.getFirst().getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 9, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(9L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertTrue(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("iiiiiiii"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("IIIIIIII"), actualData.getFirst().getAccountName());
@@ -933,15 +940,17 @@ public class AccountMapperTest {
 		void update_by_accountId() {
 			Account conditionAccount = Account.builder().accountId(new AccountId("aaaaaaaa")).build();
 			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
-			
+
 			List<Account> actualData = getAccountList("account_id='aaaaaaaa'");
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(1L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("aaaaaaaa"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("AAAAAAAA"), actualData.getFirst().getAccountName());
@@ -962,15 +971,17 @@ public class AccountMapperTest {
 		void update_by_accountName() {
 			Account conditionAccount = Account.builder().accountName(new AccountName("AAAAAAAA")).build();
 			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
-			
+
 			List<Account> actualData = getAccountList("account_name='AAAAAAAA'");
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(1L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("aaaaaaaa"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("AAAAAAAA"), actualData.getFirst().getAccountName());
@@ -991,15 +1002,17 @@ public class AccountMapperTest {
 		void update_by_password() {
 			Account conditionAccount = Account.builder().password(new Password("$2a$10$password1")).build();
 			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
-			
+
 			List<Account> actualData = getAccountList("password='$2a$10$password1'");
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(1L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("aaaaaaaa"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("AAAAAAAA"), actualData.getFirst().getAccountName());
@@ -1020,15 +1033,17 @@ public class AccountMapperTest {
 		void update_by_birthdate() {
 			Account conditionAccount = Account.builder().birthdate(new BirthDate(LocalDate.of(1991, 2, 14))).build();
 			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
-			
+
 			List<Account> actualData = getAccountList("birthdate='1991-02-14'");
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(1L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("aaaaaaaa"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("AAAAAAAA"), actualData.getFirst().getAccountName());
@@ -1049,15 +1064,17 @@ public class AccountMapperTest {
 		void update_by_sexKbnCode() {
 			Account conditionAccount = Account.builder().sexKbn(SexEnum.MAN).build();
 			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
-			
+
 			List<Account> actualData = getAccountList("sex_kbn='man'");
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(2L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(2L), actualData.getFirst().getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 2, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(2L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("bbbbbbbb"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("BBBBBBBB"), actualData.getFirst().getAccountName());
@@ -1078,15 +1095,17 @@ public class AccountMapperTest {
 		void update_by_birthplacePrefectureKbnCode() {
 			Account conditionAccount = Account.builder().birthplacePrefectureKbnCode(new BirthplacePrefectureKbnCode("Hokkaido")).build();
 			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
-			
+
 			List<Account> actualData = getAccountList("birthplace_prefecture_kbn_code='Hokkaido'");
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(3L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(3L), actualData.getFirst().getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 3, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(3L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("cccccccc"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("CCCCCCCC"), actualData.getFirst().getAccountName());
@@ -1107,15 +1126,17 @@ public class AccountMapperTest {
 		void update_by_residentPrefectureKbnCode() {
 			Account conditionAccount = Account.builder().residentPrefectureKbnCode(new ResidentPrefectureKbnCode("Okinawa")).build();
 			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
-			
+
 			List<Account> actualData = getAccountList("resident_prefecture_kbn_code='Okinawa'");
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(4L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(4L), actualData.getFirst().getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 4, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(4L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("dddddddd"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("DDDDDDDD"), actualData.getFirst().getAccountName());
@@ -1136,15 +1157,17 @@ public class AccountMapperTest {
 		void update_by_freeMemo() {
 			Account conditionAccount = Account.builder().freeMemo(new FreeMemo("フリーメモ")).build();
 			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
-			
+
 			List<Account> actualData = getAccountList("free_memo='フリーメモ'");
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(5L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(5L), actualData.getFirst().getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 5, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(5L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("eeeeeeee"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("EEEEEEEE"), actualData.getFirst().getAccountName());
@@ -1165,15 +1188,17 @@ public class AccountMapperTest {
 		void update_by_authorityKbnCode() {
 			Account conditionAccount = Account.builder().authorityKbn(AuthorityEnum.MINI).build();
 			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
-			
+
 			List<Account> actualData = getAccountList("authority_kbn='mini-user'");
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(6L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(6L), actualData.getFirst().getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 6, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(6L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("ffffffff"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("FFFFFFFF"), actualData.getFirst().getAccountName());
@@ -1196,15 +1221,17 @@ public class AccountMapperTest {
 					.lastLoginDatetime(new LastLoginDatetime(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
 					.build();
 			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
-			
+
 			List<Account> actualData = getAccountList("last_login_datetime='2024-01-01 00:00:00.000 +0000'");
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(7L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(7L), actualData.getFirst().getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 7, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(7L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("gggggggg"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("GGGGGGGG"), actualData.getFirst().getAccountName());
@@ -1225,15 +1252,17 @@ public class AccountMapperTest {
 		void update_by_loginFailureCounte() {
 			Account conditionAccount = Account.builder().loginFailureCount(new LoginFailureCount(2)).build();
 			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(0)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
-			
+
 			List<Account> actualData = getAccountList("account_no=8");
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(8L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(8L), actualData.getFirst().getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 8, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(8L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("hhhhhhhh"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("HHHHHHHH"), actualData.getFirst().getAccountName());
@@ -1267,15 +1296,17 @@ public class AccountMapperTest {
 		void update_accounts() {
 			Account conditionAccount = Account.builder().authorityKbn(AuthorityEnum.SPECIAL).build();
 			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(2, actual);
-			
+
 			List<Account> actualData = getAccountList("authority_kbn='special-user' order by account_no");
 			assertEquals(2, actualData.size());
 			assertEquals(new AccountNo(9L), actualData.get(0).getAccountNo());
 			assertEquals(new CreatedBy(9L), actualData.get(0).getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 9, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.get(0).getCreatedAt());
 			assertEquals(new UpdatedBy(9L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertTrue(actualData.get(0).getIsDeleted().value());
 			assertEquals(new AccountId("iiiiiiii"), actualData.get(0).getAccountId());
 			assertEquals(new AccountName("IIIIIIII"), actualData.get(0).getAccountName());
@@ -1293,6 +1324,7 @@ public class AccountMapperTest {
 			assertEquals(new CreatedBy(10L), actualData.get(1).getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 10, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.get(1).getCreatedAt());
 			assertEquals(new UpdatedBy(10L), actualData.get(1).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(1).getUpdatedAt().value());
 			assertFalse(actualData.get(1).getIsDeleted().value());
 			assertEquals(new AccountId("jjjjjjjj"), actualData.get(1).getAccountId());
 			assertEquals(new AccountName("JJJJJJJJ"), actualData.get(1).getAccountName());
@@ -1319,15 +1351,17 @@ public class AccountMapperTest {
 					.freeMemo(new FreeMemo("よろしく"))
 					.build();
 			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(0)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
-			
+
 			List<Account> actualData = getAccountList("account_id='llllllll'");
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(12L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(12L), actualData.getFirst().getCreatedBy());
 			assertEquals(new CreatedAt(OffsetDateTime.of(2000, 1, 12, 0, 0, 0, 0, ZoneOffset.ofHours(0))), actualData.getFirst().getCreatedAt());
 			assertEquals(new UpdatedBy(12L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("llllllll"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("LLLLLLLL"), actualData.getFirst().getAccountName());

--- a/backend/src/test/java/com/web/gallery/mapper/PhotoFavoriteMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/PhotoFavoriteMapperTest.java
@@ -51,9 +51,10 @@ public class PhotoFavoriteMapperTest {
 					.createdBy(new CreatedBy(1L))
 					.build();
 			
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actualCount = photoFavoriteMapper.insert(insertPhotoFavorite);
 			assertEquals(1, actualCount);
-			
+
 			List<PhotoFavorite> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite WHERE account_no=1 and favorite_photo_account_no=2 and favorite_photo_no=1", (rs, rowNum) ->
 						PhotoFavorite.builder()
@@ -68,6 +69,7 @@ public class PhotoFavoriteMapperTest {
 			assertEquals(new AccountNo(2L), actualData.getFirst().getFavoritePhotoAccountNo());
 			assertEquals(1L, actualData.getFirst().getFavoritePhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
 		}
 	}
 	

--- a/backend/src/test/java/com/web/gallery/mapper/PhotoMstMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/PhotoMstMapperTest.java
@@ -234,6 +234,7 @@ public class PhotoMstMapperTest {
 					.iso(new Iso(200))
 					.build();
 			
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actualCount = photoMstMapper.insert(insertPhotoMst);
 			assertEquals(1, actualCount);
 			
@@ -264,7 +265,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(4L, actualData.getFirst().getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getPhotoAt().value());
 			assertEquals(6L, actualData.getFirst().getLocationNo().value());
@@ -317,6 +320,7 @@ public class PhotoMstMapperTest {
 		void update_by_accountNo() {
 			PhotoMst conditionPhotoMst = PhotoMst.builder().accountNo(new AccountNo(1L)).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(3, actual);
 			
@@ -325,7 +329,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(1L), actualData.get(0).getAccountNo());
 			assertEquals(1L, actualData.get(0).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(0).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals(1L, actualData.get(0).getLocationNo().value());
@@ -346,6 +352,7 @@ public class PhotoMstMapperTest {
 		void update_by_photoNo() {
 			PhotoMst conditionPhotoMst = PhotoMst.builder().photoNo(new PhotoNo(1L)).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(2, actual);
 			
@@ -356,7 +363,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(1L), actualData.get(0).getAccountNo());
 			assertEquals(1L, actualData.get(0).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(0).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals(1L, actualData.get(0).getLocationNo().value());
@@ -373,7 +382,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(2L), actualData.get(1).getAccountNo());
 			assertEquals(1L, actualData.get(1).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(1).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(1).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(1).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(1).getUpdatedAt().value());
 			assertFalse(actualData.get(1).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2022, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(1).getPhotoAt().value());
 			assertEquals(4L, actualData.get(1).getLocationNo().value());
@@ -394,6 +405,7 @@ public class PhotoMstMapperTest {
 		void update_by_isDeleted() {
 			PhotoMst conditionPhotoMst = PhotoMst.builder().isDeleted(new IsDeleted(true)).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(3, actual);
 			
@@ -404,7 +416,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(2L), actualData.get(0).getAccountNo());
 			assertEquals(3L, actualData.get(0).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(0).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertTrue(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2022, 3, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals(6L, actualData.get(0).getLocationNo().value());
@@ -426,6 +440,7 @@ public class PhotoMstMapperTest {
 			PhotoMst conditionPhotoMst = PhotoMst.builder()
 					.photoAt(new PhotoAt(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
 			
@@ -435,7 +450,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(1L), actualData.get(0).getAccountNo());
 			assertEquals(1L, actualData.get(0).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(0).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals(1L, actualData.get(0).getLocationNo().value());
@@ -456,6 +473,7 @@ public class PhotoMstMapperTest {
 		void update_by_locationNo() {
 			PhotoMst conditionPhotoMst = PhotoMst.builder().locationNo(new LocationNo(1L)).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
 			
@@ -465,7 +483,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(1L), actualData.get(0).getAccountNo());
 			assertEquals(1L, actualData.get(0).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(0).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals(1L, actualData.get(0).getLocationNo().value());
@@ -486,6 +506,7 @@ public class PhotoMstMapperTest {
 		void update_by_imageFilePath() {
 			PhotoMst conditionPhotoMst = PhotoMst.builder().imageFilePath(new ImageFilePath("https://www.xxx.com/DSC111.jpg")).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
 			
@@ -495,7 +516,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(1L), actualData.get(0).getAccountNo());
 			assertEquals(1L, actualData.get(0).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(0).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals(1L, actualData.get(0).getLocationNo().value());
@@ -516,6 +539,7 @@ public class PhotoMstMapperTest {
 		void update_by_photoJapaneseTitle() {
 			PhotoMst conditionPhotoMst = PhotoMst.builder().photoJapaneseTitle(new PhotoJapaneseTitle("タイトル11")).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
 			
@@ -525,7 +549,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(1L), actualData.get(0).getAccountNo());
 			assertEquals(1L, actualData.get(0).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(0).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals(1L, actualData.get(0).getLocationNo().value());
@@ -546,6 +572,7 @@ public class PhotoMstMapperTest {
 		void update_by_photoEnglishTitle() {
 			PhotoMst conditionPhotoMst = PhotoMst.builder().photoEnglishTitle(new PhotoEnglishTitle("title11")).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
 			
@@ -555,7 +582,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(1L), actualData.get(0).getAccountNo());
 			assertEquals(1L, actualData.get(0).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(0).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals(1L, actualData.get(0).getLocationNo().value());
@@ -576,6 +605,7 @@ public class PhotoMstMapperTest {
 		void update_by_caption() {
 			PhotoMst conditionPhotoMst = PhotoMst.builder().caption(new Caption("キャプション11")).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
 			
@@ -585,7 +615,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(1L), actualData.get(0).getAccountNo());
 			assertEquals(1L, actualData.get(0).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(0).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals(1L, actualData.get(0).getLocationNo().value());
@@ -606,6 +638,7 @@ public class PhotoMstMapperTest {
 		void update_by_directionKbnCode() {
 			PhotoMst conditionPhotoMst = PhotoMst.builder().directionKbn(DirectionEnum.VERTICAL).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
 			
@@ -615,7 +648,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(1L), actualData.get(0).getAccountNo());
 			assertEquals(1L, actualData.get(0).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(0).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals(1L, actualData.get(0).getLocationNo().value());
@@ -636,6 +671,7 @@ public class PhotoMstMapperTest {
 		void update_by_focalLength() {
 			PhotoMst conditionPhotoMst = PhotoMst.builder().focalLength(new FocalLength(24)).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
 			
@@ -645,7 +681,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(1L), actualData.get(0).getAccountNo());
 			assertEquals(1L, actualData.get(0).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(0).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals(1L, actualData.get(0).getLocationNo().value());
@@ -666,6 +704,7 @@ public class PhotoMstMapperTest {
 		void update_by_fValue() {
 			PhotoMst conditionPhotoMst = PhotoMst.builder().fValue(new FValue(BigDecimal.valueOf(8.0))).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
 			
@@ -675,7 +714,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(1L), actualData.get(0).getAccountNo());
 			assertEquals(1L, actualData.get(0).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(0).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals(1L, actualData.get(0).getLocationNo().value());
@@ -696,6 +737,7 @@ public class PhotoMstMapperTest {
 		void update_by_shutterSpeed() {
 			PhotoMst conditionPhotoMst = PhotoMst.builder().shutterSpeed(new ShutterSpeed(BigDecimal.valueOf(1))).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
 			
@@ -705,7 +747,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(1L), actualData.get(0).getAccountNo());
 			assertEquals(1L, actualData.get(0).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(0).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals(1L, actualData.get(0).getLocationNo().value());
@@ -726,6 +770,7 @@ public class PhotoMstMapperTest {
 		void update_by_iso() {
 			PhotoMst conditionPhotoMst = PhotoMst.builder().iso(new Iso(100)).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
 			
@@ -735,7 +780,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(1L), actualData.get(0).getAccountNo());
 			assertEquals(1L, actualData.get(0).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(0).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals(1L, actualData.get(0).getLocationNo().value());
@@ -769,6 +816,7 @@ public class PhotoMstMapperTest {
 		void update_some_conditions() {
 			PhotoMst conditionPhotoMst = PhotoMst.builder().accountNo(new AccountNo(1L)).photoNo(new PhotoNo(1L)).build();
 			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
 			
@@ -778,7 +826,9 @@ public class PhotoMstMapperTest {
 			assertEquals(new AccountNo(1L), actualData.get(0).getAccountNo());
 			assertEquals(1L, actualData.get(0).getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.get(0).getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.get(0).getUpdatedBy());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals(1L, actualData.get(0).getLocationNo().value());

--- a/backend/src/test/java/com/web/gallery/mapper/PhotoTagMstMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/PhotoTagMstMapperTest.java
@@ -311,9 +311,10 @@ public class PhotoTagMstMapperTest {
 					.tagEnglishName(new TagEnglishName("spring"))
 					.build();
 			
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actualCount = photoTagMstMapper.insert(photoTagMst);
 			assertEquals(1, actualCount);
-			
+
 			List<PhotoTagMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_tag_mst WHERE account_no=1 and photo_no=1 and tag_no=3", (rs, rowNum) ->
 						PhotoTagMst.builder()
@@ -330,6 +331,7 @@ public class PhotoTagMstMapperTest {
 			assertEquals(1L, actualData.getFirst().getPhotoNo().value());
 			assertEquals(3L, actualData.getFirst().getTagNo().value());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
 			assertEquals("春", actualData.getFirst().getTagJapaneseName().value());
 			assertEquals("spring", actualData.getFirst().getTagEnglishName().value());
 		}

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImplTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.web.gallery.constant.Consts;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.domain.common.Address;
@@ -151,7 +152,7 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals(1L, actual.get(0).getPhotoNo().value());
 			assertEquals(1, actual.get(0).getFavoriteCount().value());
 			assertFalse(actual.get(0).getIsFavorite().value());
-			assertEquals(OffsetDateTime.of(2000, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt().value());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 9, 0, 0, 0, Consts.JST), actual.get(0).getPhotoAt().value());
 			assertEquals("https://localhost:8080/image/aaaaaaaa/DSC111.jpg", actual.get(0).getImageFilePath().value());
 			assertEquals("キャプション1", actual.get(0).getCaption().value());
 			assertEquals(DirectionEnum.VERTICAL, actual.get(0).getDirectionKbn());
@@ -160,7 +161,7 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals(2L, actual.get(1).getPhotoNo().value());
 			assertEquals(2, actual.get(1).getFavoriteCount().value());
 			assertTrue(actual.get(1).getIsFavorite().value());
-			assertEquals(OffsetDateTime.of(2000, 2, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(1).getPhotoAt().value());
+			assertEquals(OffsetDateTime.of(2000, 2, 1, 9, 0, 0, 0, Consts.JST), actual.get(1).getPhotoAt().value());
 			assertEquals("https://localhost:8080/image/aaaaaaaa/DSC222.jpg", actual.get(1).getImageFilePath().value());
 			assertEquals("キャプション2", actual.get(1).getCaption().value());
 			assertEquals(DirectionEnum.HORIZONTAL, actual.get(1).getDirectionKbn());
@@ -233,7 +234,7 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals(1L, actual.get(0).getPhotoNo().value());
 			assertEquals(1, actual.get(0).getFavoriteCount().value());
 			assertFalse(actual.get(0).getIsFavorite().value());
-			assertEquals(OffsetDateTime.of(2000, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt().value());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 9, 0, 0, 0, Consts.JST), actual.get(0).getPhotoAt().value());
 			assertEquals("https://localhost:8080/image/aaaaaaaa/DSC111.jpg", actual.get(0).getImageFilePath().value());
 			assertEquals("キャプション1", actual.get(0).getCaption().value());
 			assertEquals(DirectionEnum.VERTICAL, actual.get(0).getDirectionKbn());
@@ -246,7 +247,7 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals(2L, actual.get(1).getPhotoNo().value());
 			assertEquals(2, actual.get(1).getFavoriteCount().value());
 			assertTrue(actual.get(1).getIsFavorite().value());
-			assertEquals(OffsetDateTime.of(2000, 2, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(1).getPhotoAt().value());
+			assertEquals(OffsetDateTime.of(2000, 2, 1, 9, 0, 0, 0, Consts.JST), actual.get(1).getPhotoAt().value());
 			assertEquals("https://localhost:8080/image/aaaaaaaa/DSC222.jpg", actual.get(1).getImageFilePath().value());
 			assertEquals("キャプション2", actual.get(1).getCaption().value());
 			assertEquals(DirectionEnum.HORIZONTAL, actual.get(1).getDirectionKbn());
@@ -398,7 +399,7 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals(new AccountNo(1L), actual.getAccountNo());
 			assertEquals(1L, actual.getPhotoNo().value());
 			assertFalse(actual.getIsFavorite().value());
-			assertEquals(OffsetDateTime.of(2000, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getPhotoAt().value());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 9, 0, 0, 0, Consts.JST), actual.getPhotoAt().value());
 			assertEquals(1L, actual.getLocationNo().value());
 			assertEquals("住所", actual.getAddress().value());
 			assertEquals(0, BigDecimal.valueOf(38.000).compareTo(actual.getLatitude().value()));

--- a/backend/src/test/java/com/web/gallery/repository/impl/RefreshTokenRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/RefreshTokenRepositoryImplTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -44,17 +45,22 @@ public class RefreshTokenRepositoryImplTest {
 		@Order(1)
 		@DisplayName("正常系：リフレッシュトークンを保存する")
 		void save_success() {
+			OffsetDateTime expiresAt = OffsetDateTime.now().plusDays(7);
 			RefreshTokenModel refreshTokenModel = RefreshTokenModel.builder()
 					.accountNo(new AccountNo(1L))
 					.tokenHash(new TokenHash("abc123hash"))
-					.expiresAt(new ExpiresAt(OffsetDateTime.now().plusDays(7)))
+					.expiresAt(new ExpiresAt(expiresAt))
 					.build();
 
 			doReturn(1).when(refreshTokenMapper).insert(any(RefreshToken.class));
 
 			refreshTokenRepositoryImpl.save(refreshTokenModel);
 
-			verify(refreshTokenMapper, times(1)).insert(any(RefreshToken.class));
+			ArgumentCaptor<RefreshToken> refreshTokenCaptor = ArgumentCaptor.forClass(RefreshToken.class);
+			verify(refreshTokenMapper, times(1)).insert(refreshTokenCaptor.capture());
+			assertEquals(new AccountNo(1L), refreshTokenCaptor.getValue().getAccountNo());
+			assertEquals(new TokenHash("abc123hash"), refreshTokenCaptor.getValue().getTokenHash());
+			assertEquals(new ExpiresAt(expiresAt), refreshTokenCaptor.getValue().getExpiresAt());
 		}
 	}
 

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/AccountRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/AccountRepositoryImplIntegrationTest.java
@@ -142,9 +142,10 @@ public class AccountRepositoryImplIntegrationTest {
 					.accountName(new AccountName("ZZZZZZZZ"))
 					.password(new Password("zzzzzzzz"))
 					.build();
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			accountRepositoryImpl.regist(accountModel);
-			
+
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_id='zzzzzzzz'", (rs, rowNum) ->
 						Account.builder()
@@ -166,11 +167,13 @@ public class AccountRepositoryImplIntegrationTest {
 							.lastLoginDatetime(new LastLoginDatetime(rs.getObject("last_login_datetime", OffsetDateTime.class)))
 							.loginFailureCount(new LoginFailureCount(rs.getInt("login_failure_count")))
 							.build());
-			
+
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(0L), actualData.getFirst().getCreatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
 			assertEquals(new UpdatedBy(0L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("zzzzzzzz"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("ZZZZZZZZ"), actualData.getFirst().getAccountName());
@@ -200,9 +203,10 @@ public class AccountRepositoryImplIntegrationTest {
 					.residentPrefectureKbnCode(new ResidentPrefectureKbnCode("Okinawa"))
 					.freeMemo(new FreeMemo("フリーメモ"))
 					.build();
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			accountRepositoryImpl.regist(accountModel);
-			
+
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_id='zzzzzzzz'", (rs, rowNum) ->
 						Account.builder()
@@ -224,11 +228,13 @@ public class AccountRepositoryImplIntegrationTest {
 							.lastLoginDatetime(new LastLoginDatetime(rs.getObject("last_login_datetime", OffsetDateTime.class)))
 							.loginFailureCount(new LoginFailureCount(rs.getInt("login_failure_count")))
 							.build());
-			
+
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(0L), actualData.getFirst().getCreatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
 			assertEquals(new UpdatedBy(0L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("zzzzzzzz"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("ZZZZZZZZ"), actualData.getFirst().getAccountName());
@@ -273,9 +279,10 @@ public class AccountRepositoryImplIntegrationTest {
 					.accountId(new AccountId("aaaaaaaa"))
 					.accountName(new AccountName("AAAAAAAA"))
 					.build();
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			accountRepositoryImpl.update(accountModel);
-			
+
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_id='aaaaaaaa'", (rs, rowNum) ->
 						Account.builder()
@@ -297,11 +304,13 @@ public class AccountRepositoryImplIntegrationTest {
 							.lastLoginDatetime(new LastLoginDatetime(rs.getObject("last_login_datetime", OffsetDateTime.class)))
 							.loginFailureCount(new LoginFailureCount(rs.getInt("login_failure_count")))
 							.build());
-			
+
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("aaaaaaaa"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("AAAAAAAA"), actualData.getFirst().getAccountName());
@@ -333,9 +342,10 @@ public class AccountRepositoryImplIntegrationTest {
 					.lastLoginDatetime(new LastLoginDatetime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9))))
 					.loginFailureCount(new LoginFailureCount(2))
 					.build();
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			accountRepositoryImpl.update(accountModel);
-			
+
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_id='aaaaaaaa'", (rs, rowNum) ->
 						Account.builder()
@@ -357,11 +367,13 @@ public class AccountRepositoryImplIntegrationTest {
 							.lastLoginDatetime(new LastLoginDatetime(rs.getObject("last_login_datetime", OffsetDateTime.class)))
 							.loginFailureCount(new LoginFailureCount(rs.getInt("login_failure_count")))
 							.build());
-			
+
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("aaaaaaaa"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("AAAAAAAA"), actualData.getFirst().getAccountName());
@@ -403,9 +415,10 @@ public class AccountRepositoryImplIntegrationTest {
 			AccountModel accountModel = AccountModel.builder()
 					.accountNo(new AccountNo(8L))
 					.build();
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			accountRepositoryImpl.updateLoginFailureCount(accountModel);
-			
+
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_no=8", (rs, rowNum) ->
 						Account.builder()
@@ -427,11 +440,13 @@ public class AccountRepositoryImplIntegrationTest {
 							.lastLoginDatetime(new LastLoginDatetime(rs.getObject("last_login_datetime", OffsetDateTime.class)))
 							.loginFailureCount(new LoginFailureCount(rs.getInt("login_failure_count")))
 							.build());
-			
+
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(8L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(8L), actualData.getFirst().getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 8, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt().value());
 			assertEquals(new UpdatedBy(8L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("hhhhhhhh"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("HHHHHHHH"), actualData.getFirst().getAccountName());
@@ -455,9 +470,10 @@ public class AccountRepositoryImplIntegrationTest {
 					.lastLoginDatetime(new LastLoginDatetime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9))))
 					.loginFailureCount(new LoginFailureCount(2))
 					.build();
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			accountRepositoryImpl.updateLoginFailureCount(accountModel);
-			
+
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_no=1", (rs, rowNum) ->
 						Account.builder()
@@ -479,11 +495,13 @@ public class AccountRepositoryImplIntegrationTest {
 							.lastLoginDatetime(new LastLoginDatetime(rs.getObject("last_login_datetime", OffsetDateTime.class)))
 							.loginFailureCount(new LoginFailureCount(rs.getInt("login_failure_count")))
 							.build());
-			
+
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(new AccountId("aaaaaaaa"), actualData.getFirst().getAccountId());
 			assertEquals(new AccountName("AAAAAAAA"), actualData.getFirst().getAccountName());

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoDetailRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoDetailRepositoryImplIntegrationTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.web.gallery.constant.Consts;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.domain.common.Address;
@@ -162,7 +163,7 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 			assertEquals(new AccountNo(2L), actual.getAccountNo());
 			assertEquals(1L, actual.getPhotoNo().value());
 			assertFalse(actual.getIsFavorite().value());
-			assertEquals(OffsetDateTime.of(2022, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getPhotoAt().value());
+			assertEquals(OffsetDateTime.of(2022, 1, 1, 9, 0, 0, 0, Consts.JST), actual.getPhotoAt().value());
 			assertEquals(4L, actual.getLocationNo().value());
 			assertEquals("住所4", actual.getAddress().value());
 			assertEquals(0, BigDecimal.valueOf(38.400).compareTo(actual.getLatitude().value()));
@@ -195,7 +196,7 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 			assertEquals(new AccountNo(1L), actual.getAccountNo());
 			assertEquals(1L, actual.getPhotoNo().value());
 			assertTrue(actual.getIsFavorite().value());
-			assertEquals(OffsetDateTime.of(2021, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getPhotoAt().value());
+			assertEquals(OffsetDateTime.of(2021, 1, 1, 9, 0, 0, 0, Consts.JST), actual.getPhotoAt().value());
 			assertEquals(1L, actual.getLocationNo().value());
 			assertEquals("住所1", actual.getAddress().value());
 			assertEquals(0, BigDecimal.valueOf(38.100).compareTo(actual.getLatitude().value()));

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoFavoriteRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoFavoriteRepositoryImplIntegrationTest.java
@@ -56,6 +56,7 @@ public class PhotoFavoriteRepositoryImplIntegrationTest {
 					.favoritePhotoNo(new PhotoNo(1L))
 					.build();
 
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			photoFavoriteRepositoryImpl.regist(favoriteModel);
 
 			List<PhotoFavorite> actualData = jdbcTemplate.query(
@@ -72,6 +73,7 @@ public class PhotoFavoriteRepositoryImplIntegrationTest {
 			assertEquals(new AccountNo(2L), actualData.getFirst().getFavoritePhotoAccountNo());
 			assertEquals(1L, actualData.getFirst().getFavoritePhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
 		}
 		
 		@Test

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoMstRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoMstRepositoryImplIntegrationTest.java
@@ -76,9 +76,10 @@ public class PhotoMstRepositoryImplIntegrationTest {
 					.photoNo(new PhotoNo(4L))
 					.imageFilePath(new ImageFilePath(imageFilePath))
 					.build();
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 4L);
-			
+
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst WHERE account_no=1 and photo_no=4", (rs, rowNum) ->
 						PhotoMst.builder()
@@ -101,12 +102,14 @@ public class PhotoMstRepositoryImplIntegrationTest {
 							.shutterSpeed(new ShutterSpeed(rs.getBigDecimal("shutter_speed")))
 							.iso(new Iso(rs.getInt("iso")))
 							.build());
-			
+
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(4L, actualData.getFirst().getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getPhotoAt().value().plusHours(9));
 			assertEquals(0L, actualData.getFirst().getLocationNo().value());
@@ -120,7 +123,7 @@ public class PhotoMstRepositoryImplIntegrationTest {
 			assertEquals(0, BigDecimal.ZERO.compareTo(actualData.getFirst().getShutterSpeed().value()));
 			assertEquals(0, actualData.getFirst().getIso().value());
 		}
-		
+
 		@Test
 		@Order(2)
 		@DisplayName("正常系：Nullのパラメータを含まないPhotoDetailModelの登録")
@@ -142,9 +145,10 @@ public class PhotoMstRepositoryImplIntegrationTest {
 					.shutterSpeed(new ShutterSpeed(BigDecimal.valueOf(0.01)))
 					.iso(new Iso(100))
 					.build();
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 4L);
-			
+
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst WHERE account_no=1 and photo_no=4", (rs, rowNum) ->
 						PhotoMst.builder()
@@ -167,12 +171,14 @@ public class PhotoMstRepositoryImplIntegrationTest {
 							.shutterSpeed(new ShutterSpeed(rs.getBigDecimal("shutter_speed")))
 							.iso(new Iso(rs.getInt("iso")))
 							.build());
-			
+
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(4L, actualData.getFirst().getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getPhotoAt().value().plusHours(9));
 			assertEquals(1L, actualData.getFirst().getLocationNo().value());
@@ -220,9 +226,10 @@ public class PhotoMstRepositoryImplIntegrationTest {
 					.photoNo(new PhotoNo(1L))
 					.imageFilePath(new ImageFilePath(imageFilePath))
 					.build();
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			photoMstRepositoryImpl.update(photoDetailModel);
-			
+
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst WHERE account_no=1 and photo_no=1", (rs, rowNum) ->
 						PhotoMst.builder()
@@ -245,12 +252,14 @@ public class PhotoMstRepositoryImplIntegrationTest {
 							.shutterSpeed(new ShutterSpeed(rs.getBigDecimal("shutter_speed")))
 							.iso(new Iso(rs.getInt("iso")))
 							.build());
-			
+
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(1L, actualData.getFirst().getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getPhotoAt().value().plusHours(9));
 			assertEquals(0L, actualData.getFirst().getLocationNo().value());
@@ -286,9 +295,10 @@ public class PhotoMstRepositoryImplIntegrationTest {
 					.shutterSpeed(new ShutterSpeed(BigDecimal.valueOf(1)))
 					.iso(new Iso(1000))
 					.build();
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			photoMstRepositoryImpl.update(photoDetailModel);
-			
+
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst WHERE account_no=1 and photo_no=1", (rs, rowNum) ->
 						PhotoMst.builder()
@@ -311,12 +321,14 @@ public class PhotoMstRepositoryImplIntegrationTest {
 							.shutterSpeed(new ShutterSpeed(rs.getBigDecimal("shutter_speed")))
 							.iso(new Iso(rs.getInt("iso")))
 							.build());
-			
+
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(1L, actualData.getFirst().getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getPhotoAt().value().plusHours(9));
 			assertEquals(1L, actualData.getFirst().getLocationNo().value());
@@ -364,9 +376,10 @@ public class PhotoMstRepositoryImplIntegrationTest {
 					.photoNo(new PhotoNo(1L))
 					.imageFilePath(new ImageFilePath(imageFilePath))
 					.build();
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			photoMstRepositoryImpl.delete(photoDeleteModel);
-			
+
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst WHERE account_no=1 and photo_no=1", (rs, rowNum) ->
 						PhotoMst.builder()
@@ -389,13 +402,15 @@ public class PhotoMstRepositoryImplIntegrationTest {
 							.shutterSpeed(new ShutterSpeed(rs.getBigDecimal("shutter_speed")))
 							.iso(new Iso(rs.getInt("iso")))
 							.build());
-			
+
 			assertEquals(1, actualData.size());
 			assertEquals(1, actualData.size());
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(1L, actualData.getFirst().getPhotoNo().value());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt().value());
 			assertEquals(new UpdatedBy(1L), actualData.getFirst().getUpdatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertTrue(actualData.getFirst().getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2021, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getPhotoAt().value().plusHours(9));
 			assertEquals(1L, actualData.getFirst().getLocationNo().value());

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoTagMstRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoTagMstRepositoryImplIntegrationTest.java
@@ -59,9 +59,10 @@ public class PhotoTagMstRepositoryImplIntegrationTest {
 					.tagJapaneseName(new TagJapaneseName("海"))
 					.tagEnglishName(new TagEnglishName("sea"))
 					.build();
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			photoTagMstRepositoryImpl.regist(photoTagModel);
-			
+
 			List<PhotoTagMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_tag_mst WHERE account_no=1 and photo_no=1 and tag_no=3", (rs, rowNum) ->
 						PhotoTagMst.builder()
@@ -78,6 +79,7 @@ public class PhotoTagMstRepositoryImplIntegrationTest {
 			assertEquals(1L, actualData.getFirst().getPhotoNo().value());
 			assertEquals(3L, actualData.getFirst().getTagNo().value());
 			assertEquals(new CreatedBy(1L), actualData.getFirst().getCreatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
 			assertEquals("海", actualData.getFirst().getTagJapaneseName().value());
 			assertEquals("sea", actualData.getFirst().getTagEnglishName().value());
 		}

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/RefreshTokenRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/RefreshTokenRepositoryImplIntegrationTest.java
@@ -89,6 +89,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 					.expiresAt(new ExpiresAt(OffsetDateTime.now().plusDays(7)))
 					.build();
 
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			refreshTokenRepositoryImpl.save(refreshToken);
 
 			List<RefreshToken> actualData = getRefreshTokenData("new_token_hash");
@@ -96,7 +97,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 			assertEquals(new AccountNo(1L), actualData.getFirst().getAccountNo());
 			assertEquals(new TokenHash("new_token_hash"), actualData.getFirst().getTokenHash());
 			assertFalse(actualData.getFirst().getIsRevoked().value());
-			assertNotNull(actualData.getFirst().getCreatedAt());
+			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
 			assertTrue(actualData.getFirst().getExpiresAt().value().isAfter(OffsetDateTime.now()));
 		}
 	}

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/RefreshTokenRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/RefreshTokenRepositoryImplIntegrationTest.java
@@ -3,6 +3,7 @@ package com.web.gallery.repository.impl.integration;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -83,7 +84,8 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：リフレッシュトークンを保存する")
 		void save_success() {
-			OffsetDateTime expiresAt = OffsetDateTime.now().plusDays(7);
+			// PostgreSQLのtimestamp with time zone型はマイクロ秒精度までしか保持しないため、ナノ秒精度を切り捨てて比較値を揃える
+			OffsetDateTime expiresAt = OffsetDateTime.now().plusDays(7).truncatedTo(ChronoUnit.MICROS);
 			RefreshTokenModel refreshToken = RefreshTokenModel.builder()
 					.accountNo(new AccountNo(1L))
 					.tokenHash(new TokenHash("new_token_hash"))

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/RefreshTokenRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/RefreshTokenRepositoryImplIntegrationTest.java
@@ -83,10 +83,11 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：リフレッシュトークンを保存する")
 		void save_success() {
+			OffsetDateTime expiresAt = OffsetDateTime.now().plusDays(7);
 			RefreshTokenModel refreshToken = RefreshTokenModel.builder()
 					.accountNo(new AccountNo(1L))
 					.tokenHash(new TokenHash("new_token_hash"))
-					.expiresAt(new ExpiresAt(OffsetDateTime.now().plusDays(7)))
+					.expiresAt(new ExpiresAt(expiresAt))
 					.build();
 
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
@@ -98,7 +99,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 			assertEquals(new TokenHash("new_token_hash"), actualData.getFirst().getTokenHash());
 			assertFalse(actualData.getFirst().getIsRevoked().value());
 			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
-			assertTrue(actualData.getFirst().getExpiresAt().value().isAfter(OffsetDateTime.now()));
+			assertTrue(expiresAt.isEqual(actualData.getFirst().getExpiresAt().value()));
 		}
 	}
 

--- a/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
@@ -4,9 +4,12 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
@@ -32,6 +35,7 @@ import org.springframework.test.context.ActiveProfiles;
 import com.web.gallery.AccountPrincipal;
 import com.web.gallery.config.LoginConfig;
 import com.web.gallery.config.PhotoConfig;
+import com.web.gallery.constant.Consts;
 import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountName;
 import com.web.gallery.domain.account.AccountNo;
@@ -80,7 +84,16 @@ public class AccountServiceImplTest {
 
 	@Mock
 	private PhotoConfig photoConfig;
-	
+
+	@Mock
+	private Clock clock;
+
+	@BeforeEach
+	void setUpClock() {
+		lenient().when(clock.instant()).thenReturn(Instant.now());
+		lenient().when(clock.getZone()).thenReturn(Consts.JST);
+	}
+
 	@Nested
 	@Order(1)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -429,7 +430,7 @@ public class AccountServiceImplTest {
 			doNothing().when(accountRepositoryImpl).updateLoginFailureCount(accountModelCaptor.capture());
 			
 			accountServiceImpl.handle(event);
-			
+
 			AccountModel accountModel = accountModelCaptor.getValue();
 			assertEquals(new AccountNo(1L), accountModel.getAccountNo());
 			assertNull(accountModel.getAccountId());
@@ -441,7 +442,7 @@ public class AccountServiceImplTest {
 			assertNull(accountModel.getResidentPrefectureKbnCode());
 			assertNull(accountModel.getFreeMemo());
 			assertNull(accountModel.getAuthorityKbn());
-			assertNotNull(accountModel.getLastLoginDatetime());
+			assertEquals(OffsetDateTime.now(clock), accountModel.getLastLoginDatetime().value());
 			assertEquals(new LoginFailureCount(0), accountModel.getLoginFailureCount());
 		}
 		

--- a/backend/src/test/java/com/web/gallery/service/impl/AuthServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AuthServiceImplTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -104,7 +105,9 @@ class AuthServiceImplTest {
 			assertEquals(900L, result.getExpiresIn().value());
 
 			verify(refreshTokenRepository).revokeAllByAccountNo(1L);
-			verify(refreshTokenRepository).save(any(RefreshTokenModel.class));
+			ArgumentCaptor<RefreshTokenModel> refreshTokenModelCaptor = ArgumentCaptor.forClass(RefreshTokenModel.class);
+			verify(refreshTokenRepository).save(refreshTokenModelCaptor.capture());
+			assertEquals(OffsetDateTime.now(clock).plusDays(7), refreshTokenModelCaptor.getValue().getExpiresAt().value());
 		}
 
 		@Test

--- a/backend/src/test/java/com/web/gallery/service/impl/AuthServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AuthServiceImplTest.java
@@ -5,9 +5,12 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.doReturn;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -24,6 +27,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import com.web.gallery.AccountPrincipal;
 import com.web.gallery.config.JwtConfig;
+import com.web.gallery.constant.Consts;
 import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.common.ExpiresAt;
@@ -59,6 +63,15 @@ class AuthServiceImplTest {
 
 	@Mock
 	private AccountServiceImpl accountServiceImpl;
+
+	@Mock
+	private Clock clock;
+
+	@BeforeEach
+	void setUpClock() {
+		lenient().when(clock.instant()).thenReturn(Instant.now());
+		lenient().when(clock.getZone()).thenReturn(Consts.JST);
+	}
 
 	@Nested
 	@DisplayName("#login")

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/AccountServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/AccountServiceImplIntegrationTest.java
@@ -427,7 +427,9 @@ public class AccountServiceImplIntegrationTest {
 			AuthenticationSuccessEvent event = new AuthenticationSuccessEvent(authentication);
 
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
+			OffsetDateTime beforeLogin = OffsetDateTime.now();
 			accountServiceImpl.handle(event);
+			OffsetDateTime afterLogin = OffsetDateTime.now();
 
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_no=11", (rs, rowNum) ->
@@ -467,7 +469,8 @@ public class AccountServiceImplIntegrationTest {
 			assertEquals("Tokyo", actualData.getFirst().getResidentPrefectureKbnCode().value());
 			assertEquals("よろしく", actualData.getFirst().getFreeMemo().value());
 			assertEquals(AuthorityEnum.NORMAL, actualData.getFirst().getAuthorityKbn());
-			assertNotEquals(OffsetDateTime.of(2002, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getLastLoginDatetime().value().plusHours(9));
+			assertFalse(actualData.getFirst().getLastLoginDatetime().value().isBefore(beforeLogin));
+			assertFalse(actualData.getFirst().getLastLoginDatetime().value().isAfter(afterLogin));
 			assertEquals(new LoginFailureCount(0), actualData.getFirst().getLoginFailureCount());
 		}
 	}

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/AccountServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/AccountServiceImplIntegrationTest.java
@@ -103,8 +103,10 @@ public class AccountServiceImplIntegrationTest {
 					.accountName(new AccountName("MMMMMMMM"))
 					.password(new Password("mmmmmmmm"))
 					.build();
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			assertTrue(accountServiceImpl.registAccount(accountModel));
-			
+
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_id='mmmmmmmm'", (rs, rowNum) ->
 						Account.builder()
@@ -130,7 +132,9 @@ public class AccountServiceImplIntegrationTest {
 			assertEquals(1, actualData.size());
 			assertEquals(1L, actualData.getFirst().getAccountNo().value());
 			assertEquals(0L, actualData.getFirst().getCreatedBy().value());
+			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
 			assertEquals(0L, actualData.getFirst().getUpdatedBy().value());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals("mmmmmmmm", actualData.getFirst().getAccountId().value());
 			assertEquals("MMMMMMMM", actualData.getFirst().getAccountName().value());
@@ -170,8 +174,10 @@ public class AccountServiceImplIntegrationTest {
 		@DisplayName("正常系：アカウントを更新")
 		void updateAccount_success() throws UpdateFailureException {
 			AccountModel accountModel = AccountModel.builder().accountNo(new AccountNo(1L)).accountId(new AccountId("zzzzzzzz")).build();
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			assertFalse(accountServiceImpl.updateAccount(accountModel));
-			
+
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_no=1", (rs, rowNum) ->
 						Account.builder()
@@ -197,7 +203,9 @@ public class AccountServiceImplIntegrationTest {
 			assertEquals(1, actualData.size());
 			assertEquals(1L, actualData.getFirst().getAccountNo().value());
 			assertEquals(1L, actualData.getFirst().getCreatedBy().value());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt().value());
 			assertEquals(1L, actualData.getFirst().getUpdatedBy().value());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals("zzzzzzzz", actualData.getFirst().getAccountId().value());
 			assertEquals("AAAAAAAA", actualData.getFirst().getAccountName().value());
@@ -218,7 +226,7 @@ public class AccountServiceImplIntegrationTest {
 		void updateAccount_account_already_exist() throws UpdateFailureException {
 			AccountModel accountModel = AccountModel.builder().accountNo(new AccountNo(1L)).accountId(new AccountId("bbbbbbbb")).build();
 			assertTrue(accountServiceImpl.updateAccount(accountModel));
-			
+
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_no=1", (rs, rowNum) ->
 						Account.builder()
@@ -240,11 +248,13 @@ public class AccountServiceImplIntegrationTest {
 							.lastLoginDatetime(new LastLoginDatetime(rs.getObject("last_login_datetime", OffsetDateTime.class)))
 							.loginFailureCount(new LoginFailureCount(rs.getInt("login_failure_count")))
 							.build());
-			
+
 			assertEquals(1, actualData.size());
 			assertEquals(1L, actualData.getFirst().getAccountNo().value());
 			assertEquals(1L, actualData.getFirst().getCreatedBy().value());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt().value());
 			assertEquals(1L, actualData.getFirst().getUpdatedBy().value());
+			assertEquals(OffsetDateTime.of(2001, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals("aaaaaaaa", actualData.getFirst().getAccountId().value());
 			assertEquals("AAAAAAAA", actualData.getFirst().getAccountName().value());
@@ -415,9 +425,10 @@ public class AccountServiceImplIntegrationTest {
 			
 			Authentication authentication = new UsernamePasswordAuthenticationToken(username, password, authorities);
 			AuthenticationSuccessEvent event = new AuthenticationSuccessEvent(authentication);
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			accountServiceImpl.handle(event);
-			
+
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_no=11", (rs, rowNum) ->
 						Account.builder()
@@ -443,7 +454,9 @@ public class AccountServiceImplIntegrationTest {
 			assertEquals(1, actualData.size());
 			assertEquals(11L, actualData.getFirst().getAccountNo().value());
 			assertEquals(11L, actualData.getFirst().getCreatedBy().value());
+			assertEquals(OffsetDateTime.of(2000, 1, 11, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt().value());
 			assertEquals(11L, actualData.getFirst().getUpdatedBy().value());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals("kkkkkkkk", actualData.getFirst().getAccountId().value());
 			assertEquals("KKKKKKKK", actualData.getFirst().getAccountName().value());
@@ -480,9 +493,10 @@ public class AccountServiceImplIntegrationTest {
 			BadCredentialsException exception = new BadCredentialsException(message);
 			
 			AuthenticationFailureBadCredentialsEvent event = new AuthenticationFailureBadCredentialsEvent(authentication, exception);
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			accountServiceImpl.handle(event);
-			
+
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_id='aaaaaaaa'", (rs, rowNum) ->
 						Account.builder()
@@ -508,7 +522,9 @@ public class AccountServiceImplIntegrationTest {
 			assertEquals(1, actualData.size());
 			assertEquals(1L, actualData.getFirst().getAccountNo().value());
 			assertEquals(1L, actualData.getFirst().getCreatedBy().value());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.getFirst().getCreatedAt().value());
 			assertEquals(1L, actualData.getFirst().getUpdatedBy().value());
+			assertEquals(transactionNow, actualData.getFirst().getUpdatedAt().value());
 			assertFalse(actualData.getFirst().getIsDeleted().value());
 			assertEquals("aaaaaaaa", actualData.getFirst().getAccountId().value());
 			assertEquals("AAAAAAAA", actualData.getFirst().getAccountName().value());

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/AuthServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/AuthServiceImplIntegrationTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.web.gallery.config.JwtConfig;
 import com.web.gallery.model.AuthTokenModel;
 import com.web.gallery.model.RefreshTokenModel;
 import com.web.gallery.repository.RefreshTokenRepository;
@@ -43,6 +44,9 @@ public class AuthServiceImplIntegrationTest {
 
 	@Autowired
 	private PasswordEncoder passwordEncoder;
+
+	@Autowired
+	private JwtConfig jwtConfig;
 
 	private static final String TEST_PASSWORD = "password123";
 
@@ -96,7 +100,9 @@ public class AuthServiceImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：ログイン成功")
 		void login_success() throws Exception {
+			OffsetDateTime beforeLogin = OffsetDateTime.now();
 			AuthTokenModel result = authServiceImpl.login("testuser01", TEST_PASSWORD);
+			OffsetDateTime afterLogin = OffsetDateTime.now();
 
 			assertNotNull(result.getAccessToken().value());
 			assertFalse(result.getAccessToken().value().isEmpty());
@@ -110,7 +116,8 @@ public class AuthServiceImplIntegrationTest {
 			assertNotNull(storedToken);
 			assertEquals(1L, storedToken.getAccountNo().value());
 			assertFalse(storedToken.getIsRevoked().value());
-			assertTrue(storedToken.getExpiresAt().value().isAfter(OffsetDateTime.now()));
+			assertFalse(storedToken.getExpiresAt().value().isBefore(beforeLogin.plusDays(jwtConfig.getRefreshTokenExpirationDays())));
+			assertFalse(storedToken.getExpiresAt().value().isAfter(afterLogin.plusDays(jwtConfig.getRefreshTokenExpirationDays())));
 		}
 
 		@Test

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoFavoriteServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoFavoriteServiceImplIntegrationTest.java
@@ -54,9 +54,10 @@ public class PhotoFavoriteServiceImplIntegrationTest {
 					.favoritePhotoAccountNo(new AccountNo(1L))
 					.favoritePhotoNo(new PhotoNo(1L))
 					.build();
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			photoFavoriteServiceImpl.addFavorite(photoFavoriteModel);
-			
+
 			List<PhotoFavorite> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_favorite WHERE account_no=2 and favorite_photo_account_no=1 and favorite_photo_no=1", (rs, rowNum) ->
 						PhotoFavorite.builder()
@@ -71,6 +72,7 @@ public class PhotoFavoriteServiceImplIntegrationTest {
 			assertEquals(new AccountNo(1L), actualData.getFirst().getFavoritePhotoAccountNo());
 			assertEquals(new PhotoNo(1L), actualData.getFirst().getFavoritePhotoNo());
 			assertEquals(new CreatedBy(2L), actualData.getFirst().getCreatedBy());
+			assertEquals(transactionNow, actualData.getFirst().getCreatedAt().value());
 		}
 		
 		@Test

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoServiceImplIntegrationTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.web.gallery.constant.Consts;
 import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.common.Address;
@@ -144,7 +145,7 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(1L, actual.get(0).getAccountNo().value());
 			assertEquals(0, actual.get(0).getFavoriteCount().value());
 			assertFalse(actual.get(0).getIsFavorite().value());
-			assertEquals(OffsetDateTime.of(2023, 9, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt().value());
+			assertEquals(OffsetDateTime.of(2023, 9, 1, 9, 0, 0, 0, Consts.JST), actual.get(0).getPhotoAt().value());
 			assertEquals("https://www.xxx.com/aaaaaaaa/DSC19.jpg", actual.get(0).getImageFilePath().value());
 			assertEquals("キャプション19", actual.get(0).getCaption().value());
 			assertEquals(DirectionEnum.HORIZONTAL, actual.get(0).getDirectionKbn());
@@ -187,7 +188,7 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(1L, actual.get(0).getAccountNo().value());
 			assertEquals(4, actual.get(0).getFavoriteCount().value());
 			assertTrue(actual.get(0).getIsFavorite().value());
-			assertEquals(OffsetDateTime.of(2021, 2, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt().value());
+			assertEquals(OffsetDateTime.of(2021, 2, 1, 9, 0, 0, 0, Consts.JST), actual.get(0).getPhotoAt().value());
 			assertEquals("https://www.xxx.com/aaaaaaaa/DSC12.jpg", actual.get(0).getImageFilePath().value());
 			assertEquals("キャプション12", actual.get(0).getCaption().value());
 			assertEquals(DirectionEnum.HORIZONTAL, actual.get(0).getDirectionKbn());
@@ -238,7 +239,7 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(1L, actual.get(0).getAccountNo().value());
 			assertEquals(0, actual.get(0).getFavoriteCount().value());
 			assertFalse(actual.get(0).getIsFavorite().value());
-			assertEquals(OffsetDateTime.of(2021, 10, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt().value());
+			assertEquals(OffsetDateTime.of(2021, 10, 1, 9, 0, 0, 0, Consts.JST), actual.get(0).getPhotoAt().value());
 			assertEquals("https://www.xxx.com/aaaaaaaa/DSC20.jpg", actual.get(0).getImageFilePath().value());
 			assertEquals("キャプション20", actual.get(0).getCaption().value());
 			assertEquals(DirectionEnum.HORIZONTAL, actual.get(0).getDirectionKbn());
@@ -274,7 +275,7 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(1L, actual.get(0).getAccountNo().value());
 			assertEquals(0, actual.get(0).getFavoriteCount().value());
 			assertFalse(actual.get(0).getIsFavorite().value());
-			assertEquals(OffsetDateTime.of(2023, 8, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt().value());
+			assertEquals(OffsetDateTime.of(2023, 8, 1, 9, 0, 0, 0, Consts.JST), actual.get(0).getPhotoAt().value());
 			assertEquals("https://www.xxx.com/aaaaaaaa/DSC18.jpg", actual.get(0).getImageFilePath().value());
 			assertEquals("キャプション18", actual.get(0).getCaption().value());
 			assertEquals(DirectionEnum.VERTICAL, actual.get(0).getDirectionKbn());
@@ -309,7 +310,7 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(1L, actual.get(0).getAccountNo().value());
 			assertEquals(4, actual.get(0).getFavoriteCount().value());
 			assertTrue(actual.get(0).getIsFavorite().value());
-			assertEquals(OffsetDateTime.of(2021, 2, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt().value());
+			assertEquals(OffsetDateTime.of(2021, 2, 1, 9, 0, 0, 0, Consts.JST), actual.get(0).getPhotoAt().value());
 			assertEquals("https://www.xxx.com/aaaaaaaa/DSC12.jpg", actual.get(0).getImageFilePath().value());
 			assertEquals("キャプション12", actual.get(0).getCaption().value());
 			assertEquals(DirectionEnum.HORIZONTAL, actual.get(0).getDirectionKbn());
@@ -350,7 +351,7 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(1L, actual.get(0).getAccountNo().value());
 			assertEquals(3, actual.get(0).getFavoriteCount().value());
 			assertTrue(actual.get(0).getIsFavorite().value());
-			assertEquals(OffsetDateTime.of(2021, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.get(0).getPhotoAt().value());
+			assertEquals(OffsetDateTime.of(2021, 1, 1, 9, 0, 0, 0, Consts.JST), actual.get(0).getPhotoAt().value());
 			assertEquals("https://www.xxx.com/aaaaaaaa/DSC11.jpg", actual.get(0).getImageFilePath().value());
 			assertEquals("キャプション11", actual.get(0).getCaption().value());
 			assertEquals(DirectionEnum.HORIZONTAL, actual.get(0).getDirectionKbn());
@@ -386,7 +387,7 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(1L, actual.getAccountNo().value());
 			assertEquals(1L, actual.getPhotoNo().value());
 			assertTrue(actual.getIsFavorite().value());
-			assertEquals(OffsetDateTime.of(2021, 1, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)), actual.getPhotoAt().value());
+			assertEquals(OffsetDateTime.of(2021, 1, 1, 9, 0, 0, 0, Consts.JST), actual.getPhotoAt().value());
 			assertEquals(1L, actual.getLocationNo().value());
 			assertEquals("住所1", actual.getAddress().value());
 			assertEquals(0, BigDecimal.valueOf(38.100).compareTo(actual.getLatitude().value()));

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoServiceImplIntegrationTest.java
@@ -624,7 +624,8 @@ public class PhotoServiceImplIntegrationTest {
 			// 新規登録2枚目
 			PhotoDetailModel photoDetailModel2 = createNewPhoto();
 			photoDetailModelList.add(photoDetailModel2);
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
 
 			assertEquals(11, actual);
@@ -633,6 +634,8 @@ public class PhotoServiceImplIntegrationTest {
 
 			assertEquals(1L, actualData.get(0).getAccountNo().value());
 			assertEquals(11L, actualData.get(0).getPhotoNo().value());
+			assertEquals(transactionNow, actualData.get(0).getCreatedAt().value());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals("https://www.xxx.com/" + accountId + "/DSC21.jpg", actualData.get(0).getImageFilePath().value());
@@ -647,6 +650,8 @@ public class PhotoServiceImplIntegrationTest {
 
 			assertEquals(1L, actualData.get(1).getAccountNo().value());
 			assertEquals(12L, actualData.get(1).getPhotoNo().value());
+			assertEquals(transactionNow, actualData.get(1).getCreatedAt().value());
+			assertEquals(transactionNow, actualData.get(1).getUpdatedAt().value());
 			assertFalse(actualData.get(1).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(1).getPhotoAt().value().plusHours(9));
 			assertEquals("https://www.xxx.com/" + accountId + "/DSC22.jpg", actualData.get(1).getImageFilePath().value());
@@ -689,7 +694,8 @@ public class PhotoServiceImplIntegrationTest {
 			// 更新2枚目
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
 
 			assertEquals(3, actual);
@@ -697,6 +703,8 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(1, actualData1.size());
 			assertEquals(1L, actualData1.getFirst().getAccountNo().value());
 			assertEquals(2L, actualData1.getFirst().getPhotoNo().value());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData1.getFirst().getCreatedAt().value());
+			assertEquals(transactionNow, actualData1.getFirst().getUpdatedAt().value());
 			assertFalse(actualData1.getFirst().getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData1.getFirst().getPhotoAt().value());
 			assertEquals("https://www.xxx.com/" + accountId + "/DSC222.jpg", actualData1.getFirst().getImageFilePath().value());
@@ -726,6 +734,8 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(1, actualData2.size());
 			assertEquals(1L, actualData2.getFirst().getAccountNo().value());
 			assertEquals(3L, actualData2.getFirst().getPhotoNo().value());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData2.getFirst().getCreatedAt().value());
+			assertEquals(transactionNow, actualData2.getFirst().getUpdatedAt().value());
 			assertFalse(actualData2.getFirst().getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData2.getFirst().getPhotoAt().value());
 			assertEquals("https://www.xxx.com/" + accountId + "/DSC333.jpg", actualData2.getFirst().getImageFilePath().value());
@@ -737,11 +747,11 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(0, BigDecimal.valueOf(2.8).compareTo(actualData2.getFirst().getFValue().value()));
 			assertEquals(0, BigDecimal.valueOf(0.01).compareTo(actualData2.getFirst().getShutterSpeed().value()));
 			assertEquals(100, actualData2.getFirst().getIso().value());
-			
+
 			List<PhotoTagMst> actualTagData2 = getPhotoTagMst(accountId, 3L);
 			assertEquals(0, actualTagData2.size());
 		}
-		
+
 		@Test
 		@Order(5)
 		@DisplayName("正常系：新規登録＋更新")
@@ -755,7 +765,8 @@ public class PhotoServiceImplIntegrationTest {
 			// 更新1枚目
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
 
 			assertEquals(3, actual);
@@ -764,6 +775,8 @@ public class PhotoServiceImplIntegrationTest {
 
 			assertEquals(1L, actualData.get(0).getAccountNo().value());
 			assertEquals(11L, actualData.get(0).getPhotoNo().value());
+			assertEquals(transactionNow, actualData.get(0).getCreatedAt().value());
+			assertEquals(transactionNow, actualData.get(0).getUpdatedAt().value());
 			assertFalse(actualData.get(0).getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData.get(0).getPhotoAt().value());
 			assertEquals("https://www.xxx.com/" + accountId + "/DSC21.jpg", actualData.get(0).getImageFilePath().value());
@@ -793,6 +806,8 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(1, actualData2.size());
 			assertEquals(1L, actualData2.getFirst().getAccountNo().value());
 			assertEquals(3L, actualData2.getFirst().getPhotoNo().value());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData2.getFirst().getCreatedAt().value());
+			assertEquals(transactionNow, actualData2.getFirst().getUpdatedAt().value());
 			assertFalse(actualData2.getFirst().getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualData2.getFirst().getPhotoAt().value());
 			assertEquals("https://www.xxx.com/" + accountId + "/DSC333.jpg", actualData2.getFirst().getImageFilePath().value());
@@ -804,11 +819,11 @@ public class PhotoServiceImplIntegrationTest {
 			assertEquals(0, BigDecimal.valueOf(2.8).compareTo(actualData2.getFirst().getFValue().value()));
 			assertEquals(0, BigDecimal.valueOf(0.01).compareTo(actualData2.getFirst().getShutterSpeed().value()));
 			assertEquals(100, actualData2.getFirst().getIso().value());
-			
+
 			List<PhotoTagMst> actualTagData2 = getPhotoTagMst(accountId, 3L);
 			assertEquals(0, actualTagData2.size());
 		}
-		
+
 		@Test
 		@Order(6)
 		@DisplayName("異常系：FileDuplicateExceptionをthrowする（写真は複数枚）")
@@ -898,9 +913,10 @@ public class PhotoServiceImplIntegrationTest {
 					.photoNo(new PhotoNo(2L))
 					.imageFilePath(new ImageFilePath("DSC12.jpg"))
 					.build());
-			
+
+			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			photoServiceImpl.deletePhotos("aaaaaaaa", PhotoDeleteModelList.of(photoDeleteModelList));
-			
+
 			List<PhotoMst> actualPhotoMstData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no=1 and photo_no in (1, 2)", (rs, rowNum) ->
 						PhotoMst.builder()
@@ -924,7 +940,11 @@ public class PhotoServiceImplIntegrationTest {
 							.iso(new Iso(rs.getInt("iso")))
 							.build());
 			assertEquals(2, actualPhotoMstData.size());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualPhotoMstData.get(0).getCreatedAt().value());
+			assertEquals(transactionNow, actualPhotoMstData.get(0).getUpdatedAt().value());
 			assertTrue(actualPhotoMstData.get(0).getIsDeleted().value());
+			assertEquals(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), actualPhotoMstData.get(1).getCreatedAt().value());
+			assertEquals(transactionNow, actualPhotoMstData.get(1).getUpdatedAt().value());
 			assertTrue(actualPhotoMstData.get(1).getIsDeleted().value());
 			
 			List<PhotoMst> actualPhotoMstRestData = jdbcTemplate.query(


### PR DESCRIPTION
# 概要

## 背景

`OffsetDateTime.now()` がサーバーのデフォルトタイムゾーンに依存していたり、`plusHours(9)` によるタイムゾーン変換が各所に散在しており、JSTへの依存が明示的でなく保守性・テスト容易性に課題があった。

## 変更内容

- `ClockConfig` でJST固定の `Clock` Beanを新設
- `AccountModel#forLoginSuccess`、`AccountServiceImpl`、`AuthServiceImpl` の現在時刻取得（`OffsetDateTime.now()` / `OffsetDateTime.now(Consts.JST)`）を、DIした `Clock` 経由の `OffsetDateTime.now(clock)` に統一
- `PhotoModel`、`PhotoDetailModel`、`PhotoServiceImpl`（季節ソート用Comparator）で使われていた `plusHours(9)` を `withOffsetSameInstant(Consts.JST)` に置換
  - PostgreSQLの `timestamp with time zone` カラムがpgjdbc経由で読み込むと常にoffset+0で返るため、従来は時刻の数値だけ+9時間ずらして帳尻を合わせていた（instantとしては不正確）。`withOffsetSameInstant` により同じ瞬間を正しくJSTオフセットで表現し直すよう修正
- 上記変更に伴い、影響を受けるユニットテスト・統合テストの期待値・モック設定を修正

# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認（239件成功）
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認（335件成功）
- [x] `just dev` で frontend の起動が成功することを確認

# 懸念事項

`plusHours(9)` を `withOffsetSameInstant(Consts.JST)` に置き換えたことで、表示される日時の数値（年月日時分秒）は変わらないが、`OffsetDateTime` のoffset表記が `+00:00` から `+09:00` に変わる。これに伴いレスポンスJSON中のoffset表記も変わるため、フロントエンド側で厳密なoffset文字列比較をしている箇所がないか念のため確認をお願いしたい。