### PR TITLE
chore: WebSearch権限のドメイン制限を解除

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "permissions": {
     "allow": [
-      "WebSearch(domain:*)",
+      "WebSearch",
       "WebFetch(domain:*)",
       "Bash(chmod*)",
       "Bash(git add *)",


### PR DESCRIPTION
# 概要

## 背景

`.claude/settings.json` のWebSearch権限が `WebSearch(domain:*)` というドメイン限定の指定になっており、意図した通りに権限が機能していなかった。

## 変更内容

- `WebSearch(domain:*)` を `WebSearch` に変更し、WebSearchツールを制限なく許可するように修正

# 検証事項

- 本PRは`.claude/settings.json`の権限設定のみの変更のため、backend/frontendのビルド・テストは対象外

# 懸念事項

特になし