### PR TITLE
refactor: 写真保存パスの生成ロジックをPhotoEditResponseに移行

### DIFF
--- a/backend/src/main/java/com/web/gallery/controller/PhotoRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/PhotoRestController.java
@@ -3,7 +3,6 @@ package com.web.gallery.controller;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -186,14 +185,7 @@ public class PhotoRestController {
 
 		Long savedPhotoNo = photoService.savePhotos(photoAccountId, photoDetailModelList);
 
-		String savedImageFilePath;
-		if (Objects.isNull(photoSaveRequest.getPhotoNo()) && !Objects.isNull(photoSaveRequest.getImageFile())) {
-			savedImageFilePath = photoConfig.getOutputPath() + photoAccountId + "/" + photoSaveRequest.getImageFile().getOriginalFilename();
-		} else {
-			savedImageFilePath = Optional.ofNullable(photoSaveRequest.getImageFilePath()).orElse(Consts.STRING_EMPTY);
-		}
-
-		return ResponseEntity.ok(PhotoEditResponse.of(MessageConst.REGIST_PHOTO, savedPhotoNo, savedImageFilePath));
+		return ResponseEntity.ok(PhotoEditResponse.of(savedPhotoNo, photoAccountId, photoConfig.getOutputPath(), photoSaveRequest));
 	}
 	
 	/**

--- a/backend/src/main/java/com/web/gallery/controller/response/PhotoEditResponse.java
+++ b/backend/src/main/java/com/web/gallery/controller/response/PhotoEditResponse.java
@@ -1,6 +1,13 @@
 package com.web.gallery.controller.response;
 
+import java.util.Objects;
+import java.util.Optional;
+
 import org.springframework.http.HttpStatus;
+
+import com.web.gallery.constant.Consts;
+import com.web.gallery.constant.MessageConst;
+import com.web.gallery.controller.request.PhotoSaveRequest;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -49,5 +56,26 @@ public class PhotoEditResponse {
 				.photoNo(photoNo)
 				.imageFilePath(imageFilePath)
 				.build();
+	}
+
+	/**
+	 * 写真保存の成功レスポンスを生成する<p>
+	 * 新規登録でファイルアップロードされた場合は保存先のファイルパスを、それ以外の場合はリクエストの画像ファイルパスを設定する
+	 *
+	 * @param	photoNo				写真番号
+	 * @param	photoAccountId		写真所有者のアカウントID
+	 * @param	outputPath			写真の出力先パス
+	 * @param	photoSaveRequest	{@link PhotoSaveRequest}
+	 * @return						{@link PhotoEditResponse}
+	 */
+	public static PhotoEditResponse of(Long photoNo, String photoAccountId, String outputPath, PhotoSaveRequest photoSaveRequest) {
+		String savedImageFilePath;
+		if (Objects.isNull(photoSaveRequest.getPhotoNo()) && !Objects.isNull(photoSaveRequest.getImageFile())) {
+			savedImageFilePath = outputPath + photoAccountId + "/" + photoSaveRequest.getImageFile().getOriginalFilename();
+		} else {
+			savedImageFilePath = Optional.ofNullable(photoSaveRequest.getImageFilePath()).orElse(Consts.STRING_EMPTY);
+		}
+
+		return of(MessageConst.REGIST_PHOTO, photoNo, savedImageFilePath);
 	}
 }


### PR DESCRIPTION
# 概要

## 背景

`PhotoRestController#savePhoto`内に、レスポンスの`savedImageFilePath`を組み立てるロジックがController層に直接記述されていた。

## 変更内容

- `savedImageFilePath`の生成ロジックを`PhotoEditResponse`の新しいファクトリメソッド`of(Long photoNo, String photoAccountId, String outputPath, PhotoSaveRequest photoSaveRequest)`に移行
- メッセージ引数は`MessageConst.REGIST_PHOTO`をResponse内で直接参照する形にし、呼び出し側の引数を削減


# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認

`./backend/gradlew -p backend compileJava` でのコンパイル成功のみ確認済み（上記は未実施）。


# 懸念事項

特になし