### PR TITLE
refactor: 管理者権限チェックをAOPで共通化する

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -38,6 +38,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-aspectj:4.0.6'
 	implementation 'org.springframework.boot:spring-boot-starter-validation:4.0.6'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc:4.0.6'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:4.0.1'

--- a/backend/src/main/java/com/web/gallery/annotation/RequireAdminAuthority.java
+++ b/backend/src/main/java/com/web/gallery/annotation/RequireAdminAuthority.java
@@ -1,0 +1,14 @@
+package com.web.gallery.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 付与したメソッドの実行前に管理者権限を持つことを検証するアノテーション
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RequireAdminAuthority {
+}

--- a/backend/src/main/java/com/web/gallery/aspect/AdminAuthorityAspect.java
+++ b/backend/src/main/java/com/web/gallery/aspect/AdminAuthorityAspect.java
@@ -1,0 +1,35 @@
+package com.web.gallery.aspect;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+import com.web.gallery.enumeration.AuthorityEnum;
+import com.web.gallery.enumeration.ErrorEnum;
+import com.web.gallery.exception.ForbiddenAccountException;
+import com.web.gallery.helper.SessionHelper;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link com.web.gallery.annotation.RequireAdminAuthority}が付与されたメソッドの実行前に
+ * 管理者権限を検証するAspectクラス
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class AdminAuthorityAspect {
+	private final SessionHelper sessionHelper;
+
+	/**
+	 * 管理者権限のバリデーションを行う
+	 *
+	 * @throws	ForbiddenAccountException	管理者権限がない場合
+	 */
+	@Before("@annotation(com.web.gallery.annotation.RequireAdminAuthority)")
+	public void validateAdminAuthority() throws ForbiddenAccountException {
+		if (sessionHelper.getAuthorityKbn() != AuthorityEnum.ADMINISTRATOR) {
+			throw new ForbiddenAccountException(ErrorEnum.NOT_AUTHORIZED_TO_ADMIN);
+		}
+	}
+}

--- a/backend/src/main/java/com/web/gallery/controller/AdminAccountRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/AdminAccountRestController.java
@@ -8,15 +8,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.web.gallery.annotation.RequireAdminAuthority;
 import com.web.gallery.constant.ApiRoutes;
 import com.web.gallery.constant.MessageConst;
 import com.web.gallery.controller.response.AdminAccountListItemResponse;
 import com.web.gallery.controller.response.AdminAccountLockResponse;
-import com.web.gallery.enumeration.AuthorityEnum;
-import com.web.gallery.enumeration.ErrorEnum;
 import com.web.gallery.exception.ForbiddenAccountException;
 import com.web.gallery.exception.UpdateFailureException;
-import com.web.gallery.helper.SessionHelper;
 import com.web.gallery.service.impl.AccountServiceImpl;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,7 +33,6 @@ import lombok.RequiredArgsConstructor;
 @SecurityRequirement(name = "Bearer")
 public class AdminAccountRestController {
 	private final AccountServiceImpl accountServiceImpl;
-	private final SessionHelper sessionHelper;
 
 	/**
 	 * 管理者用アカウント一覧取得
@@ -46,11 +43,10 @@ public class AdminAccountRestController {
 	@Operation(summary = "管理者用アカウント一覧取得", description = "削除済みを含む全アカウントの一覧を取得する")
 	@ApiResponse(responseCode = "200", description = "取得成功")
 	@ApiResponse(responseCode = "403", description = "管理者権限がない", content = @Content)
+	@RequireAdminAuthority
 	@GetMapping(ApiRoutes.API_ADMIN_ACCOUNTS)
 	public ResponseEntity<List<AdminAccountListItemResponse>> getAdminAccountList()
 			throws ForbiddenAccountException {
-
-		validateAdminAuthority();
 
 		List<AdminAccountListItemResponse> responseList = accountServiceImpl.getAccountListForAdmin().stream()
 				.map(AdminAccountListItemResponse::from)
@@ -70,11 +66,10 @@ public class AdminAccountRestController {
 	@Operation(summary = "アカウントロック解除", description = "指定したアカウントのロックを解除する")
 	@ApiResponse(responseCode = "200", description = "ロック解除成功")
 	@ApiResponse(responseCode = "403", description = "管理者権限がない", content = @Content)
+	@RequireAdminAuthority
 	@PutMapping(ApiRoutes.API_ADMIN_ACCOUNT_UNLOCK)
 	public ResponseEntity<AdminAccountLockResponse> unlockAccount(
 			@PathVariable Long accountNo) throws ForbiddenAccountException, UpdateFailureException {
-
-		validateAdminAuthority();
 
 		accountServiceImpl.unlockAccount(accountNo);
 
@@ -92,25 +87,13 @@ public class AdminAccountRestController {
 	@Operation(summary = "アカウント強制ロック", description = "指定したアカウントを強制的にロックする")
 	@ApiResponse(responseCode = "200", description = "ロック成功")
 	@ApiResponse(responseCode = "403", description = "管理者権限がない", content = @Content)
+	@RequireAdminAuthority
 	@PutMapping(ApiRoutes.API_ADMIN_ACCOUNT_LOCK)
 	public ResponseEntity<AdminAccountLockResponse> lockAccount(
 			@PathVariable Long accountNo) throws ForbiddenAccountException, UpdateFailureException {
 
-		validateAdminAuthority();
-
 		accountServiceImpl.lockAccount(accountNo);
 
 		return ResponseEntity.ok(AdminAccountLockResponse.of(MessageConst.LOCK_ACCOUNT));
-	}
-
-	/**
-	 * 管理者権限のバリデーションを行う
-	 *
-	 * @throws	ForbiddenAccountException	管理者権限がない場合
-	 */
-	private void validateAdminAuthority() throws ForbiddenAccountException {
-		if (sessionHelper.getAuthorityKbn() != AuthorityEnum.ADMINISTRATOR) {
-			throw new ForbiddenAccountException(ErrorEnum.NOT_AUTHORIZED_TO_ADMIN);
-		}
 	}
 }

--- a/backend/src/test/java/com/web/gallery/aspect/AdminAuthorityAspectTest.java
+++ b/backend/src/test/java/com/web/gallery/aspect/AdminAuthorityAspectTest.java
@@ -1,0 +1,46 @@
+package com.web.gallery.aspect;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.web.gallery.enumeration.AuthorityEnum;
+import com.web.gallery.enumeration.ErrorEnum;
+import com.web.gallery.exception.ForbiddenAccountException;
+import com.web.gallery.helper.SessionHelper;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class AdminAuthorityAspectTest {
+	@InjectMocks
+	private AdminAuthorityAspect adminAuthorityAspect;
+
+	@Mock
+	private SessionHelper sessionHelper;
+
+	@Test
+	@DisplayName("正常系：管理者権限を持つ場合は例外が発生しないこと")
+	void validateAdminAuthority_success() {
+		doReturn(AuthorityEnum.ADMINISTRATOR).when(sessionHelper).getAuthorityKbn();
+
+		assertDoesNotThrow(() -> adminAuthorityAspect.validateAdminAuthority());
+	}
+
+	@Test
+	@DisplayName("異常系：管理者権限を持たない場合はForbiddenAccountExceptionが発生すること")
+	void validateAdminAuthority_forbidden() {
+		doReturn(AuthorityEnum.NORMAL).when(sessionHelper).getAuthorityKbn();
+
+		ForbiddenAccountException exception = assertThrows(ForbiddenAccountException.class,
+				() -> adminAuthorityAspect.validateAdminAuthority());
+
+		assertEquals(ErrorEnum.NOT_AUTHORIZED_TO_ADMIN.getErrorCode(), exception.getErrorCode());
+	}
+}

--- a/backend/src/test/java/com/web/gallery/controller/AdminAccountRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/AdminAccountRestControllerTest.java
@@ -34,7 +34,6 @@ import com.web.gallery.domain.account.LoginFailureCount;
 import com.web.gallery.domain.common.IsDeleted;
 import com.web.gallery.enumeration.AuthorityEnum;
 import com.web.gallery.exception.UpdateFailureException;
-import com.web.gallery.helper.SessionHelper;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.model.AccountModelList;
 import com.web.gallery.service.impl.AccountServiceImpl;
@@ -47,9 +46,6 @@ public class AdminAccountRestControllerTest {
 
 	@Mock
 	private AccountServiceImpl accountServiceImpl;
-
-	@Mock
-	private SessionHelper sessionHelper;
 
 	private MockMvc mockMvc;
 
@@ -73,8 +69,6 @@ public class AdminAccountRestControllerTest {
 		@Order(1)
 		@DisplayName("正常系：管理者がアカウント一覧を取得できること")
 		void getAdminAccountList_success() throws Exception {
-			doReturn(AuthorityEnum.ADMINISTRATOR).when(sessionHelper).getAuthorityKbn();
-
 			AccountModelList accountModels = AccountModelList.of(List.of(
 					AccountModel.builder()
 							.accountNo(new AccountNo(1L))
@@ -116,25 +110,12 @@ public class AdminAccountRestControllerTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが0件の場合は空リストを返すこと")
 		void getAdminAccountList_empty() throws Exception {
-			doReturn(AuthorityEnum.ADMINISTRATOR).when(sessionHelper).getAuthorityKbn();
 			doReturn(AccountModelList.empty()).when(accountServiceImpl).getAccountListForAdmin();
 
 			mockMvc.perform(get("/api/v1/admin/accounts"))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$").isArray())
 				.andExpect(jsonPath("$").isEmpty());
-		}
-
-		@Test
-		@Order(3)
-		@DisplayName("異常系：管理者以外は403を返すこと")
-		void getAdminAccountList_forbidden() throws Exception {
-			doReturn(AuthorityEnum.NORMAL).when(sessionHelper).getAuthorityKbn();
-
-			mockMvc.perform(get("/api/v1/admin/accounts"))
-				.andExpect(status().isForbidden());
-
-			verify(accountServiceImpl, times(0)).getAccountListForAdmin();
 		}
 	}
 
@@ -146,7 +127,6 @@ public class AdminAccountRestControllerTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントのロックを解除できること")
 		void unlockAccount_success() throws Exception {
-			doReturn(AuthorityEnum.ADMINISTRATOR).when(sessionHelper).getAuthorityKbn();
 			doNothing().when(accountServiceImpl).unlockAccount(1L);
 
 			mockMvc.perform(put("/api/v1/admin/accounts/1/unlock"))
@@ -160,21 +140,8 @@ public class AdminAccountRestControllerTest {
 
 		@Test
 		@Order(2)
-		@DisplayName("異常系：管理者以外は403を返すこと")
-		void unlockAccount_forbidden() throws Exception {
-			doReturn(AuthorityEnum.MINI).when(sessionHelper).getAuthorityKbn();
-
-			mockMvc.perform(put("/api/v1/admin/accounts/1/unlock"))
-				.andExpect(status().isForbidden());
-
-			verify(accountServiceImpl, times(0)).unlockAccount(anyLong());
-		}
-
-		@Test
-		@Order(3)
 		@DisplayName("異常系：UpdateFailureExceptionが発生した場合は409を返すこと")
 		void unlockAccount_updateFailure() throws Exception {
-			doReturn(AuthorityEnum.ADMINISTRATOR).when(sessionHelper).getAuthorityKbn();
 			doThrow(UpdateFailureException.class).when(accountServiceImpl).unlockAccount(999L);
 
 			mockMvc.perform(put("/api/v1/admin/accounts/999/unlock"))
@@ -190,7 +157,6 @@ public class AdminAccountRestControllerTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントを強制ロックできること")
 		void lockAccount_success() throws Exception {
-			doReturn(AuthorityEnum.ADMINISTRATOR).when(sessionHelper).getAuthorityKbn();
 			doNothing().when(accountServiceImpl).lockAccount(1L);
 
 			mockMvc.perform(put("/api/v1/admin/accounts/1/lock"))
@@ -204,21 +170,8 @@ public class AdminAccountRestControllerTest {
 
 		@Test
 		@Order(2)
-		@DisplayName("異常系：管理者以外は403を返すこと")
-		void lockAccount_forbidden() throws Exception {
-			doReturn(AuthorityEnum.SPECIAL).when(sessionHelper).getAuthorityKbn();
-
-			mockMvc.perform(put("/api/v1/admin/accounts/1/lock"))
-				.andExpect(status().isForbidden());
-
-			verify(accountServiceImpl, times(0)).lockAccount(anyLong());
-		}
-
-		@Test
-		@Order(3)
 		@DisplayName("異常系：UpdateFailureExceptionが発生した場合は409を返すこと")
 		void lockAccount_updateFailure() throws Exception {
-			doReturn(AuthorityEnum.ADMINISTRATOR).when(sessionHelper).getAuthorityKbn();
 			doThrow(UpdateFailureException.class).when(accountServiceImpl).lockAccount(999L);
 
 			mockMvc.perform(put("/api/v1/admin/accounts/999/lock"))


### PR DESCRIPTION
# 概要

## 背景

AdminAccountRestControllerに個別実装されていたvalidateAdminAuthority()は、他のコントローラーで管理者権限チェックが必要になった際に流用しづらい構造だった。

## 変更内容

- `spring-boot-starter-aspectj`を追加（Spring Boot 4.0では`spring-boot-starter-aop`から名称変更）
- `@RequireAdminAuthority`アノテーションを新設し、付与したメソッドの実行前に管理者権限を検証するAdminAuthorityAspectを実装
- AdminAccountRestControllerのvalidateAdminAuthority()呼び出し・実装を削除し、各メソッドに`@RequireAdminAuthority`を付与
- Aspectの権限チェックロジックを検証するAdminAuthorityAspectTestを新規作成
- standaloneSetupではAOPプロキシが効かないため、AdminAccountRestControllerTestから403系テストケースを削除（403検証は既存のIntegrationTestとAdminAuthorityAspectTestでカバー）

# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認

# 懸念事項

管理者権限チェックのテストの持ち方を変更している。AdminAccountRestControllerTest（standaloneSetup方式のため実際にAOPプロキシが介在しない）からは403系のテストケースを削除し、権限チェックロジック自体の検証はAdminAuthorityAspectTestに、実際のAOP適用込みの403検証はAdminAccountRestControllerIntegrationTestに委譲している。