### PR TITLE
refactor: Repository/Service層の引数と戻り値をドメインクラスに置換する

### DIFF
--- a/backend/src/main/java/com/web/gallery/controller/AccountRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/AccountRestController.java
@@ -25,6 +25,8 @@ import com.web.gallery.controller.response.AccountDetailResponse;
 import com.web.gallery.controller.response.AccountListItemResponse;
 import com.web.gallery.controller.response.AccountRegistResponse;
 import com.web.gallery.controller.response.AccountUpdateResponse;
+import com.web.gallery.domain.account.AccountId;
+import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.enumeration.ErrorEnum;
 import com.web.gallery.exception.BadRequestException;
 import com.web.gallery.exception.ForbiddenAccountException;
@@ -91,7 +93,7 @@ public class AccountRestController {
 			throw new ForbiddenAccountException(ErrorEnum.NOT_AUTHORIZED_TO_EDIT_ACCOUNT);
 		}
 
-		AccountModel accountModel = accountServiceImpl.getAccountById(accountId);
+		AccountModel accountModel = accountServiceImpl.getAccountById(new AccountId(accountId));
 
 		AccountDetailResponse response = AccountDetailResponse.from(accountModel);
 
@@ -200,7 +202,7 @@ public class AccountRestController {
 			throw new ForbiddenAccountException(ErrorEnum.NOT_AUTHORIZED_TO_EDIT_ACCOUNT);
 		}
 
-		accountServiceImpl.deleteAccount(sessionHelper.getAccountNo(), accountId);
+		accountServiceImpl.deleteAccount(new AccountNo(sessionHelper.getAccountNo()), new AccountId(accountId));
 
 		return ResponseEntity.ok().build();
 	}

--- a/backend/src/main/java/com/web/gallery/controller/AdminAccountRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/AdminAccountRestController.java
@@ -13,6 +13,7 @@ import com.web.gallery.constant.ApiRoutes;
 import com.web.gallery.constant.MessageConst;
 import com.web.gallery.controller.response.AdminAccountListItemResponse;
 import com.web.gallery.controller.response.AdminAccountLockResponse;
+import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.exception.ForbiddenAccountException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.service.impl.AccountServiceImpl;
@@ -71,7 +72,7 @@ public class AdminAccountRestController {
 	public ResponseEntity<AdminAccountLockResponse> unlockAccount(
 			@PathVariable Long accountNo) throws ForbiddenAccountException, UpdateFailureException {
 
-		accountServiceImpl.unlockAccount(accountNo);
+		accountServiceImpl.unlockAccount(new AccountNo(accountNo));
 
 		return ResponseEntity.ok(AdminAccountLockResponse.of(MessageConst.UNLOCK_ACCOUNT));
 	}
@@ -92,7 +93,7 @@ public class AdminAccountRestController {
 	public ResponseEntity<AdminAccountLockResponse> lockAccount(
 			@PathVariable Long accountNo) throws ForbiddenAccountException, UpdateFailureException {
 
-		accountServiceImpl.lockAccount(accountNo);
+		accountServiceImpl.lockAccount(new AccountNo(accountNo));
 
 		return ResponseEntity.ok(AdminAccountLockResponse.of(MessageConst.LOCK_ACCOUNT));
 	}

--- a/backend/src/main/java/com/web/gallery/controller/AuthRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/AuthRestController.java
@@ -18,6 +18,9 @@ import com.web.gallery.config.JwtConfig;
 import com.web.gallery.constant.ApiRoutes;
 import com.web.gallery.controller.request.AuthLoginRequest;
 import com.web.gallery.controller.response.AuthLoginResponse;
+import com.web.gallery.domain.account.AccountId;
+import com.web.gallery.domain.account.Password;
+import com.web.gallery.domain.auth.RefreshTokenValue;
 import com.web.gallery.enumeration.ErrorEnum;
 import com.web.gallery.exception.BadRequestException;
 import com.web.gallery.model.AuthTokenModel;
@@ -70,8 +73,8 @@ public class AuthRestController {
 		}
 
 		AuthTokenModel tokenModel = authService.login(
-				authLoginRequest.getAccountId(),
-				authLoginRequest.getPassword());
+				new AccountId(authLoginRequest.getAccountId()),
+				new Password(authLoginRequest.getPassword()));
 
 		ResponseCookie refreshTokenCookie = createRefreshTokenCookie(
 				tokenModel.getRefreshToken().value(),
@@ -101,7 +104,7 @@ public class AuthRestController {
 			return ResponseEntity.status(401).build();
 		}
 
-		AuthTokenModel tokenModel = authService.refresh(refreshToken);
+		AuthTokenModel tokenModel = authService.refresh(new RefreshTokenValue(refreshToken));
 
 		AuthLoginResponse response = AuthLoginResponse.from(tokenModel);
 
@@ -121,7 +124,7 @@ public class AuthRestController {
 			@CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken) {
 
 		if (refreshToken != null && !refreshToken.isEmpty()) {
-			authService.logout(refreshToken);
+			authService.logout(new RefreshTokenValue(refreshToken));
 		}
 
 		// リフレッシュトークンcookieを削除

--- a/backend/src/main/java/com/web/gallery/controller/PhotoRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/PhotoRestController.java
@@ -28,6 +28,9 @@ import com.web.gallery.controller.response.PhotoDetailGetResponse;
 import com.web.gallery.controller.response.PhotoEditResponse;
 import com.web.gallery.controller.response.PhotoListGetResponse;
 import com.web.gallery.controller.response.PhotoUpperLimitResponse;
+import com.web.gallery.domain.account.AccountId;
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.enumeration.ErrorEnum;
 import com.web.gallery.exception.BadRequestException;
 import com.web.gallery.exception.FileDuplicateException;
@@ -105,7 +108,7 @@ public class PhotoRestController {
 			@PathVariable String photoAccountId) {
 		Boolean isReachedUpperLimit = false;
 		if (photoAccountId.equals(sessionHelper.getAccountId())) {
-			isReachedUpperLimit = photoService.isReachedUpperLimit(sessionHelper.getAccountNo());
+			isReachedUpperLimit = photoService.isReachedUpperLimit(new AccountNo(sessionHelper.getAccountNo()));
 		}
 		return ResponseEntity.ok(PhotoUpperLimitResponse.of(isReachedUpperLimit));
 	}
@@ -164,7 +167,7 @@ public class PhotoRestController {
 			throw new ForbiddenAccountException(ErrorEnum.NOT_AUTHORIZED_TO_EDIT_PHOTO);
 		}
 
-		if(Objects.isNull(photoSaveRequest.getPhotoNo()) && photoService.isReachedUpperLimit(sessionHelper.getAccountNo())) {
+		if(Objects.isNull(photoSaveRequest.getPhotoNo()) && photoService.isReachedUpperLimit(new AccountNo(sessionHelper.getAccountNo()))) {
 			throw new PhotoNotAdditableException(ErrorEnum.REACHED_REGISTRATION_LIMIT);
 		}
 		
@@ -183,9 +186,9 @@ public class PhotoRestController {
 		
 		PhotoDetailModelList photoDetailModelList = PhotoDetailModelList.of(List.of(PhotoDetailModel.from(photoSaveRequest)));
 
-		Long savedPhotoNo = photoService.savePhotos(photoAccountId, photoDetailModelList);
+		PhotoNo savedPhotoNo = photoService.savePhotos(new AccountId(photoAccountId), photoDetailModelList);
 
-		return ResponseEntity.ok(PhotoEditResponse.of(savedPhotoNo, photoAccountId, photoConfig.getOutputPath(), photoSaveRequest));
+		return ResponseEntity.ok(PhotoEditResponse.of(savedPhotoNo.value(), photoAccountId, photoConfig.getOutputPath(), photoSaveRequest));
 	}
 	
 	/**
@@ -223,7 +226,7 @@ public class PhotoRestController {
 		
 		PhotoDeleteModelList photoDeleteModelList = PhotoDeleteModelList.of(List.of(PhotoDeleteModel.from(photoDeleteRequest)));
 
-		photoService.deletePhotos(photoAccountId, photoDeleteModelList);
+		photoService.deletePhotos(new AccountId(photoAccountId), photoDeleteModelList);
 		
 		return ResponseEntity.ok(PhotoEditResponse.of(MessageConst.DELETE_PHOTO, null, null));
 	}

--- a/backend/src/main/java/com/web/gallery/repository/AccountRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/AccountRepository.java
@@ -1,5 +1,7 @@
 package com.web.gallery.repository;
 
+import com.web.gallery.domain.account.AccountId;
+import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.AccountModel;
@@ -16,7 +18,7 @@ public interface AccountRepository {
 	 * @return	AccountModel	{@link AccountModel}<p>
 	 * 							取得できない場合はnullを返す
 	 */
-	AccountModel getByAccountNo(Long accountNo);
+	AccountModel getByAccountNo(AccountNo accountNo);
 
 	/**
 	 * Accountテーブルで該当するレコードを取得する
@@ -25,7 +27,7 @@ public interface AccountRepository {
 	 * @return	AccountModel	{@link AccountModel}<p>
 	 * 							取得できない場合はnullを返す
 	 */
-	AccountModel getByAccountId(String accountId);
+	AccountModel getByAccountId(AccountId accountId);
 
 	/**
 	 * Accountテーブルへ登録する
@@ -52,13 +54,21 @@ public interface AccountRepository {
 	void updateLoginFailureCount(AccountModel accountModel) throws UpdateFailureException;
 
 	/**
-	 * アカウントIDに該当するアカウントの存在有無をチェックする
+	 * アカウントIDに該当するアカウントの存在有無をチェックする（新規登録用、除外なし）
+	 *
+	 * @param	accountId	アカウントID
+	 * @return				true：存在する
+	 */
+	Boolean isExistAccount(AccountId accountId);
+
+	/**
+	 * アカウントIDに該当するアカウントの存在有無をチェックする（更新用、自分自身を除外）
 	 *
 	 * @param	accountNo	検索対象外のアカウント番号
 	 * @param	accountId	アカウントID
 	 * @return				true：存在する
 	 */
-	Boolean isExistAccount(Long accountNo, String accountId);
+	Boolean isExistAccount(AccountNo accountNo, AccountId accountId);
 
 	/**
 	 * アカウントの一覧を取得する
@@ -79,5 +89,5 @@ public interface AccountRepository {
 	 *
 	 * @param	accountNo	アカウント番号
 	 */
-	void delete(Long accountNo);
+	void delete(AccountNo accountNo);
 }

--- a/backend/src/main/java/com/web/gallery/repository/FileRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/FileRepository.java
@@ -1,5 +1,6 @@
 package com.web.gallery.repository;
 
+import com.web.gallery.domain.photo.ImageFilePath;
 import com.web.gallery.model.FileModel;
 
 /**
@@ -8,6 +9,6 @@ import com.web.gallery.model.FileModel;
 public interface FileRepository {
 
 	void save(FileModel fileModel);
-	
-	void delete(String filePath);
+
+	void delete(ImageFilePath filePath);
 }

--- a/backend/src/main/java/com/web/gallery/repository/KbnMstRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/KbnMstRepository.java
@@ -1,5 +1,6 @@
 package com.web.gallery.repository;
 
+import com.web.gallery.domain.common.KbnClassCode;
 import com.web.gallery.model.KbnMstModelList;
 
 /**
@@ -12,5 +13,5 @@ public interface KbnMstRepository {
 	 * @param	kbnClassCode	区分クラスコード
 	 * @return					{@link KbnMstModelList}
 	 */
-	KbnMstModelList get(String kbnClassCode);
+	KbnMstModelList get(KbnClassCode kbnClassCode);
 }

--- a/backend/src/main/java/com/web/gallery/repository/PhotoMstRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/PhotoMstRepository.java
@@ -1,6 +1,8 @@
 package com.web.gallery.repository;
 
 import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.photo.ImageFilePath;
+import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.PhotoDeleteModel;
@@ -18,7 +20,7 @@ public interface PhotoMstRepository {
 	 * @param	newPhotoNo				新規採番した写真番号
 	 * @throws	RegistFailureException	登録に失敗した場合
 	 */
-	void regist(PhotoDetailModel photoDetailModel, String filePath, Long newPhotoNo) throws RegistFailureException;
+	void regist(PhotoDetailModel photoDetailModel, ImageFilePath filePath, PhotoNo newPhotoNo) throws RegistFailureException;
 	
 	/**
 	 * 写真マスタを更新する
@@ -42,7 +44,7 @@ public interface PhotoMstRepository {
 	 * @param	accountNo	アカウント番号
 	 * @return				新規採番した写真番号
 	 */
-	Long getNewPhotoNo(Long accountNo);
+	PhotoNo getNewPhotoNo(AccountNo accountNo);
 	
 	/**
 	 * 同じファイル名の写真が存在するかチェックする
@@ -58,7 +60,7 @@ public interface PhotoMstRepository {
 	 * @param	accountNo	アカウント番号
 	 * @return				登録件数
 	 */
-	Integer count(Long accountNo);
+	Integer count(AccountNo accountNo);
 
 	/**
 	 * アカウント番号で写真マスタを物理削除する

--- a/backend/src/main/java/com/web/gallery/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/RefreshTokenRepository.java
@@ -1,5 +1,7 @@
 package com.web.gallery.repository;
 
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.common.TokenHash;
 import com.web.gallery.model.RefreshTokenModel;
 
 /**
@@ -22,21 +24,21 @@ public interface RefreshTokenRepository {
 	 * @param	tokenHash	トークンハッシュ
 	 * @return				{@link RefreshTokenModel}、取得できない場合はnull
 	 */
-	RefreshTokenModel findByTokenHash(String tokenHash);
+	RefreshTokenModel findByTokenHash(TokenHash tokenHash);
 
 	/**
 	 * アカウント番号に該当するリフレッシュトークンをすべて無効化する
 	 *
 	 * @param	accountNo	アカウント番号
 	 */
-	void revokeAllByAccountNo(Long accountNo);
+	void revokeAllByAccountNo(AccountNo accountNo);
 
 	/**
 	 * トークンハッシュに該当するリフレッシュトークンを無効化する
 	 *
 	 * @param	tokenHash	トークンハッシュ
 	 */
-	void revokeByTokenHash(String tokenHash);
+	void revokeByTokenHash(TokenHash tokenHash);
 
 	/**
 	 * 有効期限切れのリフレッシュトークンを削除する

--- a/backend/src/main/java/com/web/gallery/repository/impl/AccountRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/AccountRepositoryImpl.java
@@ -6,6 +6,8 @@ import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Repository;
 
+import com.web.gallery.domain.account.AccountId;
+import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.entity.Account;
 import com.web.gallery.enumeration.ErrorEnum;
 import com.web.gallery.exception.RegistFailureException;
@@ -37,8 +39,8 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 * 							取得できない場合はnullを返す
 	 */
 	@Override
-	public AccountModel getByAccountNo(Long accountNo) {
-		List<Account> accountList = accountMapper.select(Account.conditionByAccountNo(accountNo));
+	public AccountModel getByAccountNo(AccountNo accountNo) {
+		List<Account> accountList = accountMapper.select(Account.conditionByAccountNo(accountNo.value()));
 		return accountList.isEmpty() ? null : AccountModel.from(accountList.getFirst());
 	}
 
@@ -50,8 +52,8 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 * 							取得できない場合はnullを返す
 	 */
 	@Override
-	public AccountModel getByAccountId(String accountId) {
-		List<Account> accountList = accountMapper.select(Account.conditionByAccountId(accountId));
+	public AccountModel getByAccountId(AccountId accountId) {
+		List<Account> accountList = accountMapper.select(Account.conditionByAccountId(accountId.value()));
 		return accountList.isEmpty() ? null : AccountModel.from(accountList.getFirst());
 	}
 
@@ -109,15 +111,26 @@ public class AccountRepositoryImpl implements AccountRepository {
 	}
 
 	/**
-	 * アカウントIDに該当するアカウントの存在有無をチェックする
+	 * アカウントIDに該当するアカウントの存在有無をチェックする（新規登録用、除外なし）
+	 *
+	 * @param	accountId	アカウントID
+	 * @return				true：存在する
+	 */
+	@Override
+	public Boolean isExistAccount(AccountId accountId) {
+		return accountMapper.isExistAccount(Account.conditionForExistCheck(null, accountId.value()));
+	}
+
+	/**
+	 * アカウントIDに該当するアカウントの存在有無をチェックする（更新用、自分自身を除外）
 	 *
 	 * @param	accountNo	検索対象外のアカウント番号
 	 * @param	accountId	アカウントID
 	 * @return				true：存在する
 	 */
 	@Override
-	public Boolean isExistAccount(Long accountNo, String accountId) {
-		return accountMapper.isExistAccount(Account.conditionForExistCheck(accountNo, accountId));
+	public Boolean isExistAccount(AccountNo accountNo, AccountId accountId) {
+		return accountMapper.isExistAccount(Account.conditionForExistCheck(accountNo.value(), accountId.value()));
 	}
 
 	/**
@@ -148,7 +161,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 * @param	accountNo	アカウント番号
 	 */
 	@Override
-	public void delete(Long accountNo) {
-		accountMapper.delete(Account.conditionByAccountNo(accountNo));
+	public void delete(AccountNo accountNo) {
+		accountMapper.delete(Account.conditionByAccountNo(accountNo.value()));
 	}
 }

--- a/backend/src/main/java/com/web/gallery/repository/impl/FileRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/FileRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.web.gallery.repository.impl;
 
 import org.springframework.stereotype.Repository;
 
+import com.web.gallery.domain.photo.ImageFilePath;
 import com.web.gallery.model.FileModel;
 import com.web.gallery.repository.FileRepository;
 
@@ -21,7 +22,7 @@ public class FileRepositoryImpl implements FileRepository {
 	}
 
 	@Override
-	public void delete(String filePath) {
+	public void delete(ImageFilePath filePath) {
 		// TODO 自動生成されたメソッド・スタブ
 		return;
 	}

--- a/backend/src/main/java/com/web/gallery/repository/impl/KbnMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/KbnMstRepositoryImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
+import com.web.gallery.domain.common.KbnClassCode;
 import com.web.gallery.entity.KbnMst;
 import com.web.gallery.mapper.KbnMstMapper;
 import com.web.gallery.model.KbnMstModelList;
@@ -27,8 +28,8 @@ public class KbnMstRepositoryImpl implements KbnMstRepository {
 	 * @return					{@link KbnMstModelList}
 	 */
 	@Override
-	public KbnMstModelList get(String kbnClassCode) {
-		List<KbnMst> kbnMstList = kbnMstMapper.select(KbnMst.condition(kbnClassCode));
+	public KbnMstModelList get(KbnClassCode kbnClassCode) {
+		List<KbnMst> kbnMstList = kbnMstMapper.select(KbnMst.condition(kbnClassCode.value()));
 
 		return KbnMstModelList.from(kbnMstList);
 	}

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
@@ -6,6 +6,8 @@ import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Repository;
 
 import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.photo.ImageFilePath;
+import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.entity.PhotoMst;
 import com.web.gallery.enumeration.ErrorEnum;
 import com.web.gallery.exception.RegistFailureException;
@@ -37,14 +39,14 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 * @throws	RegistFailureException	登録に失敗した場合
 	 */
 	@Override
-	public void regist(PhotoDetailModel photoDetailModel, String filePath, Long newPhotoNo) throws RegistFailureException {
-		PhotoMst photoMst = PhotoMst.fromForRegist(photoDetailModel, filePath, newPhotoNo);
+	public void regist(PhotoDetailModel photoDetailModel, ImageFilePath filePath, PhotoNo newPhotoNo) throws RegistFailureException {
+		PhotoMst photoMst = PhotoMst.fromForRegist(photoDetailModel, filePath.value(), newPhotoNo.value());
 
 		try {
 			photoMstMapper.insert(photoMst);
 		}
 		catch (DuplicateKeyException e) {
-			log.warn("PhotoMst: Duplicate Key (AccountNo: {}, PhotoNo: {})", photoDetailModel.getAccountNo().value(), newPhotoNo, e);
+			log.warn("PhotoMst: Duplicate Key (AccountNo: {}, PhotoNo: {})", photoDetailModel.getAccountNo().value(), newPhotoNo.value(), e);
 			throw new RegistFailureException(ErrorEnum.FAIL_TO_REGIST_PHOTO);
 		}
 	}
@@ -90,9 +92,9 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 * @return				新規採番した写真番号
 	 */
 	@Override
-	public Long getNewPhotoNo(Long accountNo) {
-		Long photoNo = photoMstMapper.getMaxPhotoNo(accountNo);
-		return Optional.ofNullable(photoNo).map(num -> num + 1).orElse(1L);
+	public PhotoNo getNewPhotoNo(AccountNo accountNo) {
+		Long photoNo = photoMstMapper.getMaxPhotoNo(accountNo.value());
+		return new PhotoNo(Optional.ofNullable(photoNo).map(num -> num + 1).orElse(1L));
 	}
 
 	/**
@@ -113,8 +115,8 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 * @return				登録件数
 	 */
 	@Override
-	public Integer count(Long accountNo) {
-		return photoMstMapper.count(PhotoMst.conditionForCount(accountNo));
+	public Integer count(AccountNo accountNo) {
+		return photoMstMapper.count(PhotoMst.conditionForCount(accountNo.value()));
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/repository/impl/RefreshTokenRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/RefreshTokenRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.web.gallery.repository.impl;
 
 import org.springframework.stereotype.Repository;
 
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.common.TokenHash;
 import com.web.gallery.entity.RefreshToken;
 import com.web.gallery.mapper.RefreshTokenMapper;
 import com.web.gallery.model.RefreshTokenModel;
@@ -27,8 +29,8 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
 	}
 
 	@Override
-	public RefreshTokenModel findByTokenHash(String tokenHash) {
-		RefreshToken refreshToken = refreshTokenMapper.selectByTokenHash(tokenHash);
+	public RefreshTokenModel findByTokenHash(TokenHash tokenHash) {
+		RefreshToken refreshToken = refreshTokenMapper.selectByTokenHash(tokenHash.value());
 		if (refreshToken == null) {
 			return null;
 		}
@@ -36,13 +38,13 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
 	}
 
 	@Override
-	public void revokeAllByAccountNo(Long accountNo) {
-		refreshTokenMapper.revokeAllByAccountNo(accountNo);
+	public void revokeAllByAccountNo(AccountNo accountNo) {
+		refreshTokenMapper.revokeAllByAccountNo(accountNo.value());
 	}
 
 	@Override
-	public void revokeByTokenHash(String tokenHash) {
-		refreshTokenMapper.revokeByTokenHash(tokenHash);
+	public void revokeByTokenHash(TokenHash tokenHash) {
+		refreshTokenMapper.revokeByTokenHash(tokenHash.value());
 	}
 
 	@Override

--- a/backend/src/main/java/com/web/gallery/service/AuthService.java
+++ b/backend/src/main/java/com/web/gallery/service/AuthService.java
@@ -1,5 +1,8 @@
 package com.web.gallery.service;
 
+import com.web.gallery.domain.account.AccountId;
+import com.web.gallery.domain.account.Password;
+import com.web.gallery.domain.auth.RefreshTokenValue;
 import com.web.gallery.model.AuthTokenModel;
 
 /**
@@ -16,7 +19,7 @@ public interface AuthService {
 	 * @param	password	パスワード
 	 * @return				{@link AuthTokenModel}
 	 */
-	AuthTokenModel login(String accountId, String password);
+	AuthTokenModel login(AccountId accountId, Password password);
 
 	/**
 	 * リフレッシュトークンを検証し、新しいアクセストークンを発行する
@@ -24,12 +27,12 @@ public interface AuthService {
 	 * @param	refreshToken	リフレッシュトークン
 	 * @return					{@link AuthTokenModel}
 	 */
-	AuthTokenModel refresh(String refreshToken);
+	AuthTokenModel refresh(RefreshTokenValue refreshToken);
 
 	/**
 	 * ログアウトし、リフレッシュトークンを無効化する
 	 *
 	 * @param	refreshToken	リフレッシュトークン
 	 */
-	void logout(String refreshToken);
+	void logout(RefreshTokenValue refreshToken);
 }

--- a/backend/src/main/java/com/web/gallery/service/PhotoService.java
+++ b/backend/src/main/java/com/web/gallery/service/PhotoService.java
@@ -1,5 +1,8 @@
 package com.web.gallery.service;
 
+import com.web.gallery.domain.account.AccountId;
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.exception.FileDuplicateException;
 import com.web.gallery.exception.PhotoNotFoundException;
 import com.web.gallery.exception.RegistFailureException;
@@ -42,7 +45,7 @@ public interface PhotoService {
 	 * @throws	UpdateFailureException	更新に失敗した場合
 	 * @return							登録・更新した写真番号
 	 */
-	Long savePhotos(String accountId, PhotoDetailModelList photoDetailModelList) throws FileDuplicateException, RegistFailureException, UpdateFailureException;
+	PhotoNo savePhotos(AccountId accountId, PhotoDetailModelList photoDetailModelList) throws FileDuplicateException, RegistFailureException, UpdateFailureException;
 
 	/**
 	 * 写真を削除する
@@ -51,7 +54,7 @@ public interface PhotoService {
 	 * @param	photoDeleteModelList	{@link PhotoDeleteModelList}
 	 * @throws	UpdateFailureException	削除に失敗した場合
 	 */
-	void deletePhotos(String accountId, PhotoDeleteModelList photoDeleteModelList) throws UpdateFailureException;
+	void deletePhotos(AccountId accountId, PhotoDeleteModelList photoDeleteModelList) throws UpdateFailureException;
 	
 	/**
 	 * 該当アカウントが写真の登録枚数の上限に達しているかチェックする
@@ -59,5 +62,5 @@ public interface PhotoService {
 	 * @param	accountNo	アカウント番号
 	 * @return				上限に達している場合、true
 	 */
-	Boolean isReachedUpperLimit(Long accountNo);
+	Boolean isReachedUpperLimit(AccountNo accountNo);
 }

--- a/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
@@ -16,7 +16,9 @@ import com.web.gallery.AccountPrincipal;
 import com.web.gallery.config.LoginConfig;
 import com.web.gallery.config.PhotoConfig;
 import com.web.gallery.constant.MessageConst;
+import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.photo.ImageFilePath;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.AccountModel;
@@ -57,7 +59,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	@Override
 	@Transactional(readOnly = true)
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-		AccountModel accountModel = accountRepository.getByAccountId(username);
+		AccountModel accountModel = accountRepository.getByAccountId(new AccountId(username));
 
 		if (Objects.isNull(accountModel)) {
 			log.info("User not found. (username: {})", username);
@@ -75,7 +77,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 */
 	@Transactional
 	public Boolean registAccount(AccountModel accountModel) throws RegistFailureException {
-		Boolean isExist = accountRepository.isExistAccount(null, accountModel.getAccountId().value());
+		Boolean isExist = accountRepository.isExistAccount(accountModel.getAccountId());
 		if(!isExist) accountRepository.regist(accountModel);
 		return !isExist;
 	}
@@ -89,7 +91,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 */
 	@Transactional
 	public Boolean updateAccount(AccountModel accountModel) throws UpdateFailureException {
-		Boolean isExist = accountRepository.isExistAccount(accountModel.getAccountNo().value(), accountModel.getAccountId().value());
+		Boolean isExist = accountRepository.isExistAccount(accountModel.getAccountNo(), accountModel.getAccountId());
 		if(!isExist) accountRepository.update(accountModel);
 		return isExist;
 	}
@@ -101,7 +103,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @return				{@link AccountModel}
 	 */
 	@Transactional(readOnly = true)
-	public AccountModel getAccountById(String accountId) {
+	public AccountModel getAccountById(AccountId accountId) {
 		return accountRepository.getByAccountId(accountId);
 	}
 
@@ -132,8 +134,8 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @throws	UpdateFailureException	更新に失敗した場合
 	 */
 	@Transactional
-	public void unlockAccount(Long accountNo) throws UpdateFailureException {
-		accountRepository.updateLoginFailureCount(AccountModel.forUnlock(accountNo));
+	public void unlockAccount(AccountNo accountNo) throws UpdateFailureException {
+		accountRepository.updateLoginFailureCount(AccountModel.forUnlock(accountNo.value()));
 	}
 
 	/**
@@ -143,8 +145,8 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @throws	UpdateFailureException	更新に失敗した場合
 	 */
 	@Transactional
-	public void lockAccount(Long accountNo) throws UpdateFailureException {
-		accountRepository.updateLoginFailureCount(AccountModel.forLock(accountNo, loginConfig.getFailCount()));
+	public void lockAccount(AccountNo accountNo) throws UpdateFailureException {
+		accountRepository.updateLoginFailureCount(AccountModel.forLock(accountNo.value(), loginConfig.getFailCount()));
 	}
 
 	/**
@@ -154,26 +156,24 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @param	accountId	アカウントID
 	 */
 	@Transactional
-	public void deleteAccount(Long accountNo, String accountId) {
-		AccountNo accountNoVo = new AccountNo(accountNo);
-
+	public void deleteAccount(AccountNo accountNo, AccountId accountId) {
 		// 自分が登録したお気に入りを削除
-		photoFavoriteRepository.deleteByAccountNo(accountNoVo);
+		photoFavoriteRepository.deleteByAccountNo(accountNo);
 
 		// 自分の写真に対する他人のお気に入りを削除
-		photoFavoriteRepository.deleteByFavoritePhotoAccountNo(accountNoVo);
+		photoFavoriteRepository.deleteByFavoritePhotoAccountNo(accountNo);
 
 		// 写真タグを削除
-		photoTagMstRepository.deleteByAccountNo(accountNoVo);
+		photoTagMstRepository.deleteByAccountNo(accountNo);
 
 		// 写真マスタを物理削除
-		photoMstRepository.deleteByAccountNo(accountNoVo);
+		photoMstRepository.deleteByAccountNo(accountNo);
 
 		// アカウントを物理削除
 		accountRepository.delete(accountNo);
 
 		// 写真ファイルのディレクトリを削除
-		fileRepository.delete(photoConfig.getOutputPath() + accountId + "/");
+		fileRepository.delete(new ImageFilePath(photoConfig.getOutputPath() + accountId.value() + "/"));
 	}
 
 	/**
@@ -185,7 +185,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	@EventListener
 	@Transactional
 	public void handle(AuthenticationSuccessEvent event) throws UpdateFailureException {
-		AccountModel accountModel = accountRepository.getByAccountId(event.getAuthentication().getName());
+		AccountModel accountModel = accountRepository.getByAccountId(new AccountId(event.getAuthentication().getName()));
 
 		accountRepository.updateLoginFailureCount(AccountModel.forLoginSuccess(accountModel.getAccountNo(), clock));
 	}
@@ -199,7 +199,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	@EventListener
 	@Transactional
 	public void handle(AuthenticationFailureBadCredentialsEvent event) throws UpdateFailureException {
-		AccountModel accountModel = accountRepository.getByAccountId(event.getAuthentication().getName());
+		AccountModel accountModel = accountRepository.getByAccountId(new AccountId(event.getAuthentication().getName()));
 
 		if(!Objects.isNull(accountModel)) {
 			accountRepository.updateLoginFailureCount(

--- a/backend/src/main/java/com/web/gallery/service/impl/AuthServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AuthServiceImpl.java
@@ -7,7 +7,10 @@ import java.time.Clock;
 import java.time.OffsetDateTime;
 
 import com.web.gallery.constant.Consts;
+import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.account.Password;
+import com.web.gallery.domain.auth.RefreshTokenValue;
 import com.web.gallery.domain.common.ExpiresAt;
 import com.web.gallery.domain.common.TokenHash;
 
@@ -72,14 +75,14 @@ public class AuthServiceImpl implements AuthService {
 	 */
 	@Override
 	@Transactional
-	public AuthTokenModel login(String accountId, String password) {
+	public AuthTokenModel login(AccountId accountId, Password password) {
 		Authentication authentication = authenticationManager.authenticate(
-				new UsernamePasswordAuthenticationToken(accountId, password));
+				new UsernamePasswordAuthenticationToken(accountId.value(), password.value()));
 
 		AccountPrincipal principal = (AccountPrincipal) authentication.getPrincipal();
 
 		// 既存のリフレッシュトークンをすべて無効化（同時セッション制限）
-		refreshTokenRepository.revokeAllByAccountNo(principal.getAccountNo());
+		refreshTokenRepository.revokeAllByAccountNo(new AccountNo(principal.getAccountNo()));
 
 		// 新しいトークンを生成
 		String accessToken = jwtTokenProvider.generateAccessToken(principal);
@@ -104,8 +107,8 @@ public class AuthServiceImpl implements AuthService {
 	 */
 	@Override
 	@Transactional(readOnly = true)
-	public AuthTokenModel refresh(String refreshToken) {
-		String tokenHash = hashToken(refreshToken);
+	public AuthTokenModel refresh(RefreshTokenValue refreshToken) {
+		TokenHash tokenHash = new TokenHash(hashToken(refreshToken.value()));
 		RefreshTokenModel storedToken = refreshTokenRepository.findByTokenHash(tokenHash);
 
 		if (storedToken == null || storedToken.getIsRevoked().value()) {
@@ -117,13 +120,13 @@ public class AuthServiceImpl implements AuthService {
 		}
 
 		// アカウント番号からアカウント情報を取得し、新しいアクセストークンを発行
-		AccountModel accountModel = accountRepository.getByAccountNo(storedToken.getAccountNo().value());
+		AccountModel accountModel = accountRepository.getByAccountNo(storedToken.getAccountNo());
 		UserDetails userDetails = accountServiceImpl.loadUserByUsername(accountModel.getAccountId().value());
 		AccountPrincipal principal = (AccountPrincipal) userDetails;
 
 		String accessToken = jwtTokenProvider.generateAccessToken(principal);
 
-		return AuthTokenModel.of(accessToken, refreshToken,
+		return AuthTokenModel.of(accessToken, refreshToken.value(),
 				(long) jwtConfig.getAccessTokenExpirationMinutes() * 60);
 	}
 
@@ -134,8 +137,8 @@ public class AuthServiceImpl implements AuthService {
 	 */
 	@Override
 	@Transactional
-	public void logout(String refreshToken) {
-		refreshTokenRepository.revokeByTokenHash(hashToken(refreshToken));
+	public void logout(RefreshTokenValue refreshToken) {
+		refreshTokenRepository.revokeByTokenHash(new TokenHash(hashToken(refreshToken.value())));
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/service/impl/KbnMstServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/KbnMstServiceImpl.java
@@ -4,6 +4,7 @@ import com.web.gallery.constant.Consts;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.web.gallery.domain.common.KbnClassCode;
 import com.web.gallery.model.KbnMstModelList;
 import com.web.gallery.repository.KbnMstRepository;
 import com.web.gallery.service.KbnMstService;
@@ -27,6 +28,6 @@ public class KbnMstServiceImpl implements KbnMstService {
 	@Override
 	@Transactional(readOnly = true)
 	public KbnMstModelList getPrefectureList() {
-		return kbnMstRepository.get(Consts.PREFECTURE);
+		return kbnMstRepository.get(new KbnClassCode(Consts.PREFECTURE));
 	}
 }

--- a/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
@@ -15,6 +15,7 @@ import com.web.gallery.config.PhotoConfig;
 import com.web.gallery.constant.Consts;
 import com.web.gallery.domain.photo.ImageFile;
 import com.web.gallery.domain.photo.ImageFilePath;
+import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.domain.photo.TagNo;
@@ -75,7 +76,7 @@ public class PhotoServiceImpl implements PhotoService {
 	@Override
 	@Transactional(readOnly = true)
 	public PhotoModelList getPhotoList(PhotoListGetModel photoListGetModel) {
-		AccountModel accountModel = accountRepository.getByAccountId(photoListGetModel.getPhotoAccountId().value());
+		AccountModel accountModel = accountRepository.getByAccountId(photoListGetModel.getPhotoAccountId());
 
 		PhotoModelList photoModelList
 			= photoDetailRepository.getPhotoList(
@@ -111,13 +112,13 @@ public class PhotoServiceImpl implements PhotoService {
 	 */
 	@Override
 	@Transactional
-	public Long savePhotos(String accountId, PhotoDetailModelList photoDetailModelList) throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+	public PhotoNo savePhotos(AccountId accountId, PhotoDetailModelList photoDetailModelList) throws FileDuplicateException, RegistFailureException, UpdateFailureException {
 		if(Objects.isNull(photoDetailModelList)) return null;
 		if(photoDetailModelList.isEmpty()) return null;
 
-		Long photoNo = photoMstRepository.getNewPhotoNo(photoDetailModelList.getFirst().getAccountNo().value());
-		Long savedPhotoNo = photoNo;
-		String filePath = photoConfig.getOutputPath() + accountId + "/";
+		Long photoNo = photoMstRepository.getNewPhotoNo(photoDetailModelList.getFirst().getAccountNo()).value();
+		PhotoNo savedPhotoNo = new PhotoNo(photoNo);
+		String filePath = photoConfig.getOutputPath() + accountId.value() + "/";
 
 		for(PhotoDetailModel photoDetailModel : photoDetailModelList){
 			if(Objects.isNull(photoDetailModel.getPhotoNo())) {
@@ -127,11 +128,11 @@ public class PhotoServiceImpl implements PhotoService {
 					throw new FileDuplicateException(ErrorEnum.DUPLICATE_PHOTO_FILE);
 				}
 
-				photoMstRepository.regist(photoDetailModel, filePath + filename, photoNo);
+				photoMstRepository.regist(photoDetailModel, new ImageFilePath(filePath + filename), new PhotoNo(photoNo));
 				registPhotoTags(photoDetailModel.getPhotoTagModelList(), photoNo++);
 				uploadFile(new ImageFilePath(filePath + filename), photoDetailModel.getImageFile());
 			} else {
-				savedPhotoNo = photoDetailModel.getPhotoNo().value();
+				savedPhotoNo = photoDetailModel.getPhotoNo();
 				photoMstRepository.update(photoDetailModel);
 				deletePhotoTags(photoDetailModel.getAccountNo(), photoDetailModel.getPhotoNo());
 				registPhotoTags(photoDetailModel.getPhotoTagModelList(), null);
@@ -149,8 +150,8 @@ public class PhotoServiceImpl implements PhotoService {
 	 */
 	@Override
 	@Transactional
-	public void deletePhotos(String accountId, PhotoDeleteModelList photoDeleteModelList) throws UpdateFailureException {
-		String filePath = photoConfig.getOutputPath() + accountId + "/";
+	public void deletePhotos(AccountId accountId, PhotoDeleteModelList photoDeleteModelList) throws UpdateFailureException {
+		String filePath = photoConfig.getOutputPath() + accountId.value() + "/";
 
 		for(PhotoDeleteModel photoDeleteModel : photoDeleteModelList) {
 			photoFavoriteRepository.clear(PhotoFavoriteDeleteModel.from(photoDeleteModel));
@@ -159,7 +160,7 @@ public class PhotoServiceImpl implements PhotoService {
 			photoMstRepository.delete(photoDeleteModel);
 
 			String fileName = new File(photoDeleteModel.getImageFilePath().value()).getName();
-			fileRepository.delete(filePath + fileName);
+			fileRepository.delete(new ImageFilePath(filePath + fileName));
 		}
 	}
 
@@ -171,9 +172,7 @@ public class PhotoServiceImpl implements PhotoService {
 	 */
 	@Override
 	@Transactional(readOnly = true)
-	public Boolean isReachedUpperLimit(Long accountNo) {
-		if(Objects.isNull(accountNo)) return true;
-
+	public Boolean isReachedUpperLimit(AccountNo accountNo) {
 		AccountModel accountModel = accountRepository.getByAccountNo(accountNo);
 		Integer count = photoMstRepository.count(accountNo);
 

--- a/backend/src/test/java/com/web/gallery/controller/AccountRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/AccountRestControllerTest.java
@@ -142,7 +142,7 @@ public class AccountRestControllerTest {
 					.freeMemo(new FreeMemo("フリーメモ"))
 					.build();
 
-			doReturn(accountModel).when(accountServiceImpl).getAccountById(accountId);
+			doReturn(accountModel).when(accountServiceImpl).getAccountById(new AccountId(accountId));
 
 			mockMvc.perform(get("/api/v1/accounts/" + accountId))
 				.andExpect(status().isOk())
@@ -174,7 +174,7 @@ public class AccountRestControllerTest {
 					.freeMemo(new FreeMemo(""))
 					.build();
 
-			doReturn(accountModel).when(accountServiceImpl).getAccountById(accountId);
+			doReturn(accountModel).when(accountServiceImpl).getAccountById(new AccountId(accountId));
 
 			mockMvc.perform(get("/api/v1/accounts/" + accountId))
 				.andExpect(status().isOk())
@@ -196,7 +196,7 @@ public class AccountRestControllerTest {
 			mockMvc.perform(get("/api/v1/accounts/aaaaaaaa"))
 				.andExpect(status().isForbidden());
 
-			verify(accountServiceImpl, times(0)).getAccountById(anyString());
+			verify(accountServiceImpl, times(0)).getAccountById(any(AccountId.class));
 		}
 	}
 
@@ -534,12 +534,12 @@ public class AccountRestControllerTest {
 
 			doReturn(accountId).when(sessionHelper).getAccountId();
 			doReturn(1L).when(sessionHelper).getAccountNo();
-			doNothing().when(accountServiceImpl).deleteAccount(1L, accountId);
+			doNothing().when(accountServiceImpl).deleteAccount(new AccountNo(1L), new AccountId(accountId));
 
 			mockMvc.perform(delete("/api/v1/accounts/" + accountId))
 				.andExpect(status().isOk());
 
-			verify(accountServiceImpl, times(1)).deleteAccount(1L, accountId);
+			verify(accountServiceImpl, times(1)).deleteAccount(new AccountNo(1L), new AccountId(accountId));
 		}
 
 		@Test
@@ -551,7 +551,7 @@ public class AccountRestControllerTest {
 			mockMvc.perform(delete("/api/v1/accounts/aaaaaaaa"))
 				.andExpect(status().isForbidden());
 
-			verify(accountServiceImpl, times(0)).deleteAccount(anyLong(), anyString());
+			verify(accountServiceImpl, times(0)).deleteAccount(any(AccountNo.class), any(AccountId.class));
 		}
 	}
 

--- a/backend/src/test/java/com/web/gallery/controller/AdminAccountRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/AdminAccountRestControllerTest.java
@@ -127,7 +127,7 @@ public class AdminAccountRestControllerTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントのロックを解除できること")
 		void unlockAccount_success() throws Exception {
-			doNothing().when(accountServiceImpl).unlockAccount(1L);
+			doNothing().when(accountServiceImpl).unlockAccount(new AccountNo(1L));
 
 			mockMvc.perform(put("/api/v1/admin/accounts/1/unlock"))
 				.andExpect(status().isOk())
@@ -135,14 +135,14 @@ public class AdminAccountRestControllerTest {
 				.andExpect(jsonPath("$.isSuccess").value(true))
 				.andExpect(jsonPath("$.message").value(MessageConst.UNLOCK_ACCOUNT));
 
-			verify(accountServiceImpl, times(1)).unlockAccount(1L);
+			verify(accountServiceImpl, times(1)).unlockAccount(new AccountNo(1L));
 		}
 
 		@Test
 		@Order(2)
 		@DisplayName("異常系：UpdateFailureExceptionが発生した場合は409を返すこと")
 		void unlockAccount_updateFailure() throws Exception {
-			doThrow(UpdateFailureException.class).when(accountServiceImpl).unlockAccount(999L);
+			doThrow(UpdateFailureException.class).when(accountServiceImpl).unlockAccount(new AccountNo(999L));
 
 			mockMvc.perform(put("/api/v1/admin/accounts/999/unlock"))
 				.andExpect(status().isConflict());
@@ -157,7 +157,7 @@ public class AdminAccountRestControllerTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントを強制ロックできること")
 		void lockAccount_success() throws Exception {
-			doNothing().when(accountServiceImpl).lockAccount(1L);
+			doNothing().when(accountServiceImpl).lockAccount(new AccountNo(1L));
 
 			mockMvc.perform(put("/api/v1/admin/accounts/1/lock"))
 				.andExpect(status().isOk())
@@ -165,14 +165,14 @@ public class AdminAccountRestControllerTest {
 				.andExpect(jsonPath("$.isSuccess").value(true))
 				.andExpect(jsonPath("$.message").value(MessageConst.LOCK_ACCOUNT));
 
-			verify(accountServiceImpl, times(1)).lockAccount(1L);
+			verify(accountServiceImpl, times(1)).lockAccount(new AccountNo(1L));
 		}
 
 		@Test
 		@Order(2)
 		@DisplayName("異常系：UpdateFailureExceptionが発生した場合は409を返すこと")
 		void lockAccount_updateFailure() throws Exception {
-			doThrow(UpdateFailureException.class).when(accountServiceImpl).lockAccount(999L);
+			doThrow(UpdateFailureException.class).when(accountServiceImpl).lockAccount(new AccountNo(999L));
 
 			mockMvc.perform(put("/api/v1/admin/accounts/999/lock"))
 				.andExpect(status().isConflict());

--- a/backend/src/test/java/com/web/gallery/controller/AuthRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/AuthRestControllerTest.java
@@ -23,6 +23,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.web.gallery.config.JwtConfig;
+import com.web.gallery.domain.account.AccountId;
+import com.web.gallery.domain.account.Password;
 import com.web.gallery.domain.auth.AccessToken;
 import com.web.gallery.domain.auth.ExpiresIn;
 import com.web.gallery.domain.auth.RefreshTokenValue;
@@ -64,7 +66,7 @@ public class AuthRestControllerTest {
 					.expiresIn(new ExpiresIn(900L))
 					.build();
 
-			doReturn(tokenModel).when(authServiceImpl).login("testuser", "password123");
+			doReturn(tokenModel).when(authServiceImpl).login(new AccountId("testuser"), new Password("password123"));
 			doReturn(7).when(jwtConfig).getRefreshTokenExpirationDays();
 
 			mockMvc.perform(
@@ -77,7 +79,7 @@ public class AuthRestControllerTest {
 				.andExpect(jsonPath("$.expiresIn").value(900))
 				.andExpect(header().exists("Set-Cookie"));
 
-			verify(authServiceImpl, times(1)).login("testuser", "password123");
+			verify(authServiceImpl, times(1)).login(new AccountId("testuser"), new Password("password123"));
 		}
 
 		@Test
@@ -91,7 +93,7 @@ public class AuthRestControllerTest {
 				)
 				.andExpect(status().isBadRequest());
 
-			verify(authServiceImpl, times(0)).login(anyString(), anyString());
+			verify(authServiceImpl, times(0)).login(any(AccountId.class), any(Password.class));
 		}
 
 		@Test
@@ -105,7 +107,7 @@ public class AuthRestControllerTest {
 				)
 				.andExpect(status().isBadRequest());
 
-			verify(authServiceImpl, times(0)).login(anyString(), anyString());
+			verify(authServiceImpl, times(0)).login(any(AccountId.class), any(Password.class));
 		}
 
 		@Test
@@ -113,7 +115,7 @@ public class AuthRestControllerTest {
 		@DisplayName("異常系：認証失敗（BadCredentialsException）の場合、401を返す")
 		void login_bad_credentials() throws Exception {
 			doThrow(new BadCredentialsException("Bad credentials"))
-				.when(authServiceImpl).login("testuser", "wrongpassword");
+				.when(authServiceImpl).login(new AccountId("testuser"), new Password("wrongpassword"));
 
 			mockMvc.perform(
 					post("/api/v1/auth/login")
@@ -129,7 +131,7 @@ public class AuthRestControllerTest {
 		@DisplayName("異常系：アカウントロック（LockedException）の場合、423を返す")
 		void login_locked() throws Exception {
 			doThrow(new LockedException("Account is locked"))
-				.when(authServiceImpl).login("testuser", "password123");
+				.when(authServiceImpl).login(new AccountId("testuser"), new Password("password123"));
 
 			mockMvc.perform(
 					post("/api/v1/auth/login")
@@ -155,7 +157,7 @@ public class AuthRestControllerTest {
 					.expiresIn(new ExpiresIn(900L))
 					.build();
 
-			doReturn(tokenModel).when(authServiceImpl).refresh("test-refresh-token");
+			doReturn(tokenModel).when(authServiceImpl).refresh(new RefreshTokenValue("test-refresh-token"));
 
 			mockMvc.perform(
 					post("/api/v1/auth/refresh")
@@ -165,7 +167,7 @@ public class AuthRestControllerTest {
 				.andExpect(jsonPath("$.accessToken").value("new-access-token"))
 				.andExpect(jsonPath("$.expiresIn").value(900));
 
-			verify(authServiceImpl, times(1)).refresh("test-refresh-token");
+			verify(authServiceImpl, times(1)).refresh(new RefreshTokenValue("test-refresh-token"));
 		}
 
 		@Test
@@ -177,7 +179,7 @@ public class AuthRestControllerTest {
 				)
 				.andExpect(status().isUnauthorized());
 
-			verify(authServiceImpl, times(0)).refresh(anyString());
+			verify(authServiceImpl, times(0)).refresh(any(RefreshTokenValue.class));
 		}
 
 		@Test
@@ -190,7 +192,7 @@ public class AuthRestControllerTest {
 				)
 				.andExpect(status().isUnauthorized());
 
-			verify(authServiceImpl, times(0)).refresh(anyString());
+			verify(authServiceImpl, times(0)).refresh(any(RefreshTokenValue.class));
 		}
 
 		@Test
@@ -198,7 +200,7 @@ public class AuthRestControllerTest {
 		@DisplayName("異常系：無効なリフレッシュトークンの場合、401を返す")
 		void refresh_invalid_token() throws Exception {
 			doThrow(new IllegalArgumentException("無効なリフレッシュトークンです"))
-				.when(authServiceImpl).refresh("invalid-token");
+				.when(authServiceImpl).refresh(new RefreshTokenValue("invalid-token"));
 
 			mockMvc.perform(
 					post("/api/v1/auth/refresh")
@@ -217,7 +219,7 @@ public class AuthRestControllerTest {
 		@Order(1)
 		@DisplayName("正常系：ログアウト成功（refreshTokenあり）")
 		void logout_with_token() throws Exception {
-			doNothing().when(authServiceImpl).logout("test-refresh-token");
+			doNothing().when(authServiceImpl).logout(new RefreshTokenValue("test-refresh-token"));
 
 			mockMvc.perform(
 					post("/api/v1/auth/logout")
@@ -226,7 +228,7 @@ public class AuthRestControllerTest {
 				.andExpect(status().isNoContent())
 				.andExpect(header().exists("Set-Cookie"));
 
-			verify(authServiceImpl, times(1)).logout("test-refresh-token");
+			verify(authServiceImpl, times(1)).logout(new RefreshTokenValue("test-refresh-token"));
 		}
 
 		@Test
@@ -239,7 +241,7 @@ public class AuthRestControllerTest {
 				.andExpect(status().isNoContent())
 				.andExpect(header().exists("Set-Cookie"));
 
-			verify(authServiceImpl, times(0)).logout(anyString());
+			verify(authServiceImpl, times(0)).logout(any(RefreshTokenValue.class));
 		}
 
 		@Test
@@ -253,7 +255,7 @@ public class AuthRestControllerTest {
 				.andExpect(status().isNoContent())
 				.andExpect(header().exists("Set-Cookie"));
 
-			verify(authServiceImpl, times(0)).logout(anyString());
+			verify(authServiceImpl, times(0)).logout(any(RefreshTokenValue.class));
 		}
 	}
 }

--- a/backend/src/test/java/com/web/gallery/controller/PhotoRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/PhotoRestControllerTest.java
@@ -344,11 +344,11 @@ public class PhotoRestControllerTest {
 
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 			doReturn(1L).when(sessionHelper).getAccountNo();
-			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1L);
+			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(new AccountNo(1L));
 
 			ArgumentCaptor<PhotoDetailModelList> photoDetailModelCaptor = ArgumentCaptor.forClass(PhotoDetailModelList.class);
-			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
-			doReturn(1L).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
+			ArgumentCaptor<AccountId> photoAcountIdCaptor = ArgumentCaptor.forClass(AccountId.class);
+			doReturn(new PhotoNo(1L)).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
 
 			mockMvc.perform(multipart("/api/v1/accounts/aaaaaaaa/photos")
 					.file(multipartFile)
@@ -383,7 +383,7 @@ public class PhotoRestControllerTest {
 			assertNull(photoDetailModelList.getFirst().getIso());
 			assertTrue(photoDetailModelList.getFirst().getPhotoTagModelList().isEmpty());
 
-			assertEquals("aaaaaaaa", photoAcountIdCaptor.getValue());
+			assertEquals(new AccountId("aaaaaaaa"), photoAcountIdCaptor.getValue());
 		}
 
 		@Test
@@ -406,8 +406,8 @@ public class PhotoRestControllerTest {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<PhotoDetailModelList> photoDetailModelCaptor = ArgumentCaptor.forClass(PhotoDetailModelList.class);
-			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
-			doReturn(1L).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
+			ArgumentCaptor<AccountId> photoAcountIdCaptor = ArgumentCaptor.forClass(AccountId.class);
+			doReturn(new PhotoNo(1L)).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
 
 			mockMvc.perform(multipart("/api/v1/accounts/aaaaaaaa/photos")
 					.file(multipartFile)
@@ -444,7 +444,7 @@ public class PhotoRestControllerTest {
 				.andExpect(jsonPath("$.message").value("写真登録が完了しました。"));
 
 			verify(sessionHelper, times(0)).getAccountNo();
-			verify(photoServiceImpl, times(0)).isReachedUpperLimit(1L);
+			verify(photoServiceImpl, times(0)).isReachedUpperLimit(new AccountNo(1L));
 
 			PhotoDetailModelList photoDetailModelList = photoDetailModelCaptor.getValue();
 			assertEquals(1, photoDetailModelList.size());
@@ -475,7 +475,7 @@ public class PhotoRestControllerTest {
 			assertEquals("海", photoDetailModelList.getFirst().getPhotoTagModelList().get(1).getTagJapaneseName().value());
 			assertEquals("", photoDetailModelList.getFirst().getPhotoTagModelList().get(1).getTagEnglishName().value());
 
-			assertEquals("aaaaaaaa", photoAcountIdCaptor.getValue());
+			assertEquals(new AccountId("aaaaaaaa"), photoAcountIdCaptor.getValue());
 		}
 
 		@Test
@@ -490,8 +490,8 @@ public class PhotoRestControllerTest {
 					.param("directionKbn", "VERTICAL"))
 				.andExpect(status().isForbidden());
 
-			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Long.class));
-			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(PhotoDetailModelList.class));
+			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(AccountNo.class));
+			verify(photoServiceImpl, times(0)).savePhotos(any(AccountId.class), any(PhotoDetailModelList.class));
 		}
 
 		@Test
@@ -501,14 +501,14 @@ public class PhotoRestControllerTest {
 		void savePhoto_PhotoNotAdditableException() throws Exception {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 			doReturn(1L).when(sessionHelper).getAccountNo();
-			doReturn(true).when(photoServiceImpl).isReachedUpperLimit(1L);
+			doReturn(true).when(photoServiceImpl).isReachedUpperLimit(new AccountNo(1L));
 
 			mockMvc.perform(multipart("/api/v1/accounts/aaaaaaaa/photos")
 					.param("accountNo", "1")
 					.param("directionKbn", "VERTICAL"))
 				.andExpect(status().isBadRequest());
 
-			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(PhotoDetailModelList.class));
+			verify(photoServiceImpl, times(0)).savePhotos(any(AccountId.class), any(PhotoDetailModelList.class));
 		}
 
 		@Test
@@ -518,14 +518,14 @@ public class PhotoRestControllerTest {
 		void savePhoto_BadRequestException_file_and_filepath_is_null() throws Exception {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 			doReturn(1L).when(sessionHelper).getAccountNo();
-			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1L);
+			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(new AccountNo(1L));
 
 			mockMvc.perform(multipart("/api/v1/accounts/aaaaaaaa/photos")
 					.param("accountNo", "1")
 					.param("directionKbn", "VERTICAL"))
 				.andExpect(status().isBadRequest());
 
-			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(PhotoDetailModelList.class));
+			verify(photoServiceImpl, times(0)).savePhotos(any(AccountId.class), any(PhotoDetailModelList.class));
 		}
 
 		@Test
@@ -535,7 +535,7 @@ public class PhotoRestControllerTest {
 		void savePhoto_BadRequestException_file_and_filepath_is_blank() throws Exception {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 			doReturn(1L).when(sessionHelper).getAccountNo();
-			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1L);
+			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(new AccountNo(1L));
 
 			mockMvc.perform(multipart("/api/v1/accounts/aaaaaaaa/photos")
 					.param("accountNo", "1")
@@ -543,7 +543,7 @@ public class PhotoRestControllerTest {
 					.param("directionKbn", "VERTICAL"))
 				.andExpect(status().isBadRequest());
 
-			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(PhotoDetailModelList.class));
+			verify(photoServiceImpl, times(0)).savePhotos(any(AccountId.class), any(PhotoDetailModelList.class));
 		}
 
 		@Test
@@ -553,7 +553,7 @@ public class PhotoRestControllerTest {
 		void savePhoto_BadRequestException_others() throws Exception {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 			doReturn(1L).when(sessionHelper).getAccountNo();
-			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1L);
+			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(new AccountNo(1L));
 
 			mockMvc.perform(multipart("/api/v1/accounts/aaaaaaaa/photos")
 					.param("accountNo", "1")
@@ -562,7 +562,7 @@ public class PhotoRestControllerTest {
 					.param("focalLength", "-1"))
 				.andExpect(status().isBadRequest());
 
-			verify(photoServiceImpl, times(0)).savePhotos(any(String.class), any(PhotoDetailModelList.class));
+			verify(photoServiceImpl, times(0)).savePhotos(any(AccountId.class), any(PhotoDetailModelList.class));
 		}
 
 		@Test
@@ -580,7 +580,7 @@ public class PhotoRestControllerTest {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<PhotoDetailModelList> photoDetailModelCaptor = ArgumentCaptor.forClass(PhotoDetailModelList.class);
-			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
+			ArgumentCaptor<AccountId> photoAcountIdCaptor = ArgumentCaptor.forClass(AccountId.class);
 			doThrow(FileDuplicateException.class).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
 
 			mockMvc.perform(multipart("/api/v1/accounts/aaaaaaaa/photos")
@@ -591,7 +591,7 @@ public class PhotoRestControllerTest {
 					.param("directionKbn", "VERTICAL"))
 				.andExpect(status().isConflict());
 
-			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Long.class));
+			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(AccountNo.class));
 			verify(sessionHelper, times(0)).getAccountNo();
 
 			PhotoDetailModelList photoDetailModelList = photoDetailModelCaptor.getValue();
@@ -617,7 +617,7 @@ public class PhotoRestControllerTest {
 			assertNull(photoDetailModelList.getFirst().getIso());
 			assertTrue(photoDetailModelList.getFirst().getPhotoTagModelList().isEmpty());
 
-			assertEquals("aaaaaaaa", photoAcountIdCaptor.getValue());
+			assertEquals(new AccountId("aaaaaaaa"), photoAcountIdCaptor.getValue());
 		}
 
 		@Test
@@ -635,7 +635,7 @@ public class PhotoRestControllerTest {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<PhotoDetailModelList> photoDetailModelCaptor = ArgumentCaptor.forClass(PhotoDetailModelList.class);
-			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
+			ArgumentCaptor<AccountId> photoAcountIdCaptor = ArgumentCaptor.forClass(AccountId.class);
 			doThrow(RegistFailureException.class).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
 
 			mockMvc.perform(multipart("/api/v1/accounts/aaaaaaaa/photos")
@@ -646,7 +646,7 @@ public class PhotoRestControllerTest {
 					.param("directionKbn", "VERTICAL"))
 				.andExpect(status().isConflict());
 
-			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Long.class));
+			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(AccountNo.class));
 			verify(sessionHelper, times(0)).getAccountNo();
 
 			PhotoDetailModelList photoDetailModelList = photoDetailModelCaptor.getValue();
@@ -672,7 +672,7 @@ public class PhotoRestControllerTest {
 			assertNull(photoDetailModelList.getFirst().getIso());
 			assertTrue(photoDetailModelList.getFirst().getPhotoTagModelList().isEmpty());
 
-			assertEquals("aaaaaaaa", photoAcountIdCaptor.getValue());
+			assertEquals(new AccountId("aaaaaaaa"), photoAcountIdCaptor.getValue());
 		}
 
 		@Test
@@ -690,7 +690,7 @@ public class PhotoRestControllerTest {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<PhotoDetailModelList> photoDetailModelCaptor = ArgumentCaptor.forClass(PhotoDetailModelList.class);
-			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
+			ArgumentCaptor<AccountId> photoAcountIdCaptor = ArgumentCaptor.forClass(AccountId.class);
 			doThrow(UpdateFailureException.class).when(photoServiceImpl).savePhotos(photoAcountIdCaptor.capture(), photoDetailModelCaptor.capture());
 
 			mockMvc.perform(multipart("/api/v1/accounts/aaaaaaaa/photos")
@@ -701,7 +701,7 @@ public class PhotoRestControllerTest {
 					.param("directionKbn", "VERTICAL"))
 				.andExpect(status().isConflict());
 
-			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Long.class));
+			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(AccountNo.class));
 			verify(sessionHelper, times(0)).getAccountNo();
 
 			PhotoDetailModelList photoDetailModelList = photoDetailModelCaptor.getValue();
@@ -727,7 +727,7 @@ public class PhotoRestControllerTest {
 			assertNull(photoDetailModelList.getFirst().getIso());
 			assertTrue(photoDetailModelList.getFirst().getPhotoTagModelList().isEmpty());
 
-			assertEquals("aaaaaaaa", photoAcountIdCaptor.getValue());
+			assertEquals(new AccountId("aaaaaaaa"), photoAcountIdCaptor.getValue());
 		}
 	}
 
@@ -745,7 +745,7 @@ public class PhotoRestControllerTest {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<PhotoDeleteModelList> photoDeleteModelCaptor = ArgumentCaptor.forClass(PhotoDeleteModelList.class);
-			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
+			ArgumentCaptor<AccountId> photoAcountIdCaptor = ArgumentCaptor.forClass(AccountId.class);
 			doNothing().when(photoServiceImpl).deletePhotos(photoAcountIdCaptor.capture(), photoDeleteModelCaptor.capture());
 
 			mockMvc.perform(delete("/api/v1/accounts/aaaaaaaa/photos")
@@ -761,7 +761,7 @@ public class PhotoRestControllerTest {
 			assertEquals(new AccountNo(1L), photoDeleteModelList.getFirst().getAccountNo());
 			assertEquals(1L, photoDeleteModelList.getFirst().getPhotoNo().value());
 			assertEquals(imageFilePath, photoDeleteModelList.getFirst().getImageFilePath().value());
-			assertEquals("aaaaaaaa", photoAcountIdCaptor.getValue());
+			assertEquals(new AccountId("aaaaaaaa"), photoAcountIdCaptor.getValue());
 		}
 
 		@Test
@@ -802,7 +802,7 @@ public class PhotoRestControllerTest {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<PhotoDeleteModelList> photoDeleteModelCaptor = ArgumentCaptor.forClass(PhotoDeleteModelList.class);
-			ArgumentCaptor<String> photoAcountIdCaptor = ArgumentCaptor.forClass(String.class);
+			ArgumentCaptor<AccountId> photoAcountIdCaptor = ArgumentCaptor.forClass(AccountId.class);
 			doThrow(UpdateFailureException.class).when(photoServiceImpl).deletePhotos(photoAcountIdCaptor.capture(), photoDeleteModelCaptor.capture());
 
 			mockMvc.perform(delete("/api/v1/accounts/aaaaaaaa/photos")
@@ -815,7 +815,7 @@ public class PhotoRestControllerTest {
 			assertEquals(new AccountNo(1L), photoDeleteModelList.getFirst().getAccountNo());
 			assertEquals(1L, photoDeleteModelList.getFirst().getPhotoNo().value());
 			assertEquals(imageFilePath, photoDeleteModelList.getFirst().getImageFilePath().value());
-			assertEquals("aaaaaaaa", photoAcountIdCaptor.getValue());
+			assertEquals(new AccountId("aaaaaaaa"), photoAcountIdCaptor.getValue());
 		}
 	}
 
@@ -1017,7 +1017,7 @@ public class PhotoRestControllerTest {
 		void getPhotoUpperLimit_not_reached() throws Exception {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 			doReturn(1L).when(sessionHelper).getAccountNo();
-			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(1L);
+			doReturn(false).when(photoServiceImpl).isReachedUpperLimit(new AccountNo(1L));
 
 			mockMvc.perform(get("/api/v1/accounts/aaaaaaaa/photos/upper-limit"))
 				.andExpect(status().isOk())
@@ -1030,7 +1030,7 @@ public class PhotoRestControllerTest {
 		void getPhotoUpperLimit_reached() throws Exception {
 			doReturn("aaaaaaaa").when(sessionHelper).getAccountId();
 			doReturn(1L).when(sessionHelper).getAccountNo();
-			doReturn(true).when(photoServiceImpl).isReachedUpperLimit(1L);
+			doReturn(true).when(photoServiceImpl).isReachedUpperLimit(new AccountNo(1L));
 
 			mockMvc.perform(get("/api/v1/accounts/aaaaaaaa/photos/upper-limit"))
 				.andExpect(status().isOk())
@@ -1047,7 +1047,7 @@ public class PhotoRestControllerTest {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.isReachedUpperLimit").value(false));
 
-			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(Long.class));
+			verify(photoServiceImpl, times(0)).isReachedUpperLimit(any(AccountNo.class));
 		}
 	}
 }

--- a/backend/src/test/java/com/web/gallery/repository/impl/AccountRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/AccountRepositoryImplTest.java
@@ -96,7 +96,7 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(accountList).when(accountMapper).select(accountCaptor.capture());
 
-			AccountModel actual = accountRepositoryImpl.getByAccountNo(1L);
+			AccountModel actual = accountRepositoryImpl.getByAccountNo(new AccountNo(1L));
 
 			verify(accountMapper).select(any(Account.class));
 			Account accountCapture = accountCaptor.getValue();
@@ -124,7 +124,7 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(new ArrayList<Account>()).when(accountMapper).select(accountCaptor.capture());
 
-			AccountModel actual = accountRepositoryImpl.getByAccountNo(1L);
+			AccountModel actual = accountRepositoryImpl.getByAccountNo(new AccountNo(1L));
 
 			verify(accountMapper).select(any(Account.class));
 			Account accountCapture = accountCaptor.getValue();
@@ -168,7 +168,7 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(accountList).when(accountMapper).select(accountCaptor.capture());
 
-			AccountModel actual = accountRepositoryImpl.getByAccountId("aaaaaaaa");
+			AccountModel actual = accountRepositoryImpl.getByAccountId(new AccountId("aaaaaaaa"));
 
 			verify(accountMapper).select(any(Account.class));
 			Account accountCapture = accountCaptor.getValue();
@@ -196,7 +196,7 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(new ArrayList<Account>()).when(accountMapper).select(accountCaptor.capture());
 			
-			AccountModel actual = accountRepositoryImpl.getByAccountId("aaaaaaaa");
+			AccountModel actual = accountRepositoryImpl.getByAccountId(new AccountId("aaaaaaaa"));
 			
 			verify(accountMapper).select(any(Account.class));
 			Account accountCapture = accountCaptor.getValue();
@@ -587,7 +587,7 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(1).when(accountMapper).delete(accountCaptor.capture());
 
-			accountRepositoryImpl.delete(1L);
+			accountRepositoryImpl.delete(new AccountNo(1L));
 
 			verify(accountMapper, times(1)).delete(any(Account.class));
 			Account accountCapture = accountCaptor.getValue();
@@ -606,7 +606,7 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(true).when(accountMapper).isExistAccount(accountCaptor.capture());
 
-			assertTrue(accountRepositoryImpl.isExistAccount(1L, "aaaaaaaa"));
+			assertTrue(accountRepositoryImpl.isExistAccount(new AccountNo(1L), new AccountId("aaaaaaaa")));
 			verify(accountMapper, times(1)).isExistAccount(any(Account.class));
 
 			Account accountCapture = accountCaptor.getValue();
@@ -621,7 +621,7 @@ public class AccountRepositoryImplTest {
 			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
 			doReturn(false).when(accountMapper).isExistAccount(accountCaptor.capture());
 
-			assertFalse(accountRepositoryImpl.isExistAccount(1L, "aaaaaaaa"));
+			assertFalse(accountRepositoryImpl.isExistAccount(new AccountNo(1L), new AccountId("aaaaaaaa")));
 			verify(accountMapper, times(1)).isExistAccount(any());
 
 			Account accountCapture = accountCaptor.getValue();

--- a/backend/src/test/java/com/web/gallery/repository/impl/KbnMstRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/KbnMstRepositoryImplTest.java
@@ -84,7 +84,7 @@ public class KbnMstRepositoryImplTest {
 			ArgumentCaptor<KbnMst> kbnMstCaptor = ArgumentCaptor.forClass(KbnMst.class);
 			doReturn(expected).when(kbnMstMapper).select(kbnMstCaptor.capture());
 			
-			KbnMstModelList actual = kbnMstRepositoryImpl.get(kbnClassCode);
+			KbnMstModelList actual = kbnMstRepositoryImpl.get(new KbnClassCode(kbnClassCode));
 			
 			KbnMst kbnMstCapture = kbnMstCaptor.getValue();
 			assertEquals(new KbnClassCode(kbnClassCode), kbnMstCapture.getKbnClassCode());
@@ -113,7 +113,7 @@ public class KbnMstRepositoryImplTest {
 			ArgumentCaptor<KbnMst> kbnMstCaptor = ArgumentCaptor.forClass(KbnMst.class);
 			doReturn(expected).when(kbnMstMapper).select(kbnMstCaptor.capture());
 			
-			KbnMstModelList actual = kbnMstRepositoryImpl.get(kbnClassCode);
+			KbnMstModelList actual = kbnMstRepositoryImpl.get(new KbnClassCode(kbnClassCode));
 
 			KbnMst kbnMstCapture = kbnMstCaptor.getValue();
 			assertEquals(new KbnClassCode(kbnClassCode), kbnMstCapture.getKbnClassCode());

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoMstRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoMstRepositoryImplTest.java
@@ -76,7 +76,7 @@ public class PhotoMstRepositoryImplTest {
 			ArgumentCaptor<PhotoMst> photoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
 			doReturn(1).when(photoMstMapper).insert(photoMstCaptor.capture());
 			
-			photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 1L);
+			photoMstRepositoryImpl.regist(photoDetailModel, new ImageFilePath(imageFilePath), new PhotoNo(1L));
 			
 			verify(photoMstMapper).insert(any(PhotoMst.class));
 			PhotoMst photoMst = photoMstCaptor.getValue();
@@ -125,7 +125,7 @@ public class PhotoMstRepositoryImplTest {
 			ArgumentCaptor<PhotoMst> photoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
 			doReturn(1).when(photoMstMapper).insert(photoMstCaptor.capture());
 			
-			photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 1L);
+			photoMstRepositoryImpl.regist(photoDetailModel, new ImageFilePath(imageFilePath), new PhotoNo(1L));
 			
 			verify(photoMstMapper).insert(any(PhotoMst.class));
 			PhotoMst photoMst = photoMstCaptor.getValue();
@@ -164,7 +164,7 @@ public class PhotoMstRepositoryImplTest {
 			ArgumentCaptor<PhotoMst> photoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
 			doThrow(DuplicateKeyException.class).when(photoMstMapper).insert(photoMstCaptor.capture());
 			
-			assertThrows(RegistFailureException.class, () -> photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 1L));
+			assertThrows(RegistFailureException.class, () -> photoMstRepositoryImpl.regist(photoDetailModel, new ImageFilePath(imageFilePath), new PhotoNo(1L)));
 			
 			verify(photoMstMapper).insert(any(PhotoMst.class));
 			PhotoMst photoMst = photoMstCaptor.getValue();
@@ -523,7 +523,7 @@ public class PhotoMstRepositoryImplTest {
 		@DisplayName("正常系：getMaxPhotoNoがある場合")
 		void getNewPhotoNo_getMaxPhotoNo_found() {
 			doReturn(1L).when(photoMstMapper).getMaxPhotoNo(1L);
-			assertEquals(2L, photoMstRepositoryImpl.getNewPhotoNo(1L));
+			assertEquals(new PhotoNo(2L), photoMstRepositoryImpl.getNewPhotoNo(new AccountNo(1L)));
 		}
 		
 		@Test
@@ -531,7 +531,7 @@ public class PhotoMstRepositoryImplTest {
 		@DisplayName("正常系：getMaxPhotoNoがない場合")
 		void getNewPhotoNo_getMaxPhotoNo_not_found() {
 			doReturn(null).when(photoMstMapper).getMaxPhotoNo(1L);
-			assertEquals(1L, photoMstRepositoryImpl.getNewPhotoNo(1L));
+			assertEquals(new PhotoNo(1L), photoMstRepositoryImpl.getNewPhotoNo(new AccountNo(1L)));
 		}
 	}
 	
@@ -602,7 +602,7 @@ public class PhotoMstRepositoryImplTest {
 			ArgumentCaptor<PhotoMst> photoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
 			doReturn(3).when(photoMstMapper).count(photoMstCaptor.capture());
 			
-			assertEquals(3, photoMstRepositoryImpl.count(1L));
+			assertEquals(3, photoMstRepositoryImpl.count(new AccountNo(1L)));
 			
 			PhotoMst photoMst = photoMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoMst.getAccountNo());

--- a/backend/src/test/java/com/web/gallery/repository/impl/RefreshTokenRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/RefreshTokenRepositoryImplTest.java
@@ -83,7 +83,7 @@ public class RefreshTokenRepositoryImplTest {
 
 			doReturn(mapperResult).when(refreshTokenMapper).selectByTokenHash("abc123hash");
 
-			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash("abc123hash");
+			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash(new TokenHash("abc123hash"));
 
 			assertNotNull(actual);
 			assertEquals(new AccountNo(1L), actual.getAccountNo());
@@ -99,7 +99,7 @@ public class RefreshTokenRepositoryImplTest {
 		void findByTokenHash_not_found() {
 			doReturn(null).when(refreshTokenMapper).selectByTokenHash("nonexistent");
 
-			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash("nonexistent");
+			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash(new TokenHash("nonexistent"));
 
 			assertNull(actual);
 			verify(refreshTokenMapper, times(1)).selectByTokenHash("nonexistent");
@@ -116,7 +116,7 @@ public class RefreshTokenRepositoryImplTest {
 		void revokeAllByAccountNo_success() {
 			doReturn(2).when(refreshTokenMapper).revokeAllByAccountNo(1L);
 
-			refreshTokenRepositoryImpl.revokeAllByAccountNo(1L);
+			refreshTokenRepositoryImpl.revokeAllByAccountNo(new AccountNo(1L));
 
 			verify(refreshTokenMapper, times(1)).revokeAllByAccountNo(1L);
 		}
@@ -132,7 +132,7 @@ public class RefreshTokenRepositoryImplTest {
 		void revokeByTokenHash_success() {
 			doReturn(1).when(refreshTokenMapper).revokeByTokenHash("abc123hash");
 
-			refreshTokenRepositoryImpl.revokeByTokenHash("abc123hash");
+			refreshTokenRepositoryImpl.revokeByTokenHash(new TokenHash("abc123hash"));
 
 			verify(refreshTokenMapper, times(1)).revokeByTokenHash("abc123hash");
 		}

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/AccountRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/AccountRepositoryImplIntegrationTest.java
@@ -65,7 +65,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントが取得できた場合")
 		void getByAccountNo_found() {
-			AccountModel actual = accountRepositoryImpl.getByAccountNo(1L);
+			AccountModel actual = accountRepositoryImpl.getByAccountNo(new AccountNo(1L));
 
 			assertEquals(new AccountNo(1L), actual.getAccountNo());
 			assertEquals(new IsDeleted(false), actual.getIsDeleted());
@@ -86,7 +86,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが取得できなかった場合")
 		void getByAccountNo_not_found() {
-			AccountModel actual = accountRepositoryImpl.getByAccountNo(99L);
+			AccountModel actual = accountRepositoryImpl.getByAccountNo(new AccountNo(99L));
 			assertNull(actual);
 		}
 	}
@@ -101,7 +101,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントが取得できた場合")
 		void getByAccountId_found() {
-			AccountModel actual = accountRepositoryImpl.getByAccountId("aaaaaaaa");
+			AccountModel actual = accountRepositoryImpl.getByAccountId(new AccountId("aaaaaaaa"));
 
 			assertEquals(new AccountNo(1L), actual.getAccountNo());
 			assertEquals(new IsDeleted(false), actual.getIsDeleted());
@@ -122,7 +122,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが取得できなかった場合")
 		void getByAccountId_not_found() {
-			AccountModel actual = accountRepositoryImpl.getByAccountId("zzzzzzzz");
+			AccountModel actual = accountRepositoryImpl.getByAccountId(new AccountId("zzzzzzzz"));
 			assertNull(actual);
 		}
 	}
@@ -539,14 +539,14 @@ public class AccountRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントが存在する場合")
 		void isExistAccount_true() {
-			assertTrue(accountRepositoryImpl.isExistAccount(2L, "aaaaaaaa"));
+			assertTrue(accountRepositoryImpl.isExistAccount(new AccountNo(2L), new AccountId("aaaaaaaa")));
 		}
 		
 		@Test
 		@Order(2)
 		@DisplayName("正常系：アカウントが存在しない場合")
 		void isExistAccount_false() {
-			assertFalse(accountRepositoryImpl.isExistAccount(1L, "zzzzzzzz"));
+			assertFalse(accountRepositoryImpl.isExistAccount(new AccountNo(1L), new AccountId("zzzzzzzz")));
 		}
 	}
 	
@@ -583,7 +583,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントを物理削除する")
 		void delete_success() {
-			accountRepositoryImpl.delete(1L);
+			accountRepositoryImpl.delete(new AccountNo(1L));
 
 			List<Account> actualData = jdbcTemplate.query(
 					"SELECT * FROM common.account where account_no=1", (rs, rowNum) ->

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/KbnMstRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/KbnMstRepositoryImplIntegrationTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.web.gallery.domain.common.KbnClassCode;
 import com.web.gallery.domain.common.KbnCode;
 import com.web.gallery.model.KbnMstModelList;
 import com.web.gallery.repository.impl.KbnMstRepositoryImpl;
@@ -36,7 +37,7 @@ public class KbnMstRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：区分マスタが取得できた場合")
 		void get_found() {
-			KbnMstModelList actual = kbnMstRepositoryImpl.get("sex");
+			KbnMstModelList actual = kbnMstRepositoryImpl.get(new KbnClassCode("sex"));
 			assertEquals(2, actual.size());
 			assertEquals(new KbnCode("man"), actual.get(0).getKbnCode());
 			assertEquals(new KbnCode("woman"), actual.get(1).getKbnCode());
@@ -46,7 +47,7 @@ public class KbnMstRepositoryImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：区分マスタが取得できなかった場合")
 		void get_not_found() {
-			KbnMstModelList actual = kbnMstRepositoryImpl.get("test");
+			KbnMstModelList actual = kbnMstRepositoryImpl.get(new KbnClassCode("test"));
 			assertEquals(0, actual.size());
 		}
 	}

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoMstRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoMstRepositoryImplIntegrationTest.java
@@ -78,7 +78,7 @@ public class PhotoMstRepositoryImplIntegrationTest {
 					.build();
 
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
-			photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 4L);
+			photoMstRepositoryImpl.regist(photoDetailModel, new ImageFilePath(imageFilePath), new PhotoNo(4L));
 
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst WHERE account_no=1 and photo_no=4", (rs, rowNum) ->
@@ -147,7 +147,7 @@ public class PhotoMstRepositoryImplIntegrationTest {
 					.build();
 
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
-			photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 4L);
+			photoMstRepositoryImpl.regist(photoDetailModel, new ImageFilePath(imageFilePath), new PhotoNo(4L));
 
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst WHERE account_no=1 and photo_no=4", (rs, rowNum) ->
@@ -205,7 +205,7 @@ public class PhotoMstRepositoryImplIntegrationTest {
 					.imageFilePath(new ImageFilePath(imageFilePath))
 					.build();
 			
-			assertThrows(RegistFailureException.class , () -> photoMstRepositoryImpl.regist(photoDetailModel, imageFilePath, 1L));
+			assertThrows(RegistFailureException.class , () -> photoMstRepositoryImpl.regist(photoDetailModel, new ImageFilePath(imageFilePath), new PhotoNo(1L)));
 		}
 	}
 	
@@ -451,14 +451,14 @@ public class PhotoMstRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：getMaxPhotoNoがある場合")
 		void getNewPhotoNo_getMaxPhotoNo_found() {
-			assertEquals(4L, photoMstRepositoryImpl.getNewPhotoNo(1L));
+			assertEquals(new PhotoNo(4L), photoMstRepositoryImpl.getNewPhotoNo(new AccountNo(1L)));
 		}
 		
 		@Test
 		@Order(2)
 		@DisplayName("正常系：getMaxPhotoNoがない場合")
 		void getNewPhotoNo_getMaxPhotoNo_not_found() {
-			assertEquals(1L, photoMstRepositoryImpl.getNewPhotoNo(9L));
+			assertEquals(new PhotoNo(1L), photoMstRepositoryImpl.getNewPhotoNo(new AccountNo(9L)));
 		}
 	}
 	
@@ -560,7 +560,7 @@ public class PhotoMstRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系")
 		void count_success() {
-			assertEquals(2, photoMstRepositoryImpl.count(1L));
+			assertEquals(2, photoMstRepositoryImpl.count(new AccountNo(1L)));
 		}
 	}
 }

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/RefreshTokenRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/RefreshTokenRepositoryImplIntegrationTest.java
@@ -115,7 +115,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：トークンハッシュに該当するリフレッシュトークンを取得する")
 		void findByTokenHash_success() {
-			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1");
+			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash(new TokenHash("valid_token_hash_1"));
 
 			assertNotNull(actual);
 			assertEquals(new AccountNo(1L), actual.getAccountNo());
@@ -127,7 +127,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：無効化済みのトークンも取得できる")
 		void findByTokenHash_revoked() {
-			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash("revoked_token_hash_1");
+			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash(new TokenHash("revoked_token_hash_1"));
 
 			assertNotNull(actual);
 			assertTrue(actual.getIsRevoked().value());
@@ -137,7 +137,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@Order(3)
 		@DisplayName("正常系：該当するトークンが存在しない場合、nullを返す")
 		void findByTokenHash_not_found() {
-			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash("nonexistent_hash");
+			RefreshTokenModel actual = refreshTokenRepositoryImpl.findByTokenHash(new TokenHash("nonexistent_hash"));
 
 			assertNull(actual);
 		}
@@ -154,7 +154,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@DisplayName("正常系：アカウント番号に該当する有効なリフレッシュトークンをすべて無効化する")
 		void revokeAllByAccountNo_success() {
 			// アカウント1の有効なトークンが2件（token_id=1,5）、無効化済み1件（token_id=2）、期限切れ1件（token_id=3）
-			refreshTokenRepositoryImpl.revokeAllByAccountNo(1L);
+			refreshTokenRepositoryImpl.revokeAllByAccountNo(new AccountNo(1L));
 
 			List<RefreshToken> account1Tokens = getRefreshTokensByAccountNo(1L);
 			// アカウント1のトークンはすべて無効化されている
@@ -163,7 +163,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 			}
 
 			// アカウント2のトークンは影響を受けない
-			RefreshTokenModel account2Token = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_2");
+			RefreshTokenModel account2Token = refreshTokenRepositoryImpl.findByTokenHash(new TokenHash("valid_token_hash_2"));
 			assertNotNull(account2Token);
 			assertFalse(account2Token.getIsRevoked().value());
 		}
@@ -172,7 +172,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：該当するトークンが存在しない場合もエラーにならない")
 		void revokeAllByAccountNo_no_tokens() {
-			assertDoesNotThrow(() -> refreshTokenRepositoryImpl.revokeAllByAccountNo(999L));
+			assertDoesNotThrow(() -> refreshTokenRepositoryImpl.revokeAllByAccountNo(new AccountNo(999L)));
 		}
 	}
 
@@ -187,17 +187,17 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@DisplayName("正常系：トークンハッシュに該当するリフレッシュトークンを無効化する")
 		void revokeByTokenHash_success() {
 			// 無効化前は有効
-			RefreshTokenModel before = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1");
+			RefreshTokenModel before = refreshTokenRepositoryImpl.findByTokenHash(new TokenHash("valid_token_hash_1"));
 			assertFalse(before.getIsRevoked().value());
 
-			refreshTokenRepositoryImpl.revokeByTokenHash("valid_token_hash_1");
+			refreshTokenRepositoryImpl.revokeByTokenHash(new TokenHash("valid_token_hash_1"));
 
 			// 無効化後はis_revoked=true
-			RefreshTokenModel after = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1");
+			RefreshTokenModel after = refreshTokenRepositoryImpl.findByTokenHash(new TokenHash("valid_token_hash_1"));
 			assertTrue(after.getIsRevoked().value());
 
 			// 他のトークンは影響を受けない
-			RefreshTokenModel otherToken = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1b");
+			RefreshTokenModel otherToken = refreshTokenRepositoryImpl.findByTokenHash(new TokenHash("valid_token_hash_1b"));
 			assertFalse(otherToken.getIsRevoked().value());
 		}
 
@@ -205,7 +205,7 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：該当するトークンが存在しない場合もエラーにならない")
 		void revokeByTokenHash_not_found() {
-			assertDoesNotThrow(() -> refreshTokenRepositoryImpl.revokeByTokenHash("nonexistent_hash"));
+			assertDoesNotThrow(() -> refreshTokenRepositoryImpl.revokeByTokenHash(new TokenHash("nonexistent_hash")));
 		}
 	}
 
@@ -230,11 +230,11 @@ public class RefreshTokenRepositoryImplIntegrationTest {
 			assertEquals(4, afterCount);
 
 			// 期限切れトークン（token_id=3）が削除されていることを検証
-			RefreshTokenModel deletedToken = refreshTokenRepositoryImpl.findByTokenHash("expired_token_hash_1");
+			RefreshTokenModel deletedToken = refreshTokenRepositoryImpl.findByTokenHash(new TokenHash("expired_token_hash_1"));
 			assertNull(deletedToken);
 
 			// 有効なトークンは残っている
-			RefreshTokenModel validToken = refreshTokenRepositoryImpl.findByTokenHash("valid_token_hash_1");
+			RefreshTokenModel validToken = refreshTokenRepositoryImpl.findByTokenHash(new TokenHash("valid_token_hash_1"));
 			assertNotNull(validToken);
 		}
 	}

--- a/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
@@ -46,6 +46,7 @@ import com.web.gallery.domain.account.LoginFailureCount;
 import com.web.gallery.domain.account.Password;
 import com.web.gallery.domain.account.ResidentPrefectureKbnCode;
 import com.web.gallery.domain.common.IsDeleted;
+import com.web.gallery.domain.photo.ImageFilePath;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.AccountModel;
@@ -111,7 +112,7 @@ public class AccountServiceImplTest {
 					.loginFailureCount(new LoginFailureCount(0))
 					.password(new Password(password))
 					.build();
-			doReturn(account).when(accountRepositoryImpl).getByAccountId(accountId);
+			doReturn(account).when(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
 			doReturn(3).when(loginConfig).getFailCount();
 
 			UserDetails userDetails = accountServiceImpl.loadUserByUsername(accountId);
@@ -124,7 +125,7 @@ public class AccountServiceImplTest {
 		@DisplayName("異常系：UsernameNotFoundExceptionをthrowする")
 		void loadUserByUsername_UsernameNotFoundException() {
 			String accountId = "aaaaaaaa";
-			doReturn(null).when(accountRepositoryImpl).getByAccountId(accountId);
+			doReturn(null).when(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
 			assertThrows(UsernameNotFoundException.class, () -> accountServiceImpl.loadUserByUsername(accountId));
 		}
 	}
@@ -138,7 +139,7 @@ public class AccountServiceImplTest {
 		@DisplayName("正常系：アカウントを新規登録")
 		void registAccount_success() throws RegistFailureException {
 			AccountModel accountModel = AccountModel.builder().accountId(new AccountId("aaaaaaaa")).build();
-			doReturn(false).when(accountRepositoryImpl).isExistAccount(null, "aaaaaaaa");
+			doReturn(false).when(accountRepositoryImpl).isExistAccount(new AccountId("aaaaaaaa"));
 			doNothing().when(accountRepositoryImpl).regist(accountModel);
 			assertTrue(accountServiceImpl.registAccount(accountModel));
 		}
@@ -148,7 +149,7 @@ public class AccountServiceImplTest {
 		@DisplayName("正常系：アカウントが既に存在する")
 		void registAccount_account_already_exist() throws RegistFailureException {
 			AccountModel accountModel = AccountModel.builder().accountId(new AccountId("aaaaaaaa")).build();
-			doReturn(true).when(accountRepositoryImpl).isExistAccount(null, "aaaaaaaa");
+			doReturn(true).when(accountRepositoryImpl).isExistAccount(new AccountId("aaaaaaaa"));
 			verify(accountRepositoryImpl,times(0)).regist(accountModel);
 			assertFalse(accountServiceImpl.registAccount(accountModel));
 		}
@@ -158,7 +159,7 @@ public class AccountServiceImplTest {
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
 		void registAccount_RegistFailureException() throws RegistFailureException {
 			AccountModel accountModel = AccountModel.builder().accountId(new AccountId("aaaaaaaa")).build();
-			doReturn(false).when(accountRepositoryImpl).isExistAccount(null, "aaaaaaaa");
+			doReturn(false).when(accountRepositoryImpl).isExistAccount(new AccountId("aaaaaaaa"));
 			doThrow(RegistFailureException.class).when(accountRepositoryImpl).regist(accountModel);
 			assertThrows(RegistFailureException.class, () -> accountServiceImpl.registAccount(accountModel));
 		}
@@ -173,7 +174,7 @@ public class AccountServiceImplTest {
 		@DisplayName("正常系：アカウントを更新")
 		void updateAccount_success() throws UpdateFailureException {
 			AccountModel accountModel = AccountModel.builder().accountNo(new AccountNo(1L)).accountId(new AccountId("aaaaaaaa")).build();
-			doReturn(false).when(accountRepositoryImpl).isExistAccount(1L, "aaaaaaaa");
+			doReturn(false).when(accountRepositoryImpl).isExistAccount(new AccountNo(1L), new AccountId("aaaaaaaa"));
 			doNothing().when(accountRepositoryImpl).update(accountModel);
 			assertFalse(accountServiceImpl.updateAccount(accountModel));
 		}
@@ -183,7 +184,7 @@ public class AccountServiceImplTest {
 		@DisplayName("正常系：アカウントが既に存在する")
 		void updateAccount_account_already_exist() throws UpdateFailureException {
 			AccountModel accountModel = AccountModel.builder().accountNo(new AccountNo(1L)).accountId(new AccountId("aaaaaaaa")).build();
-			doReturn(true).when(accountRepositoryImpl).isExistAccount(1L, "aaaaaaaa");
+			doReturn(true).when(accountRepositoryImpl).isExistAccount(new AccountNo(1L), new AccountId("aaaaaaaa"));
 			verify(accountRepositoryImpl,times(0)).update(accountModel);
 			assertTrue(accountServiceImpl.updateAccount(accountModel));
 		}
@@ -193,7 +194,7 @@ public class AccountServiceImplTest {
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
 		void updateAccount_UpdateFailureException() throws UpdateFailureException {
 			AccountModel accountModel = AccountModel.builder().accountNo(new AccountNo(1L)).accountId(new AccountId("aaaaaaaa")).build();
-			doReturn(false).when(accountRepositoryImpl).isExistAccount(1L, "aaaaaaaa");
+			doReturn(false).when(accountRepositoryImpl).isExistAccount(new AccountNo(1L), new AccountId("aaaaaaaa"));
 			doThrow(UpdateFailureException.class).when(accountRepositoryImpl).update(accountModel);
 			assertThrows(UpdateFailureException.class, () -> accountServiceImpl.updateAccount(accountModel));
 		}
@@ -221,9 +222,9 @@ public class AccountServiceImplTest {
 					.lastLoginDatetime(null)
 					.loginFailureCount(new LoginFailureCount(0))
 					.build();
-			doReturn(account).when(accountRepositoryImpl).getByAccountId("aaaaaaaa");
+			doReturn(account).when(accountRepositoryImpl).getByAccountId(new AccountId("aaaaaaaa"));
 
-			AccountModel actual = accountServiceImpl.getAccountById("aaaaaaaa");
+			AccountModel actual = accountServiceImpl.getAccountById(new AccountId("aaaaaaaa"));
 
 			assertEquals(new AccountNo(1L), actual.getAccountNo());
 			assertEquals(new AccountId("aaaaaaaa"), actual.getAccountId());
@@ -239,8 +240,8 @@ public class AccountServiceImplTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが存在しない場合、nullを返す")
 		void getAccountById_not_found() {
-			doReturn(null).when(accountRepositoryImpl).getByAccountId("aaaaaaaa");
-			assertNull(accountServiceImpl.getAccountById("aaaaaaaa"));
+			doReturn(null).when(accountRepositoryImpl).getByAccountId(new AccountId("aaaaaaaa"));
+			assertNull(accountServiceImpl.getAccountById(new AccountId("aaaaaaaa")));
 		}
 	}
 	
@@ -323,7 +324,7 @@ public class AccountServiceImplTest {
 			ArgumentCaptor<AccountModel> captor = ArgumentCaptor.forClass(AccountModel.class);
 			doNothing().when(accountRepositoryImpl).updateLoginFailureCount(captor.capture());
 
-			accountServiceImpl.unlockAccount(1L);
+			accountServiceImpl.unlockAccount(new AccountNo(1L));
 
 			AccountModel accountModel = captor.getValue();
 			assertEquals(new AccountNo(1L), accountModel.getAccountNo());
@@ -336,7 +337,7 @@ public class AccountServiceImplTest {
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
 		void unlockAccount_UpdateFailureException() throws UpdateFailureException {
 			doThrow(UpdateFailureException.class).when(accountRepositoryImpl).updateLoginFailureCount(any(AccountModel.class));
-			assertThrows(UpdateFailureException.class, () -> accountServiceImpl.unlockAccount(999L));
+			assertThrows(UpdateFailureException.class, () -> accountServiceImpl.unlockAccount(new AccountNo(999L)));
 		}
 	}
 
@@ -353,7 +354,7 @@ public class AccountServiceImplTest {
 			ArgumentCaptor<AccountModel> captor = ArgumentCaptor.forClass(AccountModel.class);
 			doNothing().when(accountRepositoryImpl).updateLoginFailureCount(captor.capture());
 
-			accountServiceImpl.lockAccount(1L);
+			accountServiceImpl.lockAccount(new AccountNo(1L));
 
 			AccountModel accountModel = captor.getValue();
 			assertEquals(new AccountNo(1L), accountModel.getAccountNo());
@@ -366,7 +367,7 @@ public class AccountServiceImplTest {
 		void lockAccount_UpdateFailureException() throws UpdateFailureException {
 			doReturn(10).when(loginConfig).getFailCount();
 			doThrow(UpdateFailureException.class).when(accountRepositoryImpl).updateLoginFailureCount(any(AccountModel.class));
-			assertThrows(UpdateFailureException.class, () -> accountServiceImpl.lockAccount(999L));
+			assertThrows(UpdateFailureException.class, () -> accountServiceImpl.lockAccount(new AccountNo(999L)));
 		}
 	}
 
@@ -385,11 +386,11 @@ public class AccountServiceImplTest {
 			doNothing().when(photoFavoriteRepository).deleteByFavoritePhotoAccountNo(any(AccountNo.class));
 			doNothing().when(photoTagMstRepository).deleteByAccountNo(any(AccountNo.class));
 			doNothing().when(photoMstRepository).deleteByAccountNo(any(AccountNo.class));
-			doNothing().when(accountRepositoryImpl).delete(accountNo);
+			doNothing().when(accountRepositoryImpl).delete(new AccountNo(accountNo));
 			doReturn("/output/").when(photoConfig).getOutputPath();
-			doNothing().when(fileRepository).delete("/output/" + accountId + "/");
+			doNothing().when(fileRepository).delete(new ImageFilePath("/output/" + accountId + "/"));
 
-			accountServiceImpl.deleteAccount(accountNo, accountId);
+			accountServiceImpl.deleteAccount(new AccountNo(accountNo), new AccountId(accountId));
 
 			ArgumentCaptor<AccountNo> favoriteCaptor = ArgumentCaptor.forClass(AccountNo.class);
 			verify(photoFavoriteRepository, times(1)).deleteByAccountNo(favoriteCaptor.capture());
@@ -401,8 +402,8 @@ public class AccountServiceImplTest {
 
 			verify(photoTagMstRepository, times(1)).deleteByAccountNo(new AccountNo(accountNo));
 			verify(photoMstRepository, times(1)).deleteByAccountNo(new AccountNo(accountNo));
-			verify(accountRepositoryImpl, times(1)).delete(accountNo);
-			verify(fileRepository, times(1)).delete("/output/" + accountId + "/");
+			verify(accountRepositoryImpl, times(1)).delete(new AccountNo(accountNo));
+			verify(fileRepository, times(1)).delete(new ImageFilePath("/output/" + accountId + "/"));
 		}
 	}
 
@@ -424,7 +425,7 @@ public class AccountServiceImplTest {
 			AuthenticationSuccessEvent event = new AuthenticationSuccessEvent(authentication);
 			
 			AccountModel account = AccountModel.builder().accountNo(new AccountNo(1L)).build();
-			doReturn(account).when(accountRepositoryImpl).getByAccountId(username);
+			doReturn(account).when(accountRepositoryImpl).getByAccountId(new AccountId(username));
 			
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
 			doNothing().when(accountRepositoryImpl).updateLoginFailureCount(accountModelCaptor.capture());
@@ -460,7 +461,7 @@ public class AccountServiceImplTest {
 			AuthenticationSuccessEvent event = new AuthenticationSuccessEvent(authentication);
 			
 			AccountModel account = AccountModel.builder().accountNo(new AccountNo(1L)).build();
-			doReturn(account).when(accountRepositoryImpl).getByAccountId(username);
+			doReturn(account).when(accountRepositoryImpl).getByAccountId(new AccountId(username));
 			
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
 			doThrow(UpdateFailureException.class).when(accountRepositoryImpl).updateLoginFailureCount(accountModelCaptor.capture());
@@ -504,7 +505,7 @@ public class AccountServiceImplTest {
 			AuthenticationFailureBadCredentialsEvent event = new AuthenticationFailureBadCredentialsEvent(authentication, exception);
 			
 			AccountModel account = AccountModel.builder().accountNo(new AccountNo(1L)).loginFailureCount(new LoginFailureCount(1)).build();
-			doReturn(account).when(accountRepositoryImpl).getByAccountId(username);
+			doReturn(account).when(accountRepositoryImpl).getByAccountId(new AccountId(username));
 			
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
 			doNothing().when(accountRepositoryImpl).updateLoginFailureCount(accountModelCaptor.capture());
@@ -542,7 +543,7 @@ public class AccountServiceImplTest {
 			
 			AuthenticationFailureBadCredentialsEvent event = new AuthenticationFailureBadCredentialsEvent(authentication, exception);
 			
-			doReturn(null).when(accountRepositoryImpl).getByAccountId(username);
+			doReturn(null).when(accountRepositoryImpl).getByAccountId(new AccountId(username));
 			
 			accountServiceImpl.handle(event);
 			verify(accountRepositoryImpl, times(0)).updateLoginFailureCount(any(AccountModel.class));
@@ -565,7 +566,7 @@ public class AccountServiceImplTest {
 			AuthenticationFailureBadCredentialsEvent event = new AuthenticationFailureBadCredentialsEvent(authentication, exception);
 			
 			AccountModel account = AccountModel.builder().accountNo(new AccountNo(1L)).loginFailureCount(new LoginFailureCount(1)).build();
-			doReturn(account).when(accountRepositoryImpl).getByAccountId(username);
+			doReturn(account).when(accountRepositoryImpl).getByAccountId(new AccountId(username));
 			
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
 			doThrow(UpdateFailureException.class).when(accountRepositoryImpl).updateLoginFailureCount(accountModelCaptor.capture());

--- a/backend/src/test/java/com/web/gallery/service/impl/AuthServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AuthServiceImplTest.java
@@ -31,6 +31,8 @@ import com.web.gallery.config.JwtConfig;
 import com.web.gallery.constant.Consts;
 import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.account.Password;
+import com.web.gallery.domain.auth.RefreshTokenValue;
 import com.web.gallery.domain.common.ExpiresAt;
 import com.web.gallery.domain.common.IsRevoked;
 import com.web.gallery.domain.common.TokenHash;
@@ -97,14 +99,14 @@ class AuthServiceImplTest {
 			when(jwtConfig.getRefreshTokenExpirationDays()).thenReturn(7);
 			when(jwtConfig.getAccessTokenExpirationMinutes()).thenReturn(15);
 
-			AuthTokenModel result = authServiceImpl.login(accountId, password);
+			AuthTokenModel result = authServiceImpl.login(new AccountId(accountId), new Password(password));
 
 			assertNotNull(result);
 			assertEquals("access-token", result.getAccessToken().value());
 			assertEquals("refresh-token", result.getRefreshToken().value());
 			assertEquals(900L, result.getExpiresIn().value());
 
-			verify(refreshTokenRepository).revokeAllByAccountNo(1L);
+			verify(refreshTokenRepository).revokeAllByAccountNo(new AccountNo(1L));
 			ArgumentCaptor<RefreshTokenModel> refreshTokenModelCaptor = ArgumentCaptor.forClass(RefreshTokenModel.class);
 			verify(refreshTokenRepository).save(refreshTokenModelCaptor.capture());
 			assertEquals(OffsetDateTime.now(clock).plusDays(7), refreshTokenModelCaptor.getValue().getExpiresAt().value());
@@ -117,7 +119,7 @@ class AuthServiceImplTest {
 					.thenThrow(new BadCredentialsException("Bad credentials"));
 
 			assertThrows(BadCredentialsException.class, () -> {
-				authServiceImpl.login("testuser1", "wrongpassword");
+				authServiceImpl.login(new AccountId("testuser1"), new Password("wrongpassword"));
 			});
 		}
 
@@ -128,7 +130,7 @@ class AuthServiceImplTest {
 					.thenThrow(new LockedException("Account is locked"));
 
 			assertThrows(LockedException.class, () -> {
-				authServiceImpl.login("testuser1", "password1");
+				authServiceImpl.login(new AccountId("testuser1"), new Password("password1"));
 			});
 		}
 	}
@@ -148,20 +150,20 @@ class AuthServiceImplTest {
 					.isRevoked(new IsRevoked(false))
 					.build();
 
-			when(refreshTokenRepository.findByTokenHash(anyString())).thenReturn(storedToken);
+			when(refreshTokenRepository.findByTokenHash(any(TokenHash.class))).thenReturn(storedToken);
 
 			AccountModel account = AccountModel.builder()
 					.accountNo(new AccountNo(1L))
 					.accountId(new AccountId("testuser1"))
 					.build();
-			when(accountRepository.getByAccountNo(1L)).thenReturn(account);
+			when(accountRepository.getByAccountNo(new AccountNo(1L))).thenReturn(account);
 
 			AccountPrincipal principal = mock(AccountPrincipal.class);
 			when(accountServiceImpl.loadUserByUsername("testuser1")).thenReturn(principal);
 			when(jwtTokenProvider.generateAccessToken(principal)).thenReturn("new-access-token");
 			when(jwtConfig.getAccessTokenExpirationMinutes()).thenReturn(15);
 
-			AuthTokenModel result = authServiceImpl.refresh(refreshToken);
+			AuthTokenModel result = authServiceImpl.refresh(new RefreshTokenValue(refreshToken));
 
 			assertNotNull(result);
 			assertEquals("new-access-token", result.getAccessToken().value());
@@ -178,10 +180,10 @@ class AuthServiceImplTest {
 					.isRevoked(new IsRevoked(true))
 					.build();
 
-			when(refreshTokenRepository.findByTokenHash(anyString())).thenReturn(storedToken);
+			when(refreshTokenRepository.findByTokenHash(any(TokenHash.class))).thenReturn(storedToken);
 
 			assertThrows(IllegalArgumentException.class, () -> {
-				authServiceImpl.refresh("revoked-token");
+				authServiceImpl.refresh(new RefreshTokenValue("revoked-token"));
 			});
 		}
 
@@ -195,20 +197,20 @@ class AuthServiceImplTest {
 					.isRevoked(new IsRevoked(false))
 					.build();
 
-			when(refreshTokenRepository.findByTokenHash(anyString())).thenReturn(storedToken);
+			when(refreshTokenRepository.findByTokenHash(any(TokenHash.class))).thenReturn(storedToken);
 
 			assertThrows(IllegalArgumentException.class, () -> {
-				authServiceImpl.refresh("expired-token");
+				authServiceImpl.refresh(new RefreshTokenValue("expired-token"));
 			});
 		}
 
 		@Test
 		@DisplayName("異常系: リフレッシュトークンが存在しない場合は例外がスローされること")
 		void refresh_tokenNotFound() {
-			when(refreshTokenRepository.findByTokenHash(anyString())).thenReturn(null);
+			when(refreshTokenRepository.findByTokenHash(any(TokenHash.class))).thenReturn(null);
 
 			assertThrows(IllegalArgumentException.class, () -> {
-				authServiceImpl.refresh("nonexistent-token");
+				authServiceImpl.refresh(new RefreshTokenValue("nonexistent-token"));
 			});
 		}
 	}
@@ -220,9 +222,9 @@ class AuthServiceImplTest {
 		@Test
 		@DisplayName("正常系: リフレッシュトークンが無効化されること")
 		void logout_success() {
-			authServiceImpl.logout("refresh-token");
+			authServiceImpl.logout(new RefreshTokenValue("refresh-token"));
 
-			verify(refreshTokenRepository).revokeByTokenHash(anyString());
+			verify(refreshTokenRepository).revokeByTokenHash(any(TokenHash.class));
 		}
 	}
 }

--- a/backend/src/test/java/com/web/gallery/service/impl/KbnMstServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/KbnMstServiceImplTest.java
@@ -76,7 +76,7 @@ public class KbnMstServiceImplTest {
 							.kbnEnglishName(new KbnEnglishName("Okinawa"))
 							.explanation(new Explanation("沖縄は南国"))
 							.build()));
-			doReturn(kbnMstModelList).when(kbnMstRepositoryImpl).get("prefecture");
+			doReturn(kbnMstModelList).when(kbnMstRepositoryImpl).get(new KbnClassCode("prefecture"));
 			assertEquals(kbnMstModelList, kbnMstServiceImpl.getPrefectureList());
 		}
 
@@ -85,7 +85,7 @@ public class KbnMstServiceImplTest {
 		@DisplayName("正常系：区分マスタが存在しない場合")
 		void getPrefectureList_not_found() {
 			KbnMstModelList kbnMstModelList = KbnMstModelList.empty();
-			doReturn(kbnMstModelList).when(kbnMstRepositoryImpl).get("prefecture");
+			doReturn(kbnMstModelList).when(kbnMstRepositoryImpl).get(new KbnClassCode("prefecture"));
 			assertEquals(kbnMstModelList, kbnMstServiceImpl.getPrefectureList());
 		}
 	}

--- a/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
@@ -264,7 +264,7 @@ public class PhotoServiceImplTest {
 			List<String> tags = new ArrayList<String>();
 			
 			AccountModel account = AccountModel.builder().accountNo(new AccountNo(1L)).build();
-			doReturn(account).when(accountRepositoryImpl).getByAccountId(accountId);
+			doReturn(account).when(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
 			
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
 			doReturn(PhotoModelList.empty()).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
@@ -280,7 +280,7 @@ public class PhotoServiceImplTest {
 			
 			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
 			assertTrue(actual.isEmpty());
-			verify(accountRepositoryImpl).getByAccountId(accountId);
+			verify(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
 			verify(photoDetailRepositoryImpl).getPhotoList(any(PhotoGetModel.class));
 			
 			PhotoGetModel photoGetModel = photoGetModelCaptor.getValue();
@@ -296,7 +296,7 @@ public class PhotoServiceImplTest {
 			List<String> tags = Arrays.asList("太陽", "海");
 			
 			AccountModel account = AccountModel.builder().accountNo(new AccountNo(1L)).build();
-			doReturn(account).when(accountRepositoryImpl).getByAccountId(accountId);
+			doReturn(account).when(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
 			
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
 			doReturn(createPhotoModelList()).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
@@ -316,7 +316,7 @@ public class PhotoServiceImplTest {
 			assertEquals(2L, actual.get(1).getPhotoNo().value());
 			assertEquals(1L, actual.get(2).getPhotoNo().value());
 			
-			verify(accountRepositoryImpl).getByAccountId(accountId);
+			verify(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
 			verify(photoDetailRepositoryImpl).getPhotoList(any(PhotoGetModel.class));
 			
 			PhotoGetModel photoGetModel = photoGetModelCaptor.getValue();
@@ -332,7 +332,7 @@ public class PhotoServiceImplTest {
 			List<String> tags = Arrays.asList("太陽", "海");
 			
 			AccountModel account = AccountModel.builder().accountNo(new AccountNo(1L)).build();
-			doReturn(account).when(accountRepositoryImpl).getByAccountId(accountId);
+			doReturn(account).when(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
 			
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
 			doReturn(createPhotoModelList()).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
@@ -352,7 +352,7 @@ public class PhotoServiceImplTest {
 			assertEquals(3L, actual.get(1).getPhotoNo().value());
 			assertEquals(1L, actual.get(2).getPhotoNo().value());
 			
-			verify(accountRepositoryImpl).getByAccountId(accountId);
+			verify(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
 			verify(photoDetailRepositoryImpl).getPhotoList(any(PhotoGetModel.class));
 			
 			PhotoGetModel photoGetModel = photoGetModelCaptor.getValue();
@@ -368,7 +368,7 @@ public class PhotoServiceImplTest {
 			List<String> tags = Arrays.asList("太陽", "海");
 			
 			AccountModel account = AccountModel.builder().accountNo(new AccountNo(1L)).build();
-			doReturn(account).when(accountRepositoryImpl).getByAccountId(accountId);
+			doReturn(account).when(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
 			
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
 			doReturn(createPhotoModelList()).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
@@ -388,7 +388,7 @@ public class PhotoServiceImplTest {
 			assertEquals(2L, actual.get(1).getPhotoNo().value());
 			assertEquals(3L, actual.get(2).getPhotoNo().value());
 			
-			verify(accountRepositoryImpl).getByAccountId(accountId);
+			verify(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
 			verify(photoDetailRepositoryImpl).getPhotoList(any(PhotoGetModel.class));
 			
 			PhotoGetModel photoGetModel = photoGetModelCaptor.getValue();
@@ -557,11 +557,11 @@ public class PhotoServiceImplTest {
 		@Order(1)
 		@DisplayName("正常系：photoDetailModelListがnullの場合、終了")
 		void savePhotos_photoDetailModelList_is_null() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
-			Long actual = photoServiceImpl.savePhotos("aaaaaaaa", null);
+			PhotoNo actual = photoServiceImpl.savePhotos(new AccountId("aaaaaaaa"), null);
 			assertNull(actual);
-			verify(photoMstRepositoryImpl, times(0)).getNewPhotoNo(any(Long.class));
+			verify(photoMstRepositoryImpl, times(0)).getNewPhotoNo(any(AccountNo.class));
 			verify(photoMstRepositoryImpl, times(0)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
+			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(ImageFilePath.class), any(PhotoNo.class));
 			verify(photoMstRepositoryImpl, times(0)).update(any(PhotoDetailModel.class));
 		}
 		
@@ -570,11 +570,11 @@ public class PhotoServiceImplTest {
 		@DisplayName("正常系：photoDetailModelListがemptyの場合、終了")
 		void savePhotos_photoDetailModelList_is_empty() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
-			Long actual = photoServiceImpl.savePhotos("aaaaaaaa", PhotoDetailModelList.of(photoDetailModelList));
+			PhotoNo actual = photoServiceImpl.savePhotos(new AccountId("aaaaaaaa"), PhotoDetailModelList.of(photoDetailModelList));
 			assertNull(actual);
-			verify(photoMstRepositoryImpl, times(0)).getNewPhotoNo(any(Long.class));
+			verify(photoMstRepositoryImpl, times(0)).getNewPhotoNo(any(AccountNo.class));
 			verify(photoMstRepositoryImpl, times(0)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
+			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(ImageFilePath.class), any(PhotoNo.class));
 			verify(photoMstRepositoryImpl, times(0)).update(any(PhotoDetailModel.class));
 		}
 		
@@ -586,7 +586,7 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
+			doReturn(new PhotoNo(5L)).when(photoMstRepositoryImpl).getNewPhotoNo(new AccountNo(1L));
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			ArgumentCaptor<PhotoTagModel> photoTagModelCaptor = ArgumentCaptor.forClass(PhotoTagModel.class);
@@ -599,19 +599,19 @@ public class PhotoServiceImplTest {
 			PhotoDetailModel photoDetailModel1 = createNewPhotoWithTag();
 			photoDetailModelList.add(photoDetailModel1);
 			doReturn(false).when(photoMstRepositoryImpl).isExistPhoto(photoDetailModel1);
-			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel1, filePath + accountId + "/DSC111.jpg", 5L);
+			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel1, new ImageFilePath(filePath + accountId + "/DSC111.jpg"), new PhotoNo(5L));
 			
 			// 新規登録2枚目
 			PhotoDetailModel photoDetailModel2 = createNewPhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			doReturn(false).when(photoMstRepositoryImpl).isExistPhoto(photoDetailModel2);
-			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel2, filePath + accountId + "/DSC222.jpg", 6L);
+			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel2, new ImageFilePath(filePath + accountId + "/DSC222.jpg"), new PhotoNo(6L));
 			
-			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
+			PhotoNo actual = photoServiceImpl.savePhotos(new AccountId(accountId), PhotoDetailModelList.of(photoDetailModelList));
 
-			assertEquals(5, actual);
+			assertEquals(new PhotoNo(5L), actual);
 			verify(photoMstRepositoryImpl, times(2)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(2)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
+			verify(photoMstRepositoryImpl, times(2)).regist(any(PhotoDetailModel.class), any(ImageFilePath.class), any(PhotoNo.class));
 			verify(photoMstRepositoryImpl, times(0)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(2)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).clear(any(PhotoTagDeleteModel.class));
@@ -644,7 +644,7 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
+			doReturn(new PhotoNo(5L)).when(photoMstRepositoryImpl).getNewPhotoNo(new AccountNo(1L));
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			ArgumentCaptor<PhotoTagDeleteModel> photoTagDeleteModelCaptor = ArgumentCaptor.forClass(PhotoTagDeleteModel.class);
@@ -663,11 +663,11 @@ public class PhotoServiceImplTest {
 			photoDetailModelList.add(photoDetailModel2);
 			doNothing().when(photoMstRepositoryImpl).update(photoDetailModel2);
 			
-			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
+			PhotoNo actual = photoServiceImpl.savePhotos(new AccountId(accountId), PhotoDetailModelList.of(photoDetailModelList));
 
-			assertEquals(3, actual);
+			assertEquals(new PhotoNo(3L), actual);
 			verify(photoMstRepositoryImpl, times(0)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
+			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(ImageFilePath.class), any(PhotoNo.class));
 			verify(photoMstRepositoryImpl, times(2)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(2)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(2)).clear(any(PhotoTagDeleteModel.class));
@@ -694,7 +694,7 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
+			doReturn(new PhotoNo(5L)).when(photoMstRepositoryImpl).getNewPhotoNo(new AccountNo(1L));
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			ArgumentCaptor<PhotoTagDeleteModel> photoTagDeleteModelCaptor = ArgumentCaptor.forClass(PhotoTagDeleteModel.class);
@@ -710,18 +710,18 @@ public class PhotoServiceImplTest {
 			PhotoDetailModel photoDetailModel1 = createNewPhotoWithTag();
 			photoDetailModelList.add(photoDetailModel1);
 			doReturn(false).when(photoMstRepositoryImpl).isExistPhoto(photoDetailModel1);
-			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel1, filePath + accountId + "/DSC111.jpg", 5L);
+			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel1, new ImageFilePath(filePath + accountId + "/DSC111.jpg"), new PhotoNo(5L));
 			
 			// 更新1枚目
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			doNothing().when(photoMstRepositoryImpl).update(photoDetailModel2);
 			
-			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
+			PhotoNo actual = photoServiceImpl.savePhotos(new AccountId(accountId), PhotoDetailModelList.of(photoDetailModelList));
 
-			assertEquals(3, actual);
+			assertEquals(new PhotoNo(3L), actual);
 			verify(photoMstRepositoryImpl, times(1)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(1)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
+			verify(photoMstRepositoryImpl, times(1)).regist(any(PhotoDetailModel.class), any(ImageFilePath.class), any(PhotoNo.class));
 			verify(photoMstRepositoryImpl, times(1)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(2)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(1)).clear(any(PhotoTagDeleteModel.class));
@@ -748,7 +748,7 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
+			doReturn(new PhotoNo(5L)).when(photoMstRepositoryImpl).getNewPhotoNo(new AccountNo(1L));
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			// 新規登録1枚目
@@ -760,10 +760,10 @@ public class PhotoServiceImplTest {
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			assertThrows(FileDuplicateException.class, () -> photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList)));
+			assertThrows(FileDuplicateException.class, () -> photoServiceImpl.savePhotos(new AccountId(accountId), PhotoDetailModelList.of(photoDetailModelList)));
 			
 			verify(photoMstRepositoryImpl, times(1)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
+			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(ImageFilePath.class), any(PhotoNo.class));
 			verify(photoMstRepositoryImpl, times(0)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).clear(any(PhotoTagDeleteModel.class));
@@ -778,23 +778,23 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
+			doReturn(new PhotoNo(5L)).when(photoMstRepositoryImpl).getNewPhotoNo(new AccountNo(1L));
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			// 新規登録1枚目
 			PhotoDetailModel photoDetailModel1 = createNewPhotoWithTag();
 			photoDetailModelList.add(photoDetailModel1);
 			doReturn(false).when(photoMstRepositoryImpl).isExistPhoto(photoDetailModel1);
-			doThrow(RegistFailureException.class).when(photoMstRepositoryImpl).regist(photoDetailModel1, filePath + accountId + "/DSC111.jpg", 5L);
+			doThrow(RegistFailureException.class).when(photoMstRepositoryImpl).regist(photoDetailModel1, new ImageFilePath(filePath + accountId + "/DSC111.jpg"), new PhotoNo(5L));
 			
 			// 更新1枚目
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			assertThrows(RegistFailureException.class, () -> photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList)));
+			assertThrows(RegistFailureException.class, () -> photoServiceImpl.savePhotos(new AccountId(accountId), PhotoDetailModelList.of(photoDetailModelList)));
 			
 			verify(photoMstRepositoryImpl, times(1)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(1)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
+			verify(photoMstRepositoryImpl, times(1)).regist(any(PhotoDetailModel.class), any(ImageFilePath.class), any(PhotoNo.class));
 			verify(photoMstRepositoryImpl, times(0)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).clear(any(PhotoTagDeleteModel.class));
@@ -809,7 +809,7 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
+			doReturn(new PhotoNo(5L)).when(photoMstRepositoryImpl).getNewPhotoNo(new AccountNo(1L));
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			ArgumentCaptor<PhotoTagModel> photoTagModelCaptor = ArgumentCaptor.forClass(PhotoTagModel.class);
@@ -819,16 +819,16 @@ public class PhotoServiceImplTest {
 			PhotoDetailModel photoDetailModel1 = createNewPhotoWithTag();
 			photoDetailModelList.add(photoDetailModel1);
 			doReturn(false).when(photoMstRepositoryImpl).isExistPhoto(photoDetailModel1);
-			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel1, filePath + accountId + "/DSC111.jpg", 5L);
+			doNothing().when(photoMstRepositoryImpl).regist(photoDetailModel1, new ImageFilePath(filePath + accountId + "/DSC111.jpg"), new PhotoNo(5L));
 			
 			// 更新1枚目
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			assertThrows(RegistFailureException.class, () -> photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList)));
+			assertThrows(RegistFailureException.class, () -> photoServiceImpl.savePhotos(new AccountId(accountId), PhotoDetailModelList.of(photoDetailModelList)));
 			
 			verify(photoMstRepositoryImpl, times(1)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(1)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
+			verify(photoMstRepositoryImpl, times(1)).regist(any(PhotoDetailModel.class), any(ImageFilePath.class), any(PhotoNo.class));
 			verify(photoMstRepositoryImpl, times(0)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(1)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).clear(any(PhotoTagDeleteModel.class));
@@ -850,7 +850,7 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
+			doReturn(new PhotoNo(5L)).when(photoMstRepositoryImpl).getNewPhotoNo(new AccountNo(1L));
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			ArgumentCaptor<PhotoTagDeleteModel> photoTagDeleteModelCaptor = ArgumentCaptor.forClass(PhotoTagDeleteModel.class);
@@ -868,10 +868,10 @@ public class PhotoServiceImplTest {
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			assertThrows(RegistFailureException.class, () -> photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList)));
+			assertThrows(RegistFailureException.class, () -> photoServiceImpl.savePhotos(new AccountId(accountId), PhotoDetailModelList.of(photoDetailModelList)));
 			
 			verify(photoMstRepositoryImpl, times(0)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
+			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(ImageFilePath.class), any(PhotoNo.class));
 			verify(photoMstRepositoryImpl, times(1)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(1)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(1)).clear(any(PhotoTagDeleteModel.class));
@@ -893,7 +893,7 @@ public class PhotoServiceImplTest {
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			
-			doReturn(5L).when(photoMstRepositoryImpl).getNewPhotoNo(1L);
+			doReturn(new PhotoNo(5L)).when(photoMstRepositoryImpl).getNewPhotoNo(new AccountNo(1L));
 			doReturn(filePath).when(photoConfig).getOutputPath();
 			
 			// 更新1枚目
@@ -905,10 +905,10 @@ public class PhotoServiceImplTest {
 			PhotoDetailModel photoDetailModel2 = createUpdatePhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			assertThrows(UpdateFailureException.class, () -> photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList)));
+			assertThrows(UpdateFailureException.class, () -> photoServiceImpl.savePhotos(new AccountId(accountId), PhotoDetailModelList.of(photoDetailModelList)));
 			
 			verify(photoMstRepositoryImpl, times(0)).isExistPhoto(any(PhotoDetailModel.class));
-			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(String.class), any(Long.class));
+			verify(photoMstRepositoryImpl, times(0)).regist(any(PhotoDetailModel.class), any(ImageFilePath.class), any(PhotoNo.class));
 			verify(photoMstRepositoryImpl, times(1)).update(any(PhotoDetailModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).regist(any(PhotoTagModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).clear(any(PhotoTagDeleteModel.class));
@@ -926,11 +926,11 @@ public class PhotoServiceImplTest {
 		void deletePhotos_photoDeleteModelList_empty() throws UpdateFailureException {
 			doReturn("https://localhost:8080/image/").when(photoConfig).getOutputPath();
 			
-			photoServiceImpl.deletePhotos("aaaaaaaa", PhotoDeleteModelList.empty());
+			photoServiceImpl.deletePhotos(new AccountId("aaaaaaaa"), PhotoDeleteModelList.empty());
 			verify(photoFavoriteRepositoryImpl, times(0)).clear(any(PhotoFavoriteDeleteModel.class));
 			verify(photoTagMstRepositoryImpl, times(0)).clear(any(PhotoTagDeleteModel.class));
 			verify(photoMstRepositoryImpl, times(0)).delete(any(PhotoDeleteModel.class));
-			verify(fileRepositoryImpl, times(0)).delete(any(String.class));
+			verify(fileRepositoryImpl, times(0)).delete(any(ImageFilePath.class));
 		}
 		
 		@Test
@@ -948,7 +948,7 @@ public class PhotoServiceImplTest {
 			ArgumentCaptor<PhotoDeleteModel> photoDeleteModelCaptor = ArgumentCaptor.forClass(PhotoDeleteModel.class);
 			doNothing().when(photoMstRepositoryImpl).delete(photoDeleteModelCaptor.capture());
 			
-			ArgumentCaptor<String> fileDeleteCaptor = ArgumentCaptor.forClass(String.class);
+			ArgumentCaptor<ImageFilePath> fileDeleteCaptor = ArgumentCaptor.forClass(ImageFilePath.class);
 			doNothing().when(fileRepositoryImpl).delete(fileDeleteCaptor.capture());
 			
 			List<PhotoDeleteModel> photoDeleteModelList = new ArrayList<PhotoDeleteModel>();
@@ -963,11 +963,11 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("DSC222.jpg"))
 					.build());
 			
-			photoServiceImpl.deletePhotos("aaaaaaaa", PhotoDeleteModelList.of(photoDeleteModelList));
+			photoServiceImpl.deletePhotos(new AccountId("aaaaaaaa"), PhotoDeleteModelList.of(photoDeleteModelList));
 			verify(photoFavoriteRepositoryImpl, times(2)).clear(any(PhotoFavoriteDeleteModel.class));
 			verify(photoTagMstRepositoryImpl, times(2)).clear(any(PhotoTagDeleteModel.class));
 			verify(photoMstRepositoryImpl, times(2)).delete(any(PhotoDeleteModel.class));
-			verify(fileRepositoryImpl, times(2)).delete(any(String.class));
+			verify(fileRepositoryImpl, times(2)).delete(any(ImageFilePath.class));
 			
 			List<PhotoFavoriteDeleteModel> photoFavoriteDeleteModelCaptureList = photoFavoriteDeleteModelCaptor.getAllValues();
 			assertEquals(null, photoFavoriteDeleteModelCaptureList.get(0).getAccountNo());
@@ -991,9 +991,9 @@ public class PhotoServiceImplTest {
 			assertEquals(2L, photoDeleteModelCaptureList.get(1).getPhotoNo().value());
 			assertEquals("DSC222.jpg", photoDeleteModelCaptureList.get(1).getImageFilePath().value());
 			
-			List<String> fileDeleteCaptureList = fileDeleteCaptor.getAllValues();
-			assertEquals("https://localhost:8080/image/aaaaaaaa/DSC111.jpg", fileDeleteCaptureList.get(0));
-			assertEquals("https://localhost:8080/image/aaaaaaaa/DSC222.jpg", fileDeleteCaptureList.get(1));
+			List<ImageFilePath> fileDeleteCaptureList = fileDeleteCaptor.getAllValues();
+			assertEquals(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC111.jpg"), fileDeleteCaptureList.get(0));
+			assertEquals(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC222.jpg"), fileDeleteCaptureList.get(1));
 		}
 		
 		@Test
@@ -1013,11 +1013,11 @@ public class PhotoServiceImplTest {
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC111.jpg"))
 					.build());
 			
-			assertThrows(UpdateFailureException.class, () -> photoServiceImpl.deletePhotos("aaaaaaaa", PhotoDeleteModelList.of(photoDeleteModelList)));
+			assertThrows(UpdateFailureException.class, () -> photoServiceImpl.deletePhotos(new AccountId("aaaaaaaa"), PhotoDeleteModelList.of(photoDeleteModelList)));
 
 			verify(photoFavoriteRepositoryImpl, times(1)).clear(any(PhotoFavoriteDeleteModel.class));
 			verify(photoMstRepositoryImpl, times(1)).delete(any(PhotoDeleteModel.class));
-			verify(fileRepositoryImpl, times(0)).delete(any(String.class));
+			verify(fileRepositoryImpl, times(0)).delete(any(ImageFilePath.class));
 			
 			PhotoFavoriteDeleteModel photoFavoriteDeleteModelCapture = photoFavoriteDeleteModelCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoFavoriteDeleteModelCapture.getFavoritePhotoAccountNo());
@@ -1031,11 +1031,9 @@ public class PhotoServiceImplTest {
 	class isReachedUpperLimit {
 		@Test
 		@Order(1)
-		@DisplayName("正常系：アカウント番号がnullの場合")
+		@DisplayName("異常系：アカウント番号がnullの場合、NullPointerExceptionをthrowする")
 		void isReachedUpperLimit_accountNo_is_null() {
-			assertTrue(photoServiceImpl.isReachedUpperLimit(null));
-			verify(accountRepositoryImpl, times(0)).getByAccountNo(any(Long.class));
-			verify(photoMstRepositoryImpl, times(0)).count(any(Long.class));
+			assertThrows(NullPointerException.class, () -> photoServiceImpl.isReachedUpperLimit(null));
 			verify(photoConfig, times(0)).getMiniUserUpperLimit();
 			verify(photoConfig, times(0)).getNormalUserUpperLimit();
 		}
@@ -1044,7 +1042,7 @@ public class PhotoServiceImplTest {
 		@Order(2)
 		@DisplayName("正常系：mini-userで、上限まで登録済みの場合")
 		void isReachedUpperLimit_mini_user_reached() {
-			Long accountNo = 1L;
+			AccountNo accountNo = new AccountNo(1L);
 			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.MINI).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(10).when(photoMstRepositoryImpl).count(accountNo);
@@ -1056,7 +1054,7 @@ public class PhotoServiceImplTest {
 		@Order(3)
 		@DisplayName("正常系：mini-userで、上限まで未登録の場合")
 		void isReachedUpperLimit_mini_user_not_reached() {
-			Long accountNo = 1L;
+			AccountNo accountNo = new AccountNo(1L);
 			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.MINI).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(9).when(photoMstRepositoryImpl).count(accountNo);
@@ -1068,7 +1066,7 @@ public class PhotoServiceImplTest {
 		@Order(4)
 		@DisplayName("正常系：normal-userで、上限まで登録済みの場合")
 		void isReachedUpperLimit_normal_user_reached() {
-			Long accountNo = 1L;
+			AccountNo accountNo = new AccountNo(1L);
 			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.NORMAL).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(1000).when(photoMstRepositoryImpl).count(accountNo);
@@ -1080,7 +1078,7 @@ public class PhotoServiceImplTest {
 		@Order(5)
 		@DisplayName("正常系：normal-userで、上限まで未登録の場合")
 		void isReachedUpperLimit_normal_user_not_reached() {
-			Long accountNo = 1L;
+			AccountNo accountNo = new AccountNo(1L);
 			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.NORMAL).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(999).when(photoMstRepositoryImpl).count(accountNo);
@@ -1092,7 +1090,7 @@ public class PhotoServiceImplTest {
 		@Order(6)
 		@DisplayName("正常系：special-userの場合")
 		void isReachedUpperLimit_special_user() {
-			Long accountNo = 1L;
+			AccountNo accountNo = new AccountNo(1L);
 			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.SPECIAL).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(1000).when(photoMstRepositoryImpl).count(accountNo);
@@ -1103,7 +1101,7 @@ public class PhotoServiceImplTest {
 		@Order(7)
 		@DisplayName("正常系：administratorの場合")
 		void isReachedUpperLimit_administrator() {
-			Long accountNo = 1L;
+			AccountNo accountNo = new AccountNo(1L);
 			AccountModel account = AccountModel.builder().authorityKbn(AuthorityEnum.ADMINISTRATOR).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountNo(accountNo);
 			doReturn(1000).when(photoMstRepositoryImpl).count(accountNo);

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/AccountServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/AccountServiceImplIntegrationTest.java
@@ -288,7 +288,7 @@ public class AccountServiceImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントが存在する場合")
 		void getAccountById_found() {
-			AccountModel actual = accountServiceImpl.getAccountById("aaaaaaaa");
+			AccountModel actual = accountServiceImpl.getAccountById(new AccountId("aaaaaaaa"));
 
 			assertEquals(1L, actual.getAccountNo().value());
 			assertEquals("aaaaaaaa", actual.getAccountId().value());
@@ -308,7 +308,7 @@ public class AccountServiceImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが存在しない場合、nullを返す")
 		void getAccountById_not_found() {
-			assertNull(accountServiceImpl.getAccountById("zzzzzzzz"));
+			assertNull(accountServiceImpl.getAccountById(new AccountId("zzzzzzzz")));
 		}
 	}
 	
@@ -357,7 +357,7 @@ public class AccountServiceImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントと関連データがすべて物理削除されること")
 		void deleteAccount_success() {
-			accountServiceImpl.deleteAccount(1L, "aaaaaaaa");
+			accountServiceImpl.deleteAccount(new AccountNo(1L), new AccountId("aaaaaaaa"));
 
 			// アカウントが削除されたことを確認
 			List<Account> accountData = jdbcTemplate.query(

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/AuthServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/AuthServiceImplIntegrationTest.java
@@ -24,6 +24,10 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.web.gallery.config.JwtConfig;
+import com.web.gallery.domain.account.AccountId;
+import com.web.gallery.domain.account.Password;
+import com.web.gallery.domain.auth.RefreshTokenValue;
+import com.web.gallery.domain.common.TokenHash;
 import com.web.gallery.model.AuthTokenModel;
 import com.web.gallery.model.RefreshTokenModel;
 import com.web.gallery.repository.RefreshTokenRepository;
@@ -101,7 +105,7 @@ public class AuthServiceImplIntegrationTest {
 		@DisplayName("正常系：ログイン成功")
 		void login_success() throws Exception {
 			OffsetDateTime beforeLogin = OffsetDateTime.now();
-			AuthTokenModel result = authServiceImpl.login("testuser01", TEST_PASSWORD);
+			AuthTokenModel result = authServiceImpl.login(new AccountId("testuser01"), new Password(TEST_PASSWORD));
 			OffsetDateTime afterLogin = OffsetDateTime.now();
 
 			assertNotNull(result.getAccessToken().value());
@@ -112,7 +116,7 @@ public class AuthServiceImplIntegrationTest {
 
 			// リフレッシュトークンがDBに保存されていることを検証
 			String tokenHash = hashToken(result.getRefreshToken().value());
-			RefreshTokenModel storedToken = refreshTokenRepository.findByTokenHash(tokenHash);
+			RefreshTokenModel storedToken = refreshTokenRepository.findByTokenHash(new TokenHash(tokenHash));
 			assertNotNull(storedToken);
 			assertEquals(1L, storedToken.getAccountNo().value());
 			assertFalse(storedToken.getIsRevoked().value());
@@ -125,20 +129,20 @@ public class AuthServiceImplIntegrationTest {
 		@DisplayName("正常系：再ログイン時に既存のリフレッシュトークンが無効化される")
 		void login_revokes_existing_tokens() throws Exception {
 			// 1回目のログイン
-			AuthTokenModel firstResult = authServiceImpl.login("testuser01", TEST_PASSWORD);
+			AuthTokenModel firstResult = authServiceImpl.login(new AccountId("testuser01"), new Password(TEST_PASSWORD));
 			String firstTokenHash = hashToken(firstResult.getRefreshToken().value());
 
 			// 2回目のログイン
-			AuthTokenModel secondResult = authServiceImpl.login("testuser01", TEST_PASSWORD);
+			AuthTokenModel secondResult = authServiceImpl.login(new AccountId("testuser01"), new Password(TEST_PASSWORD));
 			String secondTokenHash = hashToken(secondResult.getRefreshToken().value());
 
 			// 1回目のトークンが無効化されていることを検証
-			RefreshTokenModel firstToken = refreshTokenRepository.findByTokenHash(firstTokenHash);
+			RefreshTokenModel firstToken = refreshTokenRepository.findByTokenHash(new TokenHash(firstTokenHash));
 			assertNotNull(firstToken);
 			assertTrue(firstToken.getIsRevoked().value());
 
 			// 2回目のトークンが有効であることを検証
-			RefreshTokenModel secondToken = refreshTokenRepository.findByTokenHash(secondTokenHash);
+			RefreshTokenModel secondToken = refreshTokenRepository.findByTokenHash(new TokenHash(secondTokenHash));
 			assertNotNull(secondToken);
 			assertFalse(secondToken.getIsRevoked().value());
 		}
@@ -148,7 +152,7 @@ public class AuthServiceImplIntegrationTest {
 		@DisplayName("異常系：パスワード不一致の場合、BadCredentialsExceptionをthrowする")
 		void login_wrong_password() {
 			assertThrows(BadCredentialsException.class,
-				() -> authServiceImpl.login("testuser01", "wrongpassword"));
+				() -> authServiceImpl.login(new AccountId("testuser01"), new Password("wrongpassword")));
 		}
 
 		@Test
@@ -156,7 +160,7 @@ public class AuthServiceImplIntegrationTest {
 		@DisplayName("異常系：存在しないアカウントIDの場合、BadCredentialsExceptionをthrowする")
 		void login_account_not_found() {
 			assertThrows(BadCredentialsException.class,
-				() -> authServiceImpl.login("notexists", TEST_PASSWORD));
+				() -> authServiceImpl.login(new AccountId("notexists"), new Password(TEST_PASSWORD)));
 		}
 
 		@Test
@@ -164,7 +168,7 @@ public class AuthServiceImplIntegrationTest {
 		@DisplayName("異常系：アカウントロックの場合、LockedException をthrowする")
 		void login_locked_account() {
 			assertThrows(LockedException.class,
-				() -> authServiceImpl.login("lockeduser", TEST_PASSWORD));
+				() -> authServiceImpl.login(new AccountId("lockeduser"), new Password(TEST_PASSWORD)));
 		}
 	}
 
@@ -183,10 +187,10 @@ public class AuthServiceImplIntegrationTest {
 		@DisplayName("正常系：リフレッシュ成功")
 		void refresh_success() {
 			// ログインしてリフレッシュトークンを取得
-			AuthTokenModel loginResult = authServiceImpl.login("testuser01", TEST_PASSWORD);
+			AuthTokenModel loginResult = authServiceImpl.login(new AccountId("testuser01"), new Password(TEST_PASSWORD));
 
 			// リフレッシュ
-			AuthTokenModel refreshResult = authServiceImpl.refresh(loginResult.getRefreshToken().value());
+			AuthTokenModel refreshResult = authServiceImpl.refresh(loginResult.getRefreshToken());
 
 			assertNotNull(refreshResult.getAccessToken().value());
 			assertFalse(refreshResult.getAccessToken().value().isEmpty());
@@ -199,7 +203,7 @@ public class AuthServiceImplIntegrationTest {
 		@DisplayName("異常系：存在しないリフレッシュトークンの場合、IllegalArgumentExceptionをthrowする")
 		void refresh_invalid_token() {
 			IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> authServiceImpl.refresh("invalid-refresh-token"));
+				() -> authServiceImpl.refresh(new RefreshTokenValue("invalid-refresh-token")));
 			assertEquals("無効なリフレッシュトークンです", exception.getMessage());
 		}
 
@@ -208,15 +212,15 @@ public class AuthServiceImplIntegrationTest {
 		@DisplayName("異常系：無効化済みリフレッシュトークンの場合、IllegalArgumentExceptionをthrowする")
 		void refresh_revoked_token() throws Exception {
 			// ログインしてリフレッシュトークンを取得
-			AuthTokenModel loginResult = authServiceImpl.login("testuser01", TEST_PASSWORD);
+			AuthTokenModel loginResult = authServiceImpl.login(new AccountId("testuser01"), new Password(TEST_PASSWORD));
 			String refreshToken = loginResult.getRefreshToken().value();
 
 			// トークンを無効化
-			refreshTokenRepository.revokeByTokenHash(hashToken(refreshToken));
+			refreshTokenRepository.revokeByTokenHash(new TokenHash(hashToken(refreshToken)));
 
 			// 無効化済みトークンでリフレッシュ
 			IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> authServiceImpl.refresh(refreshToken));
+				() -> authServiceImpl.refresh(new RefreshTokenValue(refreshToken)));
 			assertEquals("無効なリフレッシュトークンです", exception.getMessage());
 		}
 
@@ -225,7 +229,7 @@ public class AuthServiceImplIntegrationTest {
 		@DisplayName("異常系：有効期限切れリフレッシュトークンの場合、IllegalArgumentExceptionをthrowする")
 		void refresh_expired_token() throws Exception {
 			// ログインしてリフレッシュトークンを取得
-			AuthTokenModel loginResult = authServiceImpl.login("testuser01", TEST_PASSWORD);
+			AuthTokenModel loginResult = authServiceImpl.login(new AccountId("testuser01"), new Password(TEST_PASSWORD));
 			String refreshToken = loginResult.getRefreshToken().value();
 
 			// 有効期限を過去に設定
@@ -237,7 +241,7 @@ public class AuthServiceImplIntegrationTest {
 
 			// 有効期限切れトークンでリフレッシュ
 			IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> authServiceImpl.refresh(refreshToken));
+				() -> authServiceImpl.refresh(new RefreshTokenValue(refreshToken)));
 			assertEquals("リフレッシュトークンの有効期限が切れています", exception.getMessage());
 		}
 	}
@@ -257,20 +261,20 @@ public class AuthServiceImplIntegrationTest {
 		@DisplayName("正常系：ログアウト成功（リフレッシュトークンが無効化される）")
 		void logout_success() throws Exception {
 			// ログインしてリフレッシュトークンを取得
-			AuthTokenModel loginResult = authServiceImpl.login("testuser01", TEST_PASSWORD);
+			AuthTokenModel loginResult = authServiceImpl.login(new AccountId("testuser01"), new Password(TEST_PASSWORD));
 			String refreshToken = loginResult.getRefreshToken().value();
 			String tokenHash = hashToken(refreshToken);
 
 			// ログアウト前はトークンが有効
-			RefreshTokenModel beforeLogout = refreshTokenRepository.findByTokenHash(tokenHash);
+			RefreshTokenModel beforeLogout = refreshTokenRepository.findByTokenHash(new TokenHash(tokenHash));
 			assertNotNull(beforeLogout);
 			assertFalse(beforeLogout.getIsRevoked().value());
 
 			// ログアウト
-			authServiceImpl.logout(refreshToken);
+			authServiceImpl.logout(new RefreshTokenValue(refreshToken));
 
 			// ログアウト後はトークンが無効化されている
-			RefreshTokenModel afterLogout = refreshTokenRepository.findByTokenHash(tokenHash);
+			RefreshTokenModel afterLogout = refreshTokenRepository.findByTokenHash(new TokenHash(tokenHash));
 			assertNotNull(afterLogout);
 			assertTrue(afterLogout.getIsRevoked().value());
 		}
@@ -279,7 +283,7 @@ public class AuthServiceImplIntegrationTest {
 		@Order(2)
 		@DisplayName("正常系：存在しないリフレッシュトークンでログアウトしてもエラーにならない")
 		void logout_with_nonexistent_token() {
-			assertDoesNotThrow(() -> authServiceImpl.logout("nonexistent-token"));
+			assertDoesNotThrow(() -> authServiceImpl.logout(new RefreshTokenValue("nonexistent-token")));
 		}
 
 		@Test
@@ -287,15 +291,15 @@ public class AuthServiceImplIntegrationTest {
 		@DisplayName("正常系：ログアウト後にリフレッシュが失敗する")
 		void logout_then_refresh_fails() {
 			// ログイン
-			AuthTokenModel loginResult = authServiceImpl.login("testuser01", TEST_PASSWORD);
+			AuthTokenModel loginResult = authServiceImpl.login(new AccountId("testuser01"), new Password(TEST_PASSWORD));
 			String refreshToken = loginResult.getRefreshToken().value();
 
 			// ログアウト
-			authServiceImpl.logout(refreshToken);
+			authServiceImpl.logout(new RefreshTokenValue(refreshToken));
 
 			// ログアウト後のリフレッシュは失敗
 			IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-				() -> authServiceImpl.refresh(refreshToken));
+				() -> authServiceImpl.refresh(new RefreshTokenValue(refreshToken)));
 			assertEquals("無効なリフレッシュトークンです", exception.getMessage());
 		}
 	}

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoServiceImplIntegrationTest.java
@@ -592,7 +592,7 @@ public class PhotoServiceImplIntegrationTest {
 		void savePhotos_photoDetailModelList_is_null() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
 			String accountId = "aaaaaaaa";
 			List<PhotoMst> beforeSaveData = getPhotoMstData(accountId);
-			Long actual = photoServiceImpl.savePhotos(accountId, null);
+			PhotoNo actual = photoServiceImpl.savePhotos(new AccountId(accountId), null);
 			assertNull(actual);
 			List<PhotoMst> afterData = getPhotoMstData(accountId);
 			assertEquals(beforeSaveData.size(), afterData.size());
@@ -605,7 +605,7 @@ public class PhotoServiceImplIntegrationTest {
 			String accountId = "aaaaaaaa";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			List<PhotoMst> beforeSaveData = getPhotoMstData(accountId);
-			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
+			PhotoNo actual = photoServiceImpl.savePhotos(new AccountId(accountId), PhotoDetailModelList.of(photoDetailModelList));
 			assertNull(actual);
 			List<PhotoMst> afterData = getPhotoMstData(accountId);
 			assertEquals(beforeSaveData.size(), afterData.size());
@@ -626,9 +626,9 @@ public class PhotoServiceImplIntegrationTest {
 			photoDetailModelList.add(photoDetailModel2);
 
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
-			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
+			PhotoNo actual = photoServiceImpl.savePhotos(new AccountId(accountId), PhotoDetailModelList.of(photoDetailModelList));
 
-			assertEquals(11, actual);
+			assertEquals(new PhotoNo(11L), actual);
 			List<PhotoMst> actualData = getPhotoMstData(accountId).stream().filter(photoMst -> photoMst.getPhotoNo().value() > 10).toList();
 			assertEquals(2, actualData.size());
 
@@ -696,9 +696,9 @@ public class PhotoServiceImplIntegrationTest {
 			photoDetailModelList.add(photoDetailModel2);
 
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
-			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
+			PhotoNo actual = photoServiceImpl.savePhotos(new AccountId(accountId), PhotoDetailModelList.of(photoDetailModelList));
 
-			assertEquals(3, actual);
+			assertEquals(new PhotoNo(3L), actual);
 			List<PhotoMst> actualData1 = getPhotoMstData(accountId).stream().filter(photoMst -> photoMst.getPhotoNo().value()==2).toList();
 			assertEquals(1, actualData1.size());
 			assertEquals(1L, actualData1.getFirst().getAccountNo().value());
@@ -767,9 +767,9 @@ public class PhotoServiceImplIntegrationTest {
 			photoDetailModelList.add(photoDetailModel2);
 
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
-			Long actual = photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList));
+			PhotoNo actual = photoServiceImpl.savePhotos(new AccountId(accountId), PhotoDetailModelList.of(photoDetailModelList));
 
-			assertEquals(3, actual);
+			assertEquals(new PhotoNo(3L), actual);
 			List<PhotoMst> actualData = getPhotoMstData(accountId).stream().filter(photoMst -> photoMst.getPhotoNo().value() > 10).toList();
 			assertEquals(1, actualData.size());
 
@@ -856,7 +856,7 @@ public class PhotoServiceImplIntegrationTest {
 			PhotoDetailModel photoDetailModel2 = createNewPhoto();
 			photoDetailModelList.add(photoDetailModel2);
 			
-			assertThrows(FileDuplicateException.class, () -> photoServiceImpl.savePhotos(accountId, PhotoDetailModelList.of(photoDetailModelList)));
+			assertThrows(FileDuplicateException.class, () -> photoServiceImpl.savePhotos(new AccountId(accountId), PhotoDetailModelList.of(photoDetailModelList)));
 		}
 	}
 	
@@ -870,7 +870,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Order(1)
 		@DisplayName("正常系：photoDeleteModelListが0件の場合、終了")
 		void deletePhotos_photoDeleteModelList_empty() throws UpdateFailureException {
-			photoServiceImpl.deletePhotos("aaaaaaaa", PhotoDeleteModelList.empty());
+			photoServiceImpl.deletePhotos(new AccountId("aaaaaaaa"), PhotoDeleteModelList.empty());
 			
 			List<PhotoMst> actualData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no = (SELECT account_no FROM common.account where account_id='aaaaaaaa')", (rs, rowNum) ->
@@ -915,7 +915,7 @@ public class PhotoServiceImplIntegrationTest {
 					.build());
 
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
-			photoServiceImpl.deletePhotos("aaaaaaaa", PhotoDeleteModelList.of(photoDeleteModelList));
+			photoServiceImpl.deletePhotos(new AccountId("aaaaaaaa"), PhotoDeleteModelList.of(photoDeleteModelList));
 
 			List<PhotoMst> actualPhotoMstData = jdbcTemplate.query(
 					"SELECT * FROM photo.photo_mst where account_no=1 and photo_no in (1, 2)", (rs, rowNum) ->
@@ -1031,7 +1031,7 @@ public class PhotoServiceImplIntegrationTest {
 					.imageFilePath(new ImageFilePath("DSC99.jpg"))
 					.build());
 			
-			assertThrows(UpdateFailureException.class, () -> photoServiceImpl.deletePhotos("aaaaaaaa", PhotoDeleteModelList.of(photoDeleteModelList)));
+			assertThrows(UpdateFailureException.class, () -> photoServiceImpl.deletePhotos(new AccountId("aaaaaaaa"), PhotoDeleteModelList.of(photoDeleteModelList)));
 		}
 	}
 	
@@ -1043,16 +1043,16 @@ public class PhotoServiceImplIntegrationTest {
 	class isReachedUpperLimit {
 		@Test
 		@Order(1)
-		@DisplayName("正常系：アカウント番号がnullの場合")
+		@DisplayName("異常系：アカウント番号がnullの場合、NullPointerExceptionをthrowする")
 		void isReachedUpperLimit_accountNo_is_null() {
-			assertTrue(photoServiceImpl.isReachedUpperLimit(null));
+			assertThrows(NullPointerException.class, () -> photoServiceImpl.isReachedUpperLimit(null));
 		}
 		
 		@Test
 		@Order(2)
 		@DisplayName("正常系：mini-userで、上限まで登録済みの場合")
 		void isReachedUpperLimit_mini_user_reached() {
-			Long accountNo = 1L;
+			AccountNo accountNo = new AccountNo(1L);
 			assertTrue(photoServiceImpl.isReachedUpperLimit(accountNo));
 		}
 		
@@ -1060,7 +1060,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Order(3)
 		@DisplayName("正常系：mini-userで、上限まで未登録の場合")
 		void isReachedUpperLimit_mini_user_not_reached() {
-			Long accountNo = 2L;
+			AccountNo accountNo = new AccountNo(2L);
 			assertFalse(photoServiceImpl.isReachedUpperLimit(accountNo));
 		}
 		
@@ -1068,7 +1068,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Order(4)
 		@DisplayName("正常系：normal-userで、上限まで登録済みの場合")
 		void isReachedUpperLimit_normal_user_reached() {
-			Long accountNo = 3L;
+			AccountNo accountNo = new AccountNo(3L);
 			assertTrue(photoServiceImpl.isReachedUpperLimit(accountNo));
 		}
 		
@@ -1076,7 +1076,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Order(5)
 		@DisplayName("正常系：normal-userで、上限まで未登録の場合")
 		void isReachedUpperLimit_normal_user_not_reached() {
-			Long accountNo = 4L;
+			AccountNo accountNo = new AccountNo(4L);
 			assertFalse(photoServiceImpl.isReachedUpperLimit(accountNo));
 		}
 		
@@ -1084,7 +1084,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Order(6)
 		@DisplayName("正常系：special-userの場合")
 		void isReachedUpperLimit_special_user() {
-			Long accountNo = 5L;
+			AccountNo accountNo = new AccountNo(5L);
 			assertFalse(photoServiceImpl.isReachedUpperLimit(accountNo));
 		}
 		
@@ -1092,7 +1092,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Order(7)
 		@DisplayName("正常系：administratorの場合")
 		void isReachedUpperLimit_administrator() {
-			Long accountNo = 6L;
+			AccountNo accountNo = new AccountNo(6L);
 			assertFalse(photoServiceImpl.isReachedUpperLimit(accountNo));
 		}
 	}


### PR DESCRIPTION
# 概要

## 背景

Repository層・Service層の公開メソッドシグネチャに、Long・Stringのプリミティブ型が一部残っており、バリデーション責務がレイヤー境界で曖昧になっていた。プロジェクトには既にdomain/配下にAccountNo・AccountId等の値オブジェクト（コンパクトコンストラクタでnullチェック等のバリデーションを行うrecord）が整備されており、それらを一貫して使う方針とした。

## 変更内容

- Repository層・Service層の引数と戻り値を、ドメインクラス・Boolean・Integer（件数用）・voidのみに統一
  - AccountRepository: getByAccountNo/getByAccountId/deleteをドメインクラス引数に変更。isExistAccountは新規登録用（除外なし）と更新用（自分自身を除外）の2メソッドに分割
  - FileRepository/KbnMstRepository/RefreshTokenRepository/PhotoMstRepositoryも同様にLong/String引数をドメインクラス化
  - AuthService/PhotoServiceのインターフェース・実装、およびインターフェースを持たないAccountServiceImpl（getAccountById/unlockAccount/lockAccount/deleteAccount）も対象
  - Spring Security契約であるUserDetailsService#loadUserByUsername(String)は対象外
- Controller層は呼び出し箇所でLong/Stringをドメインクラスにラップするよう追従修正
- PhotoService#isReachedUpperLimitの既存nullガードを削除（呼び出し元は認証済みコンテキストのみのため実質未到達。null参照が渡された場合はNullPointerExceptionとなる仕様に変更）
- 上記変更に伴い、影響するユニットテスト・統合テストを追従修正

# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認

# 懸念事項

- PhotoService#isReachedUpperLimit(AccountNo)にnullを渡すとNullPointerExceptionが送出される仕様に変更した（従来はtrueを返す実装だった）。既存の呼び出し元（PhotoRestController）はいずれも認証済みかつ検証済みのアカウント番号のみを渡しているため実質影響はない想定だが、念のためレビューをお願いしたい。