### PR TITLE
refactor: PhotoMstエンティティの条件・更新対象クラスを分離する

### DIFF
--- a/.claude/rules/entity.md
+++ b/.claude/rules/entity.md
@@ -13,3 +13,16 @@ paths:
 ## プロパティ
 
 - ドメインクラス（値オブジェクト）、Modelクラス、Dtoクラスは使用しない（依存性・責務の分離のため）
+
+## 抽出条件・更新対象クラスの分離
+
+- Entityクラス自体は「永続化Entity」に専念させ、DBレコードのマッピング（resultMap）と登録（insert）用のファクトリメソッドのみを持つ
+- MyBatisのSELECT/DELETE等の抽出条件（WHERE句）は、Entityとは別クラスに分離する
+- UPDATEのSET句（更新対象）がある場合も、Entityとは別クラスに分離する
+- 1つのクラスが「永続化Entity」「抽出条件」「更新対象」を兼務しないこと（単一責任原則のため）
+
+## クラス名の命名規約
+
+- 抽出条件クラス: `<Entity名>Condition`（例: `PhotoMstCondition`, `AccountCondition`）
+- 更新対象クラス: `<Entity名>UpdateTarget`（例: `PhotoMstUpdateTarget`, `AccountUpdateTarget`）
+- UPDATE操作を持たないEntityの場合、更新対象クラスは作成せず抽出条件クラスのみを分離する

--- a/backend/src/main/java/com/web/gallery/entity/AccountCondition.java
+++ b/backend/src/main/java/com/web/gallery/entity/AccountCondition.java
@@ -1,0 +1,130 @@
+package com.web.gallery.entity;
+
+import com.web.gallery.domain.account.AccountId;
+import com.web.gallery.domain.account.AccountName;
+import com.web.gallery.domain.account.BirthDate;
+import com.web.gallery.domain.account.BirthplacePrefectureKbnCode;
+import com.web.gallery.domain.account.FreeMemo;
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.account.LastLoginDatetime;
+import com.web.gallery.domain.account.LoginFailureCount;
+import com.web.gallery.domain.account.Password;
+import com.web.gallery.domain.account.ResidentPrefectureKbnCode;
+import com.web.gallery.domain.common.IsDeleted;
+import com.web.gallery.enumeration.AuthorityEnum;
+import com.web.gallery.enumeration.SexEnum;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * アカウントテーブルの抽出条件クラス
+ */
+@Data
+@Builder
+public class AccountCondition {
+	/** アカウント番号 */
+	private AccountNo accountNo;
+
+	/** 削除フラグ */
+	private IsDeleted isDeleted;
+
+	/** アカウントID */
+	private AccountId accountId;
+
+	/** アカウント名 */
+	private AccountName accountName;
+
+	/** パスワード */
+	private Password password;
+
+	/** 生年月日 */
+	private BirthDate birthdate;
+
+	/**
+	 * 性別区分
+	 * <p>
+	 * {@link SexEnum}
+	 */
+	private SexEnum sexKbn;
+
+	/** 出身都道府県区分コード */
+	private BirthplacePrefectureKbnCode birthplacePrefectureKbnCode;
+
+	/** 在住都道府県区分コード */
+	private ResidentPrefectureKbnCode residentPrefectureKbnCode;
+
+	/** フリーメモ */
+	private FreeMemo freeMemo;
+
+	/**
+	 * 権限区分
+	 * <p>
+	 * {@link AuthorityEnum}
+	 */
+	private AuthorityEnum authorityKbn;
+
+	/** 最終ログイン日時 */
+	private LastLoginDatetime lastLoginDatetime;
+
+	/** ログイン失敗回数 */
+	private LoginFailureCount loginFailureCount;
+
+	/**
+	 * アカウント番号で検索するための抽出条件を生成する
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @return				{@link AccountCondition}
+	 */
+	public static AccountCondition byAccountNo(Long accountNo) {
+		return AccountCondition.builder()
+				.accountNo(new AccountNo(accountNo))
+				.build();
+	}
+
+	/**
+	 * アカウントIDで検索するための抽出条件を生成する
+	 *
+	 * @param	accountId	アカウントID
+	 * @return				{@link AccountCondition}
+	 */
+	public static AccountCondition byAccountId(String accountId) {
+		return AccountCondition.builder()
+				.accountId(new AccountId(accountId))
+				.build();
+	}
+
+	/**
+	 * アカウント存在チェック用の抽出条件を生成する
+	 *
+	 * @param	accountNo	検索対象外のアカウント番号
+	 * @param	accountId	アカウントID
+	 * @return				{@link AccountCondition}
+	 */
+	public static AccountCondition forExistCheck(Long accountNo, String accountId) {
+		return AccountCondition.builder()
+				.accountNo(accountNo != null ? new AccountNo(accountNo) : null)
+				.accountId(new AccountId(accountId))
+				.build();
+	}
+
+	/**
+	 * アカウント一覧取得用の抽出条件を生成する
+	 *
+	 * @return	{@link AccountCondition}
+	 */
+	public static AccountCondition forList() {
+		return AccountCondition.builder()
+				.isDeleted(new IsDeleted(false))
+				.build();
+	}
+
+	/**
+	 * 管理者用アカウント一覧取得用の抽出条件を生成する（全件取得）
+	 *
+	 * @return	{@link AccountCondition}
+	 */
+	public static AccountCondition forAdminList() {
+		return AccountCondition.builder().build();
+	}
+}

--- a/backend/src/main/java/com/web/gallery/entity/AccountUpdateTarget.java
+++ b/backend/src/main/java/com/web/gallery/entity/AccountUpdateTarget.java
@@ -10,16 +10,12 @@ import com.web.gallery.domain.account.AccountName;
 import com.web.gallery.domain.account.BirthDate;
 import com.web.gallery.domain.account.BirthplacePrefectureKbnCode;
 import com.web.gallery.domain.account.FreeMemo;
-import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.account.LastLoginDatetime;
 import com.web.gallery.domain.account.LoginFailureCount;
 import com.web.gallery.domain.account.Password;
 import com.web.gallery.domain.account.ResidentPrefectureKbnCode;
-import com.web.gallery.domain.common.CreatedBy;
-import com.web.gallery.domain.common.CreatedAt;
 import com.web.gallery.domain.common.IsDeleted;
 import com.web.gallery.domain.common.UpdatedBy;
-import com.web.gallery.domain.common.UpdatedAt;
 import com.web.gallery.enumeration.AuthorityEnum;
 import com.web.gallery.enumeration.SexEnum;
 import com.web.gallery.model.AccountModel;
@@ -28,25 +24,13 @@ import lombok.Builder;
 import lombok.Data;
 
 /**
- * アカウントテーブルのEntityクラス
+ * アカウントテーブルの更新対象クラス
  */
 @Data
 @Builder
-public class Account {
-	/** アカウント番号 */
-	private AccountNo accountNo;
-
-	/** 作成者 */
-	private CreatedBy createdBy;
-
-	/** 作成日時 */
-	private CreatedAt createdAt;
-
+public class AccountUpdateTarget {
 	/** 更新者 */
 	private UpdatedBy updatedBy;
-
-	/** 更新日時 */
-	private UpdatedAt updatedAt;
 
 	/** 削除フラグ */
 	private IsDeleted isDeleted;
@@ -93,19 +77,16 @@ public class Account {
 	private LoginFailureCount loginFailureCount;
 
 	/**
-	 * アカウント登録用のAccountModelからAccountエンティティを生成する
+	 * アカウント更新用のAccountModelから更新対象を生成する
 	 *
 	 * @param	model			{@link AccountModel}
 	 * @param	passwordEncoder	{@link PasswordEncoder}
-	 * @return					{@link Account}
+	 * @return					{@link AccountUpdateTarget}
 	 */
-	public static Account from(AccountModel model, PasswordEncoder passwordEncoder) {
-		return Account.builder()
-				.createdBy(new CreatedBy(0L))
-				.updatedBy(new UpdatedBy(0L))
+	public static AccountUpdateTarget fromForUpdate(AccountModel model, PasswordEncoder passwordEncoder) {
+		AccountUpdateTarget target = AccountUpdateTarget.builder()
 				.accountId(model.getAccountId())
 				.accountName(model.getAccountName())
-				.password(new Password(passwordEncoder.encode(model.getPassword().value())))
 				.birthdate(
 					Optional.ofNullable(model.getBirthdate())
 						.orElse(new BirthDate(Consts.MIN_LOCAL_DATE)))
@@ -120,9 +101,33 @@ public class Account {
 				.freeMemo(
 					Optional.ofNullable(model.getFreeMemo())
 						.orElse(new FreeMemo(Consts.STRING_EMPTY)))
-				.authorityKbn(AuthorityEnum.MINI)
-				.lastLoginDatetime(new LastLoginDatetime(Consts.MIN_OFFSET_DATE_TIME))
-				.loginFailureCount(new LoginFailureCount(0))
+				.lastLoginDatetime(
+					Optional.ofNullable(model.getLastLoginDatetime())
+						.orElse(new LastLoginDatetime(Consts.MIN_OFFSET_DATE_TIME)))
+				.loginFailureCount(
+					Optional.ofNullable(model.getLoginFailureCount())
+						.orElse(new LoginFailureCount(0)))
+				.build();
+
+		if (model.getPassword() != null) {
+			target.setPassword(new Password(passwordEncoder.encode(model.getPassword().value())));
+		}
+
+		return target;
+	}
+
+	/**
+	 * ログイン失敗回数更新用のAccountModelから更新対象を生成する
+	 *
+	 * @param	model	{@link AccountModel}
+	 * @return			{@link AccountUpdateTarget}
+	 */
+	public static AccountUpdateTarget fromForUpdateLoginFailure(AccountModel model) {
+		return AccountUpdateTarget.builder()
+				.lastLoginDatetime(model.getLastLoginDatetime())
+				.loginFailureCount(
+					Optional.ofNullable(model.getLoginFailureCount())
+						.orElse(new LoginFailureCount(0)))
 				.build();
 	}
 }

--- a/backend/src/main/java/com/web/gallery/entity/KbnMstCondition.java
+++ b/backend/src/main/java/com/web/gallery/entity/KbnMstCondition.java
@@ -1,7 +1,5 @@
 package com.web.gallery.entity;
 
-import com.web.gallery.domain.common.CreatedBy;
-import com.web.gallery.domain.common.CreatedAt;
 import com.web.gallery.domain.common.Explanation;
 import com.web.gallery.domain.common.KbnClassCode;
 import com.web.gallery.domain.common.KbnClassEnglishName;
@@ -18,22 +16,16 @@ import lombok.Builder;
 import lombok.Data;
 
 /**
- * 区分マスタテーブルのEntityクラス
+ * 区分マスタテーブルの抽出条件クラス
  */
 @Data
 @Builder
-public class KbnMst {
+public class KbnMstCondition {
 	/** 区分分類コード */
 	private KbnClassCode kbnClassCode;
 
 	/** 区分コード */
 	private KbnCode kbnCode;
-
-	/** 作成者 */
-	private CreatedBy createdBy;
-
-	/** 作成日時 */
-	private CreatedAt createdAt;
 
 	/** 並び順 */
 	private SortOrder sortOrder;
@@ -61,4 +53,16 @@ public class KbnMst {
 
 	/** 説明 */
 	private Explanation explanation;
+
+	/**
+	 * 区分分類コードによる抽出条件を生成する
+	 *
+	 * @param	kbnClassCode	区分分類コード
+	 * @return					{@link KbnMstCondition}
+	 */
+	public static KbnMstCondition byKbnClassCode(String kbnClassCode) {
+		return KbnMstCondition.builder()
+				.kbnClassCode(new KbnClassCode(kbnClassCode))
+				.build();
+	}
 }

--- a/backend/src/main/java/com/web/gallery/entity/PhotoFavorite.java
+++ b/backend/src/main/java/com/web/gallery/entity/PhotoFavorite.java
@@ -4,7 +4,6 @@ import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.common.CreatedBy;
 import com.web.gallery.domain.common.CreatedAt;
 import com.web.gallery.domain.photo.PhotoNo;
-import com.web.gallery.model.PhotoFavoriteDeleteModel;
 import com.web.gallery.model.PhotoFavoriteModel;
 
 import lombok.Builder;
@@ -46,57 +45,6 @@ public class PhotoFavorite {
 				.favoritePhotoAccountNo(model.getFavoritePhotoAccountNo())
 				.favoritePhotoNo(model.getFavoritePhotoNo())
 				.createdBy(new CreatedBy(model.getAccountNo().value()))
-				.build();
-	}
-
-	/**
-	 * PhotoFavoriteDeleteModelからPhotoFavoriteエンティティを生成する
-	 *
-	 * @param	model	{@link PhotoFavoriteDeleteModel}
-	 * @return			{@link PhotoFavorite}
-	 */
-	public static PhotoFavorite from(PhotoFavoriteDeleteModel model) {
-		return PhotoFavorite.builder()
-				.accountNo(model.getAccountNo())
-				.favoritePhotoAccountNo(model.getFavoritePhotoAccountNo())
-				.favoritePhotoNo(model.getFavoritePhotoNo())
-				.build();
-	}
-
-	/**
-	 * 写真お気に入り全件削除用のPhotoFavoriteDeleteModelからPhotoFavoriteエンティティを生成する
-	 *
-	 * @param	model	{@link PhotoFavoriteDeleteModel}
-	 * @return			{@link PhotoFavorite}
-	 */
-	public static PhotoFavorite fromForClear(PhotoFavoriteDeleteModel model) {
-		return PhotoFavorite.builder()
-				.favoritePhotoAccountNo(model.getFavoritePhotoAccountNo())
-				.favoritePhotoNo(model.getFavoritePhotoNo())
-				.build();
-	}
-
-	/**
-	 * アカウント番号で自分が登録したお気に入り削除用のPhotoFavoriteエンティティを生成する
-	 *
-	 * @param	accountNo	アカウント番号
-	 * @return				{@link PhotoFavorite}
-	 */
-	public static PhotoFavorite conditionByAccountNo(AccountNo accountNo) {
-		return PhotoFavorite.builder()
-				.accountNo(accountNo)
-				.build();
-	}
-
-	/**
-	 * アカウント番号で自分の写真に対する他人のお気に入り削除用のPhotoFavoriteエンティティを生成する
-	 *
-	 * @param	favoritePhotoAccountNo	お気に入り写真アカウント番号
-	 * @return							{@link PhotoFavorite}
-	 */
-	public static PhotoFavorite conditionByFavoritePhotoAccountNo(AccountNo favoritePhotoAccountNo) {
-		return PhotoFavorite.builder()
-				.favoritePhotoAccountNo(favoritePhotoAccountNo)
 				.build();
 	}
 }

--- a/backend/src/main/java/com/web/gallery/entity/PhotoFavoriteCondition.java
+++ b/backend/src/main/java/com/web/gallery/entity/PhotoFavoriteCondition.java
@@ -1,0 +1,75 @@
+package com.web.gallery.entity;
+
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.photo.PhotoNo;
+import com.web.gallery.model.PhotoFavoriteDeleteModel;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * 写真お気に入りテーブルの抽出条件クラス
+ */
+@Data
+@Builder
+public class PhotoFavoriteCondition {
+	/** アカウント番号 */
+	private AccountNo accountNo;
+
+	/** お気に入り写真アカウント番号 */
+	private AccountNo favoritePhotoAccountNo;
+
+	/** お気に入り写真番号 */
+	private PhotoNo favoritePhotoNo;
+
+	/**
+	 * PhotoFavoriteDeleteModelから抽出条件を生成する
+	 *
+	 * @param	model	{@link PhotoFavoriteDeleteModel}
+	 * @return			{@link PhotoFavoriteCondition}
+	 */
+	public static PhotoFavoriteCondition from(PhotoFavoriteDeleteModel model) {
+		return PhotoFavoriteCondition.builder()
+				.accountNo(model.getAccountNo())
+				.favoritePhotoAccountNo(model.getFavoritePhotoAccountNo())
+				.favoritePhotoNo(model.getFavoritePhotoNo())
+				.build();
+	}
+
+	/**
+	 * 写真お気に入り全件削除用のPhotoFavoriteDeleteModelから抽出条件を生成する
+	 *
+	 * @param	model	{@link PhotoFavoriteDeleteModel}
+	 * @return			{@link PhotoFavoriteCondition}
+	 */
+	public static PhotoFavoriteCondition forClear(PhotoFavoriteDeleteModel model) {
+		return PhotoFavoriteCondition.builder()
+				.favoritePhotoAccountNo(model.getFavoritePhotoAccountNo())
+				.favoritePhotoNo(model.getFavoritePhotoNo())
+				.build();
+	}
+
+	/**
+	 * アカウント番号で自分が登録したお気に入り削除用の抽出条件を生成する
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @return				{@link PhotoFavoriteCondition}
+	 */
+	public static PhotoFavoriteCondition byAccountNo(AccountNo accountNo) {
+		return PhotoFavoriteCondition.builder()
+				.accountNo(accountNo)
+				.build();
+	}
+
+	/**
+	 * アカウント番号で自分の写真に対する他人のお気に入り削除用の抽出条件を生成する
+	 *
+	 * @param	favoritePhotoAccountNo	お気に入り写真アカウント番号
+	 * @return							{@link PhotoFavoriteCondition}
+	 */
+	public static PhotoFavoriteCondition byFavoritePhotoAccountNo(AccountNo favoritePhotoAccountNo) {
+		return PhotoFavoriteCondition.builder()
+				.favoritePhotoAccountNo(favoritePhotoAccountNo)
+				.build();
+	}
+}

--- a/backend/src/main/java/com/web/gallery/entity/PhotoMstCondition.java
+++ b/backend/src/main/java/com/web/gallery/entity/PhotoMstCondition.java
@@ -1,0 +1,125 @@
+package com.web.gallery.entity;
+
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.common.IsDeleted;
+import com.web.gallery.domain.photo.Caption;
+import com.web.gallery.domain.photo.FValue;
+import com.web.gallery.domain.photo.FocalLength;
+import com.web.gallery.domain.photo.ImageFilePath;
+import com.web.gallery.domain.photo.Iso;
+import com.web.gallery.domain.photo.LocationNo;
+import com.web.gallery.domain.photo.PhotoAt;
+import com.web.gallery.domain.photo.PhotoEnglishTitle;
+import com.web.gallery.domain.photo.PhotoJapaneseTitle;
+import com.web.gallery.domain.photo.PhotoNo;
+import com.web.gallery.domain.photo.ShutterSpeed;
+import com.web.gallery.enumeration.DirectionEnum;
+import com.web.gallery.model.PhotoDetailModel;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * 写真マスタテーブルの抽出条件クラス
+ */
+@Data
+@Builder
+public class PhotoMstCondition {
+	/** アカウント番号 */
+	private AccountNo accountNo;
+
+	/** 写真番号 */
+	private PhotoNo photoNo;
+
+	/** 削除フラグ */
+	private IsDeleted isDeleted;
+
+	/** 撮影日時 */
+	private PhotoAt photoAt;
+
+	/** ロケーション番号 */
+	private LocationNo locationNo;
+
+	/** 画像ファイルパス */
+	private ImageFilePath imageFilePath;
+
+	/** 写真タイトル日本語名 */
+	private PhotoJapaneseTitle photoJapaneseTitle;
+
+	/** 写真タイトル英語名 */
+	private PhotoEnglishTitle photoEnglishTitle;
+
+	/** キャプション */
+	private Caption caption;
+
+	/**
+	 * 向き区分
+	 * <p>
+	 * {@link DirectionEnum}
+	 */
+	private DirectionEnum directionKbn;
+
+	/** 焦点距離 */
+	private FocalLength focalLength;
+
+	/** F値 */
+	private FValue fValue;
+
+	/** シャッタースピード */
+	private ShutterSpeed shutterSpeed;
+
+	/** ISO */
+	private Iso iso;
+
+	/**
+	 * アカウント番号・写真番号による抽出条件を生成する
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @param	photoNo		写真番号
+	 * @return				{@link PhotoMstCondition}
+	 */
+	public static PhotoMstCondition byAccountAndPhoto(Long accountNo, Long photoNo) {
+		return PhotoMstCondition.builder()
+				.accountNo(new AccountNo(accountNo))
+				.photoNo(new PhotoNo(photoNo))
+				.build();
+	}
+
+	/**
+	 * 写真存在チェック用の抽出条件を生成する
+	 *
+	 * @param	model	{@link PhotoDetailModel}
+	 * @return			{@link PhotoMstCondition}
+	 */
+	public static PhotoMstCondition forExistCheck(PhotoDetailModel model) {
+		return PhotoMstCondition.builder()
+				.accountNo(model.getAccountNo())
+				.imageFilePath(new ImageFilePath(model.getImageFile().value().getOriginalFilename()))
+				.build();
+	}
+
+	/**
+	 * 写真件数取得用の抽出条件を生成する
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @return				{@link PhotoMstCondition}
+	 */
+	public static PhotoMstCondition forCount(Long accountNo) {
+		return PhotoMstCondition.builder()
+				.accountNo(new AccountNo(accountNo))
+				.isDeleted(new IsDeleted(false))
+				.build();
+	}
+
+	/**
+	 * アカウント番号による抽出条件を生成する
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @return				{@link PhotoMstCondition}
+	 */
+	public static PhotoMstCondition byAccountNo(AccountNo accountNo) {
+		return PhotoMstCondition.builder()
+				.accountNo(accountNo)
+				.build();
+	}
+}

--- a/backend/src/main/java/com/web/gallery/entity/PhotoMstUpdateTarget.java
+++ b/backend/src/main/java/com/web/gallery/entity/PhotoMstUpdateTarget.java
@@ -4,12 +4,8 @@ import java.math.BigDecimal;
 import java.util.Optional;
 
 import com.web.gallery.constant.Consts;
-import com.web.gallery.domain.account.AccountNo;
-import com.web.gallery.domain.common.CreatedBy;
-import com.web.gallery.domain.common.CreatedAt;
 import com.web.gallery.domain.common.IsDeleted;
 import com.web.gallery.domain.common.UpdatedBy;
-import com.web.gallery.domain.common.UpdatedAt;
 import com.web.gallery.domain.photo.Caption;
 import com.web.gallery.domain.photo.FValue;
 import com.web.gallery.domain.photo.FocalLength;
@@ -19,40 +15,22 @@ import com.web.gallery.domain.photo.LocationNo;
 import com.web.gallery.domain.photo.PhotoAt;
 import com.web.gallery.domain.photo.PhotoEnglishTitle;
 import com.web.gallery.domain.photo.PhotoJapaneseTitle;
-import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.domain.photo.ShutterSpeed;
 import com.web.gallery.enumeration.DirectionEnum;
+import com.web.gallery.model.PhotoDeleteModel;
 import com.web.gallery.model.PhotoDetailModel;
 
 import lombok.Builder;
 import lombok.Data;
 
 /**
- * 写真マスタテーブルのEntityクラス
+ * 写真マスタテーブルの更新対象クラス
  */
 @Data
 @Builder
-public class PhotoMst {
-	/** ID */
-	private Long id;
-
-	/** アカウント番号 */
-	private AccountNo accountNo;
-
-	/** 写真番号 */
-	private PhotoNo photoNo;
-
-	/** 作成者 */
-	private CreatedBy createdBy;
-
-	/** 作成日時 */
-	private CreatedAt createdAt;
-
+public class PhotoMstUpdateTarget {
 	/** 更新者 */
 	private UpdatedBy updatedBy;
-
-	/** 更新日時 */
-	private UpdatedAt updatedAt;
 
 	/** 削除フラグ */
 	private IsDeleted isDeleted;
@@ -95,24 +73,20 @@ public class PhotoMst {
 	private Iso iso;
 
 	/**
-	 * 写真登録用のPhotoDetailModelからPhotoMstエンティティを生成する
+	 * 写真更新用のPhotoDetailModelから更新対象を生成する
 	 *
-	 * @param	model		{@link PhotoDetailModel}
-	 * @param	filePath	写真の保存ファイルパス
-	 * @param	newPhotoNo	新規採番した写真番号
-	 * @return				{@link PhotoMst}
+	 * @param	model	{@link PhotoDetailModel}
+	 * @return			{@link PhotoMstUpdateTarget}
 	 */
-	public static PhotoMst fromForRegist(PhotoDetailModel model, String filePath, Long newPhotoNo) {
-		return PhotoMst.builder()
-				.accountNo(model.getAccountNo())
-				.photoNo(new PhotoNo(newPhotoNo))
-				.createdBy(new CreatedBy(model.getAccountNo().value()))
+	public static PhotoMstUpdateTarget fromForUpdate(PhotoDetailModel model) {
+		return PhotoMstUpdateTarget.builder()
 				.updatedBy(new UpdatedBy(model.getAccountNo().value()))
+				.isDeleted(new IsDeleted(false))
 				.photoAt(new PhotoAt(
 					Optional.ofNullable(model.getPhotoAt()).map(PhotoAt::value).orElse(Consts.MIN_OFFSET_DATE_TIME)))
 				.locationNo(new LocationNo(
 					Optional.ofNullable(model.getLocationNo()).map(LocationNo::value).orElse(0L)))
-				.imageFilePath(new ImageFilePath(filePath))
+				.imageFilePath(model.getImageFilePath())
 				.photoJapaneseTitle(new PhotoJapaneseTitle(
 					Optional.ofNullable(model.getPhotoJapaneseTitle()).map(PhotoJapaneseTitle::value).orElse(Consts.STRING_EMPTY)))
 				.photoEnglishTitle(new PhotoEnglishTitle(
@@ -129,6 +103,19 @@ public class PhotoMst {
 					Optional.ofNullable(model.getShutterSpeed()).map(ShutterSpeed::value).orElse(BigDecimal.ZERO)))
 				.iso(new Iso(
 					Optional.ofNullable(model.getIso()).map(Iso::value).orElse(0)))
+				.build();
+	}
+
+	/**
+	 * 写真削除用のPhotoDeleteModelから更新対象を生成する
+	 *
+	 * @param	model	{@link PhotoDeleteModel}
+	 * @return			{@link PhotoMstUpdateTarget}
+	 */
+	public static PhotoMstUpdateTarget forDelete(PhotoDeleteModel model) {
+		return PhotoMstUpdateTarget.builder()
+				.updatedBy(new UpdatedBy(model.getAccountNo().value()))
+				.isDeleted(new IsDeleted(true))
 				.build();
 	}
 }

--- a/backend/src/main/java/com/web/gallery/entity/PhotoTagMst.java
+++ b/backend/src/main/java/com/web/gallery/entity/PhotoTagMst.java
@@ -7,9 +7,6 @@ import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.domain.photo.TagEnglishName;
 import com.web.gallery.domain.photo.TagJapaneseName;
 import com.web.gallery.domain.photo.TagNo;
-import com.web.gallery.model.PhotoDetailGetModel;
-import com.web.gallery.model.PhotoGetModel;
-import com.web.gallery.model.PhotoTagDeleteModel;
 import com.web.gallery.model.PhotoTagModel;
 
 import lombok.Builder;
@@ -59,56 +56,6 @@ public class PhotoTagMst {
 				.createdBy(new CreatedBy(model.getAccountNo().value()))
 				.tagJapaneseName(model.getTagJapaneseName())
 				.tagEnglishName(model.getTagEnglishName())
-				.build();
-	}
-
-	/**
-	 * 写真タグ削除用のPhotoTagDeleteModelからPhotoTagMstエンティティを生成する
-	 *
-	 * @param	model	{@link PhotoTagDeleteModel}
-	 * @return			{@link PhotoTagMst}
-	 */
-	public static PhotoTagMst from(PhotoTagDeleteModel model) {
-		return PhotoTagMst.builder()
-				.accountNo(model.getAccountNo())
-				.photoNo(model.getPhotoNo())
-				.build();
-	}
-
-	/**
-	 * PhotoDetailGetModelから条件用のPhotoTagMstエンティティを生成する
-	 *
-	 * @param	model	{@link PhotoDetailGetModel}
-	 * @return			{@link PhotoTagMst}
-	 */
-	public static PhotoTagMst condition(PhotoDetailGetModel model) {
-		return PhotoTagMst.builder()
-				.accountNo(model.getPhotoAccountNo())
-				.photoNo(model.getPhotoNo())
-				.build();
-	}
-
-	/**
-	 * PhotoGetModelから条件用のPhotoTagMstエンティティを生成する
-	 *
-	 * @param	model	{@link PhotoGetModel}
-	 * @return			{@link PhotoTagMst}
-	 */
-	public static PhotoTagMst condition(PhotoGetModel model) {
-		return PhotoTagMst.builder()
-				.accountNo(model.getPhotoAccountNo())
-				.build();
-	}
-
-	/**
-	 * アカウント番号で写真タグ削除用のPhotoTagMstエンティティを生成する
-	 *
-	 * @param	accountNo	アカウント番号
-	 * @return				{@link PhotoTagMst}
-	 */
-	public static PhotoTagMst conditionByAccountNo(AccountNo accountNo) {
-		return PhotoTagMst.builder()
-				.accountNo(accountNo)
 				.build();
 	}
 }

--- a/backend/src/main/java/com/web/gallery/entity/PhotoTagMstCondition.java
+++ b/backend/src/main/java/com/web/gallery/entity/PhotoTagMstCondition.java
@@ -1,0 +1,85 @@
+package com.web.gallery.entity;
+
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.photo.PhotoNo;
+import com.web.gallery.domain.photo.TagEnglishName;
+import com.web.gallery.domain.photo.TagJapaneseName;
+import com.web.gallery.domain.photo.TagNo;
+import com.web.gallery.model.PhotoDetailGetModel;
+import com.web.gallery.model.PhotoGetModel;
+import com.web.gallery.model.PhotoTagDeleteModel;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * 写真タグマスタテーブルの抽出条件クラス
+ */
+@Data
+@Builder
+public class PhotoTagMstCondition {
+	/** アカウント番号 */
+	private AccountNo accountNo;
+
+	/** 写真番号 */
+	private PhotoNo photoNo;
+
+	/** タグ番号 */
+	private TagNo tagNo;
+
+	/** タグ日本語名 */
+	private TagJapaneseName tagJapaneseName;
+
+	/** タグ英語名 */
+	private TagEnglishName tagEnglishName;
+
+	/**
+	 * 写真タグ削除用のPhotoTagDeleteModelから抽出条件を生成する
+	 *
+	 * @param	model	{@link PhotoTagDeleteModel}
+	 * @return			{@link PhotoTagMstCondition}
+	 */
+	public static PhotoTagMstCondition from(PhotoTagDeleteModel model) {
+		return PhotoTagMstCondition.builder()
+				.accountNo(model.getAccountNo())
+				.photoNo(model.getPhotoNo())
+				.build();
+	}
+
+	/**
+	 * PhotoDetailGetModelから抽出条件を生成する
+	 *
+	 * @param	model	{@link PhotoDetailGetModel}
+	 * @return			{@link PhotoTagMstCondition}
+	 */
+	public static PhotoTagMstCondition from(PhotoDetailGetModel model) {
+		return PhotoTagMstCondition.builder()
+				.accountNo(model.getPhotoAccountNo())
+				.photoNo(model.getPhotoNo())
+				.build();
+	}
+
+	/**
+	 * PhotoGetModelから抽出条件を生成する
+	 *
+	 * @param	model	{@link PhotoGetModel}
+	 * @return			{@link PhotoTagMstCondition}
+	 */
+	public static PhotoTagMstCondition from(PhotoGetModel model) {
+		return PhotoTagMstCondition.builder()
+				.accountNo(model.getPhotoAccountNo())
+				.build();
+	}
+
+	/**
+	 * アカウント番号で写真タグ削除用の抽出条件を生成する
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @return				{@link PhotoTagMstCondition}
+	 */
+	public static PhotoTagMstCondition byAccountNo(AccountNo accountNo) {
+		return PhotoTagMstCondition.builder()
+				.accountNo(accountNo)
+				.build();
+	}
+}

--- a/backend/src/main/java/com/web/gallery/mapper/AccountMapper.java
+++ b/backend/src/main/java/com/web/gallery/mapper/AccountMapper.java
@@ -6,6 +6,8 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import com.web.gallery.entity.Account;
+import com.web.gallery.entity.AccountCondition;
+import com.web.gallery.entity.AccountUpdateTarget;
 
 /**
  * アカウントテーブルのMapperクラス
@@ -14,23 +16,23 @@ import com.web.gallery.entity.Account;
 public interface AccountMapper {
 	/**
 	 * 条件に該当するアカウントの一覧を取得する
-	 * 
-	 * @param	account	抽出条件
-	 * @return			{@link Account}
+	 *
+	 * @param	condition	抽出条件
+	 * @return				{@link Account}
 	 */
-	public List<Account> select(Account account);
-	
+	public List<Account> select(AccountCondition condition);
+
 	/**
 	 * 条件に該当するアカウントの件数を取得する
-	 * 
-	 * @param	account	カウント条件
-	 * @return			抽出件数
+	 *
+	 * @param	condition	カウント条件
+	 * @return				抽出件数
 	 */
-	public Integer count(Account account);
+	public Integer count(AccountCondition condition);
 
 	/**
 	 * アカウントを登録する
-	 * 
+	 *
 	 * @param	account	{@link Account}
 	 * @return			登録件数
 	 */
@@ -38,26 +40,26 @@ public interface AccountMapper {
 
 	/**
 	 * アカウントを更新する
-	 * 
-	 * @param	conditionAccount	更新対象の抽出条件
-	 * @param	targetAccount		更新内容
-	 * @return						更新件数
+	 *
+	 * @param	condition	更新対象の抽出条件
+	 * @param	target		更新内容
+	 * @return				更新件数
 	 */
-	public Integer update(@Param("condition") Account conditionAccount, @Param("target") Account targetAccount);
-	
+	public Integer update(@Param("condition") AccountCondition condition, @Param("target") AccountUpdateTarget target);
+
 	/**
 	 * アカウントを削除する
-	 * 
-	 * @param	account	削除対象の抽出条件
-	 * @return			削除件数
+	 *
+	 * @param	condition	削除対象の抽出条件
+	 * @return				削除件数
 	 */
-	public Integer delete(Account account);
-	
+	public Integer delete(AccountCondition condition);
+
 	/**
 	 * アカウントIDに該当するアカウントが存在するかをチェックする
-	 * 
-	 * @param	account	{@link Account}
-	 * @return			アカウントの存在有無
+	 *
+	 * @param	condition	{@link AccountCondition}
+	 * @return				アカウントの存在有無
 	 */
-	public Boolean isExistAccount(Account account);
+	public Boolean isExistAccount(AccountCondition condition);
 }

--- a/backend/src/main/java/com/web/gallery/mapper/KbnMstMapper.java
+++ b/backend/src/main/java/com/web/gallery/mapper/KbnMstMapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.web.gallery.entity.KbnMst;
+import com.web.gallery.entity.KbnMstCondition;
 
 /**
  * 区分マスタテーブルのMapperクラス
@@ -13,9 +14,9 @@ import com.web.gallery.entity.KbnMst;
 public interface KbnMstMapper {
 	/**
 	 * 条件に該当する区分マスタの一覧を取得する
-	 * 
-	 * @param	kbnMst	抽出条件
-	 * @return			{@link KbnMst}
+	 *
+	 * @param	condition	抽出条件
+	 * @return				{@link KbnMst}
 	 */
-	public List<KbnMst> select(KbnMst kbnMst);
+	public List<KbnMst> select(KbnMstCondition condition);
 }

--- a/backend/src/main/java/com/web/gallery/mapper/PhotoFavoriteMapper.java
+++ b/backend/src/main/java/com/web/gallery/mapper/PhotoFavoriteMapper.java
@@ -3,6 +3,7 @@ package com.web.gallery.mapper;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.web.gallery.entity.PhotoFavorite;
+import com.web.gallery.entity.PhotoFavoriteCondition;
 
 /**
  * 写真お気に入りテーブルのMapperクラス
@@ -11,17 +12,17 @@ import com.web.gallery.entity.PhotoFavorite;
 public interface PhotoFavoriteMapper {
 	/**
 	 * 写真お気に入りを登録する
-	 * 
+	 *
 	 * @param	photoFavorite	{@link PhotoFavorite}
 	 * @return					登録件数
 	 */
 	public Integer insert(PhotoFavorite photoFavorite);
-	
+
 	/**
 	 * 写真お気に入りを削除する
-	 * 
-	 * @param	photoFavorite	削除対象の抽出条件
-	 * @return					削除件数
+	 *
+	 * @param	condition	削除対象の抽出条件
+	 * @return				削除件数
 	 */
-	public Integer delete(PhotoFavorite photoFavorite);
+	public Integer delete(PhotoFavoriteCondition condition);
 }

--- a/backend/src/main/java/com/web/gallery/mapper/PhotoMstMapper.java
+++ b/backend/src/main/java/com/web/gallery/mapper/PhotoMstMapper.java
@@ -4,6 +4,8 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import com.web.gallery.entity.PhotoMst;
+import com.web.gallery.entity.PhotoMstCondition;
+import com.web.gallery.entity.PhotoMstUpdateTarget;
 
 /**
  * 写真マスタテーブルのMapperクラス
@@ -12,50 +14,50 @@ import com.web.gallery.entity.PhotoMst;
 public interface PhotoMstMapper {
 	/**
 	 * 条件に該当する写真マスタの件数を取得する
-	 * 
-	 * @param	photoMst	カウント条件
+	 *
+	 * @param	condition	カウント条件
 	 * @return				抽出件数
 	 */
-	public Integer count(PhotoMst photoMst);
-	
+	public Integer count(PhotoMstCondition condition);
+
 	/**
 	 * 写真マスタを登録する
-	 * 
+	 *
 	 * @param	photoMst	{@link PhotoMst}
 	 * @return				登録件数
 	 */
 	public Integer insert(PhotoMst photoMst);
-	
+
 	/**
 	 * 写真マスタを更新する
-	 * 
-	 * @param	conditionPhotoMst	更新対象の抽出条件
-	 * @param	targetPhotoMst		更新内容
-	 * @return						更新件数
+	 *
+	 * @param	condition	更新対象の抽出条件
+	 * @param	target		更新内容
+	 * @return				更新件数
 	 */
-	public Integer update(@Param("condition") PhotoMst conditionPhotoMst, @Param("target") PhotoMst targetPhotoMst);
-	
+	public Integer update(@Param("condition") PhotoMstCondition condition, @Param("target") PhotoMstUpdateTarget target);
+
 	/**
 	 * アカウントが登録済みの最大の写真番号を取得する
-	 * 
+	 *
 	 * @param	accountNo	アカウント番号
 	 * @return				最大の写真番号
 	 */
 	public Long getMaxPhotoNo(Long accountNo);
-	
+
 	/**
 	 * ファイル名から登録済みの写真家判定する
 	 *
-	 * @param	photoMst	{@link PhotoMst}
+	 * @param	condition	{@link PhotoMstCondition}
 	 * @return				登録有無
 	 */
-	public Boolean isExistPhoto(PhotoMst photoMst);
+	public Boolean isExistPhoto(PhotoMstCondition condition);
 
 	/**
 	 * 写真マスタを物理削除する
 	 *
-	 * @param	photoMst	削除対象の抽出条件
+	 * @param	condition	削除対象の抽出条件
 	 * @return				削除件数
 	 */
-	public Integer delete(PhotoMst photoMst);
+	public Integer delete(PhotoMstCondition condition);
 }

--- a/backend/src/main/java/com/web/gallery/mapper/PhotoTagMstMapper.java
+++ b/backend/src/main/java/com/web/gallery/mapper/PhotoTagMstMapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.web.gallery.entity.PhotoTagMst;
+import com.web.gallery.entity.PhotoTagMstCondition;
 
 /**
  * 写真タグマスタのMapperクラス
@@ -13,25 +14,25 @@ import com.web.gallery.entity.PhotoTagMst;
 public interface PhotoTagMstMapper {
 	/**
 	 * 条件に該当する写真タグマスタの一覧を取得する
-	 * 
-	 * @param	photoTagMst	抽出条件
+	 *
+	 * @param	condition	抽出条件
 	 * @return				@{link PhotoTagMst}
 	 */
-	public List<PhotoTagMst> select(PhotoTagMst photoTagMst);
-	
+	public List<PhotoTagMst> select(PhotoTagMstCondition condition);
+
 	/**
 	 * 写真タグマスタを登録する
-	 * 
+	 *
 	 * @param	photoTagMst	{@link PhotoTagMst}
 	 * @return				登録件数
 	 */
 	public Integer insert(PhotoTagMst photoTagMst);
-	
+
 	/**
 	 * 写真タグマスタを削除する
-	 * 
-	 * @param	photoTagMst	削除対象の抽出条件
+	 *
+	 * @param	condition	削除対象の抽出条件
 	 * @return				削除件数
 	 */
-	public Integer delete(PhotoTagMst photoTagMst);
+	public Integer delete(PhotoTagMstCondition condition);
 }

--- a/backend/src/main/java/com/web/gallery/repository/impl/AccountRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/AccountRepositoryImpl.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Repository;
 import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.entity.Account;
+import com.web.gallery.entity.AccountCondition;
+import com.web.gallery.entity.AccountUpdateTarget;
 import com.web.gallery.enumeration.ErrorEnum;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
@@ -40,7 +42,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public AccountModel getByAccountNo(AccountNo accountNo) {
-		List<Account> accountList = accountMapper.select(Account.conditionByAccountNo(accountNo.value()));
+		List<Account> accountList = accountMapper.select(AccountCondition.byAccountNo(accountNo.value()));
 		return accountList.isEmpty() ? null : AccountModel.from(accountList.getFirst());
 	}
 
@@ -53,7 +55,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public AccountModel getByAccountId(AccountId accountId) {
-		List<Account> accountList = accountMapper.select(Account.conditionByAccountId(accountId.value()));
+		List<Account> accountList = accountMapper.select(AccountCondition.byAccountId(accountId.value()));
 		return accountList.isEmpty() ? null : AccountModel.from(accountList.getFirst());
 	}
 
@@ -84,10 +86,10 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public void update(AccountModel accountModel) throws UpdateFailureException {
-		Account cndAccount = Account.conditionByAccountNo(accountModel.getAccountNo().value());
-		Account targetAccount = Account.fromForUpdate(accountModel, passwordEncoder);
+		AccountCondition condition = AccountCondition.byAccountNo(accountModel.getAccountNo().value());
+		AccountUpdateTarget target = AccountUpdateTarget.fromForUpdate(accountModel, passwordEncoder);
 
-		if (accountMapper.update(cndAccount, targetAccount) < 1) {
+		if (accountMapper.update(condition, target) < 1) {
 			log.warn("Account: Update Failed (AccountNo: {})", accountModel.getAccountNo().value());
 			throw new UpdateFailureException(ErrorEnum.FAIL_TO_UPDATE_ACCOUNT);
 		}
@@ -101,10 +103,10 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public void updateLoginFailureCount(AccountModel accountModel) throws UpdateFailureException {
-		Account cndAccount = Account.conditionByAccountNo(accountModel.getAccountNo().value());
-		Account targetAccount = Account.fromForUpdateLoginFailure(accountModel);
+		AccountCondition condition = AccountCondition.byAccountNo(accountModel.getAccountNo().value());
+		AccountUpdateTarget target = AccountUpdateTarget.fromForUpdateLoginFailure(accountModel);
 
-		if (accountMapper.update(cndAccount, targetAccount) < 1) {
+		if (accountMapper.update(condition, target) < 1) {
 			log.warn("Account: Update Failed (AccountNo: {})", accountModel.getAccountNo().value());
 			throw new UpdateFailureException(ErrorEnum.FAIL_TO_UPDATE_ACCOUNT);
 		}
@@ -118,7 +120,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public Boolean isExistAccount(AccountId accountId) {
-		return accountMapper.isExistAccount(Account.conditionForExistCheck(null, accountId.value()));
+		return accountMapper.isExistAccount(AccountCondition.forExistCheck(null, accountId.value()));
 	}
 
 	/**
@@ -130,7 +132,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public Boolean isExistAccount(AccountNo accountNo, AccountId accountId) {
-		return accountMapper.isExistAccount(Account.conditionForExistCheck(accountNo.value(), accountId.value()));
+		return accountMapper.isExistAccount(AccountCondition.forExistCheck(accountNo.value(), accountId.value()));
 	}
 
 	/**
@@ -140,7 +142,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public AccountModelList getAccountList() {
-		List<Account> accountList = accountMapper.select(Account.conditionForList());
+		List<Account> accountList = accountMapper.select(AccountCondition.forList());
 		return AccountModelList.from(accountList);
 	}
 
@@ -151,7 +153,7 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public AccountModelList getAccountListAll() {
-		List<Account> accountList = accountMapper.select(Account.conditionForAdminList());
+		List<Account> accountList = accountMapper.select(AccountCondition.forAdminList());
 		return AccountModelList.from(accountList);
 	}
 
@@ -162,6 +164,6 @@ public class AccountRepositoryImpl implements AccountRepository {
 	 */
 	@Override
 	public void delete(AccountNo accountNo) {
-		accountMapper.delete(Account.conditionByAccountNo(accountNo.value()));
+		accountMapper.delete(AccountCondition.byAccountNo(accountNo.value()));
 	}
 }

--- a/backend/src/main/java/com/web/gallery/repository/impl/KbnMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/KbnMstRepositoryImpl.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import com.web.gallery.domain.common.KbnClassCode;
 import com.web.gallery.entity.KbnMst;
+import com.web.gallery.entity.KbnMstCondition;
 import com.web.gallery.mapper.KbnMstMapper;
 import com.web.gallery.model.KbnMstModelList;
 import com.web.gallery.repository.KbnMstRepository;
@@ -29,7 +30,7 @@ public class KbnMstRepositoryImpl implements KbnMstRepository {
 	 */
 	@Override
 	public KbnMstModelList get(KbnClassCode kbnClassCode) {
-		List<KbnMst> kbnMstList = kbnMstMapper.select(KbnMst.condition(kbnClassCode.value()));
+		List<KbnMst> kbnMstList = kbnMstMapper.select(KbnMstCondition.byKbnClassCode(kbnClassCode.value()));
 
 		return KbnMstModelList.from(kbnMstList);
 	}

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.web.gallery.dto.PhotoDetailGetDto;
 import com.web.gallery.dto.PhotoDto;
 import com.web.gallery.dto.PhotoListGetDto;
 import com.web.gallery.entity.PhotoTagMst;
+import com.web.gallery.entity.PhotoTagMstCondition;
 import com.web.gallery.enumeration.ErrorEnum;
 import com.web.gallery.exception.PhotoNotFoundException;
 import com.web.gallery.mapper.PhotoDetailMapper;
@@ -47,7 +48,7 @@ public class PhotoDetailRepositoryImpl implements PhotoDetailRepository {
 		List<PhotoDto> photoDtoList = photoDetailMapper.getPhotoList(PhotoListGetDto.from(photoGetModel));
 
 		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(
-				PhotoTagMst.condition(photoGetModel));
+				PhotoTagMstCondition.from(photoGetModel));
 
 		return PhotoModelList.from(photoDtoList, photoTagMstList);
 	}
@@ -71,7 +72,7 @@ public class PhotoDetailRepositoryImpl implements PhotoDetailRepository {
 		}
 
 		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(
-				PhotoTagMst.condition(photoDetailGetModel));
+				PhotoTagMstCondition.from(photoDetailGetModel));
 
 		return PhotoDetailModel.from(photoDetailDto, photoTagMstList);
 	}

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoFavoriteRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoFavoriteRepositoryImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Repository;
 
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.entity.PhotoFavorite;
+import com.web.gallery.entity.PhotoFavoriteCondition;
 import com.web.gallery.enumeration.ErrorEnum;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
@@ -54,9 +55,9 @@ public class PhotoFavoriteRepositoryImpl implements PhotoFavoriteRepository{
 	 */
 	@Override
 	public void delete(PhotoFavoriteDeleteModel favoriteDeleteModel) throws UpdateFailureException {
-		PhotoFavorite photoFavorite = PhotoFavorite.from(favoriteDeleteModel);
+		PhotoFavoriteCondition condition = PhotoFavoriteCondition.from(favoriteDeleteModel);
 
-		if (photoFavoriteMapper.delete(photoFavorite) < 1) {
+		if (photoFavoriteMapper.delete(condition) < 1) {
 			log.warn("PhotoFavorite: Delete Failed (AccountNo: {}, FavoritePhotoAccountNo: {}, FavoritePhotoNo: {})",
 					favoriteDeleteModel.getAccountNo() != null ? favoriteDeleteModel.getAccountNo().value() : null,
 					favoriteDeleteModel.getFavoritePhotoAccountNo().value(), favoriteDeleteModel.getFavoritePhotoNo().value());
@@ -71,8 +72,8 @@ public class PhotoFavoriteRepositoryImpl implements PhotoFavoriteRepository{
 	 */
 	@Override
 	public void clear(PhotoFavoriteDeleteModel favoriteDeleteModel) {
-		PhotoFavorite photoFavorite = PhotoFavorite.fromForClear(favoriteDeleteModel);
-		photoFavoriteMapper.delete(photoFavorite);
+		PhotoFavoriteCondition condition = PhotoFavoriteCondition.forClear(favoriteDeleteModel);
+		photoFavoriteMapper.delete(condition);
 	}
 
 	/**
@@ -82,7 +83,7 @@ public class PhotoFavoriteRepositoryImpl implements PhotoFavoriteRepository{
 	 */
 	@Override
 	public void deleteByAccountNo(AccountNo accountNo) {
-		photoFavoriteMapper.delete(PhotoFavorite.conditionByAccountNo(accountNo));
+		photoFavoriteMapper.delete(PhotoFavoriteCondition.byAccountNo(accountNo));
 	}
 
 	/**
@@ -92,6 +93,6 @@ public class PhotoFavoriteRepositoryImpl implements PhotoFavoriteRepository{
 	 */
 	@Override
 	public void deleteByFavoritePhotoAccountNo(AccountNo favoritePhotoAccountNo) {
-		photoFavoriteMapper.delete(PhotoFavorite.conditionByFavoritePhotoAccountNo(favoritePhotoAccountNo));
+		photoFavoriteMapper.delete(PhotoFavoriteCondition.byFavoritePhotoAccountNo(favoritePhotoAccountNo));
 	}
 }

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
@@ -9,6 +9,8 @@ import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.ImageFilePath;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.entity.PhotoMst;
+import com.web.gallery.entity.PhotoMstCondition;
+import com.web.gallery.entity.PhotoMstUpdateTarget;
 import com.web.gallery.enumeration.ErrorEnum;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
@@ -59,10 +61,10 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 */
 	@Override
 	public void update(PhotoDetailModel photoDetailModel) throws UpdateFailureException {
-		PhotoMst cndPhotoMst = PhotoMst.condition(photoDetailModel.getAccountNo().value(), photoDetailModel.getPhotoNo().value());
-		PhotoMst targetPhotoMst = PhotoMst.targetForUpdate(photoDetailModel);
+		PhotoMstCondition condition = PhotoMstCondition.byAccountAndPhoto(photoDetailModel.getAccountNo().value(), photoDetailModel.getPhotoNo().value());
+		PhotoMstUpdateTarget target = PhotoMstUpdateTarget.fromForUpdate(photoDetailModel);
 
-		if (photoMstMapper.update(cndPhotoMst, targetPhotoMst) < 1) {
+		if (photoMstMapper.update(condition, target) < 1) {
 			log.warn("PhotoMst: Update Failed (AccountNo: {}, PhotoNo: {})", photoDetailModel.getAccountNo().value(), photoDetailModel.getPhotoNo().value());
 			throw new UpdateFailureException(ErrorEnum.FAIL_TO_UPDATE_PHOTO);
 		}
@@ -76,10 +78,10 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 */
 	@Override
 	public void delete(PhotoDeleteModel photoDeleteModel) throws UpdateFailureException {
-		PhotoMst cndPhotoMst = PhotoMst.condition(photoDeleteModel.getAccountNo().value(), photoDeleteModel.getPhotoNo().value());
-		PhotoMst targetPhotoMst = PhotoMst.targetForDelete(photoDeleteModel);
+		PhotoMstCondition condition = PhotoMstCondition.byAccountAndPhoto(photoDeleteModel.getAccountNo().value(), photoDeleteModel.getPhotoNo().value());
+		PhotoMstUpdateTarget target = PhotoMstUpdateTarget.forDelete(photoDeleteModel);
 
-		if (photoMstMapper.update(cndPhotoMst, targetPhotoMst) < 1) {
+		if (photoMstMapper.update(condition, target) < 1) {
 			log.warn("PhotoMst: Delete Failed (AccountNo: {}, PhotoNo: {})", photoDeleteModel.getAccountNo().value(), photoDeleteModel.getPhotoNo().value());
 			throw new UpdateFailureException(ErrorEnum.FAIL_TO_DELETE_PHOTO);
 		}
@@ -105,7 +107,7 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 */
 	@Override
 	public Boolean isExistPhoto(PhotoDetailModel photoDetailModel) {
-		return photoMstMapper.isExistPhoto(PhotoMst.conditionForExistCheck(photoDetailModel));
+		return photoMstMapper.isExistPhoto(PhotoMstCondition.forExistCheck(photoDetailModel));
 	}
 
 	/**
@@ -116,7 +118,7 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 */
 	@Override
 	public Integer count(AccountNo accountNo) {
-		return photoMstMapper.count(PhotoMst.conditionForCount(accountNo.value()));
+		return photoMstMapper.count(PhotoMstCondition.forCount(accountNo.value()));
 	}
 
 	/**
@@ -126,6 +128,6 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 */
 	@Override
 	public void deleteByAccountNo(AccountNo accountNo) {
-		photoMstMapper.delete(PhotoMst.conditionByAccountNo(accountNo));
+		photoMstMapper.delete(PhotoMstCondition.byAccountNo(accountNo));
 	}
 }

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoTagMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoTagMstRepositoryImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Repository;
 
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.entity.PhotoTagMst;
+import com.web.gallery.entity.PhotoTagMstCondition;
 import com.web.gallery.enumeration.ErrorEnum;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.mapper.PhotoTagMstMapper;
@@ -52,8 +53,8 @@ public class PhotoTagMstRepositoryImpl implements PhotoTagMstRepository {
 	 */
 	@Override
 	public void clear(PhotoTagDeleteModel photoTagDeleteModel) {
-		PhotoTagMst photoTagMst = PhotoTagMst.from(photoTagDeleteModel);
-		photoTagMstMapper.delete(photoTagMst);
+		PhotoTagMstCondition condition = PhotoTagMstCondition.from(photoTagDeleteModel);
+		photoTagMstMapper.delete(condition);
 	}
 
 	/**
@@ -63,6 +64,6 @@ public class PhotoTagMstRepositoryImpl implements PhotoTagMstRepository {
 	 */
 	@Override
 	public void deleteByAccountNo(AccountNo accountNo) {
-		photoTagMstMapper.delete(PhotoTagMst.conditionByAccountNo(accountNo));
+		photoTagMstMapper.delete(PhotoTagMstCondition.byAccountNo(accountNo));
 	}
 }

--- a/backend/src/main/resources/com/web/gallery/mapper/AccountMapper.xml
+++ b/backend/src/main/resources/com/web/gallery/mapper/AccountMapper.xml
@@ -23,7 +23,7 @@
 		<result property="loginFailureCount" column="login_failure_count" typeHandler="com.web.gallery.type_handler.LoginFailureCountTypeHandler"/>
 	</resultMap>
 
-	<select id="select" parameterType="com.web.gallery.entity.Account" resultMap="AccountMap">
+	<select id="select" parameterType="com.web.gallery.entity.AccountCondition" resultMap="AccountMap">
 		SELECT
 			account_no AS accountNo,
 			created_by AS createdBy,
@@ -61,7 +61,7 @@
 		</where>
 	</select>
 
-	<select id="count" parameterType="com.web.gallery.entity.Account" resultType="Integer">
+	<select id="count" parameterType="com.web.gallery.entity.AccountCondition" resultType="Integer">
 		SELECT
 			COUNT(*)
 		FROM
@@ -126,7 +126,7 @@
 			)
 	</insert>
 
-	<update id="update" parameterType="com.web.gallery.entity.Account">
+	<update id="update">
 		UPDATE
 			common.account
 		<set>
@@ -162,7 +162,7 @@
 		</where>
 	</update>
 
-	<delete id="delete" parameterType="com.web.gallery.entity.Account">
+	<delete id="delete" parameterType="com.web.gallery.entity.AccountCondition">
 		DELETE FROM
 			common.account
 		<where>
@@ -182,7 +182,7 @@
 		</where>
 	</delete>
 
-	<select id="isExistAccount" parameterType="com.web.gallery.entity.Account" resultType="Boolean">
+	<select id="isExistAccount" parameterType="com.web.gallery.entity.AccountCondition" resultType="Boolean">
 		SELECT
 			CASE WHEN COUNT(*)>0 THEN true ELSE false END
 		FROM

--- a/backend/src/main/resources/com/web/gallery/mapper/KbnMstMapper.xml
+++ b/backend/src/main/resources/com/web/gallery/mapper/KbnMstMapper.xml
@@ -18,7 +18,7 @@
 		<result property="explanation" column="explanation" typeHandler="com.web.gallery.type_handler.ExplanationTypeHandler"/>
 	</resultMap>
 
-	<select id="select" parameterType="com.web.gallery.entity.KbnMst" resultMap="KbnMstMap">
+	<select id="select" parameterType="com.web.gallery.entity.KbnMstCondition" resultMap="KbnMstMap">
 		SELECT
 			kbn_class_code AS kbnClassCode,
 			kbn_code AS kbnCode,

--- a/backend/src/main/resources/com/web/gallery/mapper/PhotoFavoriteMapper.xml
+++ b/backend/src/main/resources/com/web/gallery/mapper/PhotoFavoriteMapper.xml
@@ -21,7 +21,7 @@
 			)
 	</insert>
 
-	<delete id="delete" parameterType="com.web.gallery.entity.PhotoFavorite">
+	<delete id="delete" parameterType="com.web.gallery.entity.PhotoFavoriteCondition">
 		DELETE FROM
 			photo.photo_favorite
 		<where>

--- a/backend/src/main/resources/com/web/gallery/mapper/PhotoMstMapper.xml
+++ b/backend/src/main/resources/com/web/gallery/mapper/PhotoMstMapper.xml
@@ -23,7 +23,7 @@
 		<result property="iso" column="iso" typeHandler="com.web.gallery.type_handler.IsoTypeHandler"/>
 	</resultMap>
 
-	<select id="count" parameterType="com.web.gallery.entity.PhotoMst" resultType="Integer">
+	<select id="count" parameterType="com.web.gallery.entity.PhotoMstCondition" resultType="Integer">
 		SELECT
 			COUNT(*)
 		FROM
@@ -91,7 +91,7 @@
 			)
 	</insert>
 
-	<update id="update" parameterType="com.web.gallery.entity.PhotoMst">
+	<update id="update">
 		UPDATE
 			photo.photo_mst
 		<set>
@@ -137,7 +137,7 @@
 			account_no = #{accountNo}
 	</select>
 
-	<select id="isExistPhoto" parameterType="com.web.gallery.entity.PhotoMst" resultType="Boolean">
+	<select id="isExistPhoto" parameterType="com.web.gallery.entity.PhotoMstCondition" resultType="Boolean">
 		SELECT
 			CASE WHEN COUNT(*)>0 THEN true ELSE false END
 		FROM
@@ -148,7 +148,7 @@
 		AND is_deleted = false
 	</select>
 
-	<delete id="delete" parameterType="com.web.gallery.entity.PhotoMst">
+	<delete id="delete" parameterType="com.web.gallery.entity.PhotoMstCondition">
 		DELETE FROM
 			photo.photo_mst
 		<where>

--- a/backend/src/main/resources/com/web/gallery/mapper/PhotoTagMstMapper.xml
+++ b/backend/src/main/resources/com/web/gallery/mapper/PhotoTagMstMapper.xml
@@ -12,7 +12,7 @@
 		<result property="tagEnglishName" column="tag_english_name" typeHandler="com.web.gallery.type_handler.TagEnglishNameTypeHandler"/>
 	</resultMap>
 
-	<select id="select" parameterType="com.web.gallery.entity.PhotoTagMst" resultMap="PhotoTagMstMap">
+	<select id="select" parameterType="com.web.gallery.entity.PhotoTagMstCondition" resultMap="PhotoTagMstMap">
 		SELECT
 			id,
 			account_no AS accountNo,
@@ -56,7 +56,7 @@
 			)
 	</insert>
 
-	<delete id="delete" parameterType="com.web.gallery.entity.PhotoTagMst">
+	<delete id="delete" parameterType="com.web.gallery.entity.PhotoTagMstCondition">
 		DELETE FROM
 			photo.photo_tag_mst
 		<where>

--- a/backend/src/test/java/com/web/gallery/mapper/AccountMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/AccountMapperTest.java
@@ -37,6 +37,8 @@ import com.web.gallery.domain.common.IsDeleted;
 import com.web.gallery.domain.common.UpdatedAt;
 import com.web.gallery.domain.common.UpdatedBy;
 import com.web.gallery.entity.Account;
+import com.web.gallery.entity.AccountCondition;
+import com.web.gallery.entity.AccountUpdateTarget;
 import com.web.gallery.enumeration.AuthorityEnum;
 import com.web.gallery.enumeration.SexEnum;
 
@@ -60,7 +62,7 @@ public class AccountMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのselectで1件の場合")
 		void select_by_accountNo() {
-			Account account = Account.builder().accountNo(new AccountNo(1L)).build();
+			AccountCondition account = AccountCondition.builder().accountNo(new AccountNo(1L)).build();
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
@@ -94,7 +96,7 @@ public class AccountMapperTest {
 		@Order(2)
 		@DisplayName("正常系：削除フラグでのselectで1件の場合")
 		void select_by_isDeleted() {
-			Account account = Account.builder().isDeleted(new IsDeleted(true)).build();
+			AccountCondition account = AccountCondition.builder().isDeleted(new IsDeleted(true)).build();
 			List<Account> actual = accountMapper.select(account);
 		
 			Account expectedAccount = Account.builder()
@@ -128,7 +130,7 @@ public class AccountMapperTest {
 		@Order(3)
 		@DisplayName("正常系：アカウントIDでのselectで1件の場合")
 		void select_by_accountId() {
-			Account account = Account.builder().accountId(new AccountId("aaaaaaaa")).build();
+			AccountCondition account = AccountCondition.builder().accountId(new AccountId("aaaaaaaa")).build();
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
@@ -162,7 +164,7 @@ public class AccountMapperTest {
 		@Order(4)
 		@DisplayName("正常系：アカウント名でのselectで1件の場合")
 		void select_by_accountName() {
-			Account account = Account.builder().accountName(new AccountName("AAAAAAAA")).build();
+			AccountCondition account = AccountCondition.builder().accountName(new AccountName("AAAAAAAA")).build();
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
@@ -196,7 +198,7 @@ public class AccountMapperTest {
 		@Order(5)
 		@DisplayName("正常系：パスワードでのselectで1件の場合")
 		void select_by_password() {
-			Account account = Account.builder().password(new Password("$2a$10$password1")).build();
+			AccountCondition account = AccountCondition.builder().password(new Password("$2a$10$password1")).build();
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
@@ -230,7 +232,7 @@ public class AccountMapperTest {
 		@Order(6)
 		@DisplayName("正常系：生年月日でのselectで1件の場合")
 		void select_by_birthdate() {
-			Account account = Account.builder().birthdate(new BirthDate(LocalDate.of(1991, 2, 14))).build();
+			AccountCondition account = AccountCondition.builder().birthdate(new BirthDate(LocalDate.of(1991, 2, 14))).build();
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
@@ -264,7 +266,7 @@ public class AccountMapperTest {
 		@Order(7)
 		@DisplayName("正常系：性別区分コードでのselectで1件の場合")
 		void select_by_sexKbnCode() {
-			Account account = Account.builder().sexKbn(SexEnum.MAN).build();
+			AccountCondition account = AccountCondition.builder().sexKbn(SexEnum.MAN).build();
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
@@ -298,7 +300,7 @@ public class AccountMapperTest {
 		@Order(8)
 		@DisplayName("正常系：出身都道府県区分コードでのselectで1件の場合")
 		void select_by_birthplacePrefectureKbnCode() {
-			Account account = Account.builder().birthplacePrefectureKbnCode(new BirthplacePrefectureKbnCode("Hokkaido")).build();
+			AccountCondition account = AccountCondition.builder().birthplacePrefectureKbnCode(new BirthplacePrefectureKbnCode("Hokkaido")).build();
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
@@ -332,7 +334,7 @@ public class AccountMapperTest {
 		@Order(9)
 		@DisplayName("正常系：在住都道府県区分コードでのselectで1件の場合")
 		void select_by_residentPrefectureKbnCode() {
-			Account account = Account.builder().residentPrefectureKbnCode(new ResidentPrefectureKbnCode("Okinawa")).build();
+			AccountCondition account = AccountCondition.builder().residentPrefectureKbnCode(new ResidentPrefectureKbnCode("Okinawa")).build();
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
@@ -366,7 +368,7 @@ public class AccountMapperTest {
 		@Order(10)
 		@DisplayName("正常系：フリーメモでのselectで1件の場合")
 		void select_by_freeMemo() {
-			Account account = Account.builder().freeMemo(new FreeMemo("フリーメモ")).build();
+			AccountCondition account = AccountCondition.builder().freeMemo(new FreeMemo("フリーメモ")).build();
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
@@ -400,7 +402,7 @@ public class AccountMapperTest {
 		@Order(11)
 		@DisplayName("正常系：権限区分コードでのselectで1件の場合")
 		void select_by_authorityKbnCode() {
-			Account account = Account.builder().authorityKbn(AuthorityEnum.MINI).build();
+			AccountCondition account = AccountCondition.builder().authorityKbn(AuthorityEnum.MINI).build();
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
@@ -434,7 +436,7 @@ public class AccountMapperTest {
 		@Order(12)
 		@DisplayName("正常系：最終ログイン日時でのselectで1件の場合")
 		void select_by_lastLoginDatetime() {
-			Account account = Account.builder().lastLoginDatetime(new LastLoginDatetime(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))).build();
+			AccountCondition account = AccountCondition.builder().lastLoginDatetime(new LastLoginDatetime(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))).build();
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
@@ -468,7 +470,7 @@ public class AccountMapperTest {
 		@Order(13)
 		@DisplayName("正常系：ログイン失敗回数でのselectで1件の場合")
 		void select_by_loginFailureCount() {
-			Account account = Account.builder().loginFailureCount(new LoginFailureCount(2)).build();
+			AccountCondition account = AccountCondition.builder().loginFailureCount(new LoginFailureCount(2)).build();
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount = Account.builder()
@@ -502,7 +504,7 @@ public class AccountMapperTest {
 		@Order(14)
 		@DisplayName("正常系：selectで0件の場合")
 		void select_not_found() {
-			Account account = Account.builder().accountNo(new AccountNo(99L)).build();
+			AccountCondition account = AccountCondition.builder().accountNo(new AccountNo(99L)).build();
 			List<Account> actual = accountMapper.select(account);
 			List<Account> expected = new ArrayList<Account>();
 			
@@ -514,7 +516,7 @@ public class AccountMapperTest {
 		@Order(15)
 		@DisplayName("正常系：selectで2件以上の場合")
 		void select_accounts() {
-			Account account = Account.builder().authorityKbn(AuthorityEnum.SPECIAL).build();
+			AccountCondition account = AccountCondition.builder().authorityKbn(AuthorityEnum.SPECIAL).build();
 			List<Account> actual = accountMapper.select(account);
 			
 			Account expectedAccount1 = Account.builder()
@@ -569,7 +571,7 @@ public class AccountMapperTest {
 		@Order(16)
 		@DisplayName("正常系：複数の条件でselectする場合")
 		void select_some_conditions() {
-			Account account = Account.builder()
+			AccountCondition account = AccountCondition.builder()
 					.accountId(new AccountId("llllllll"))
 					.sexKbn(SexEnum.WOMAN)
 					.birthplacePrefectureKbnCode(new BirthplacePrefectureKbnCode("Okinawa"))
@@ -616,7 +618,7 @@ public class AccountMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのcount")
 		void count_by_accountNo() {
-			Account account = Account.builder().accountNo(new AccountNo(1L)).build();
+			AccountCondition account = AccountCondition.builder().accountNo(new AccountNo(1L)).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(1, actual);
 		}
@@ -625,7 +627,7 @@ public class AccountMapperTest {
 		@Order(2)
 		@DisplayName("正常系：削除フラグでのcount")
 		void count_by_isDeleted() {
-			Account account = Account.builder().isDeleted(new IsDeleted(true)).build();
+			AccountCondition account = AccountCondition.builder().isDeleted(new IsDeleted(true)).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(1, actual);
 		}
@@ -634,7 +636,7 @@ public class AccountMapperTest {
 		@Order(3)
 		@DisplayName("正常系：アカウントIDでのcount")
 		void count_by_accountId() {
-			Account account = Account.builder().accountId(new AccountId("aaaaaaaa")).build();
+			AccountCondition account = AccountCondition.builder().accountId(new AccountId("aaaaaaaa")).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(1, actual);
 		}
@@ -643,7 +645,7 @@ public class AccountMapperTest {
 		@Order(4)
 		@DisplayName("正常系：アカウント名でのcount")
 		void count_by_accountName() {
-			Account account = Account.builder().accountName(new AccountName("AAAAAAAA")).build();
+			AccountCondition account = AccountCondition.builder().accountName(new AccountName("AAAAAAAA")).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(1, actual);
 		}
@@ -652,7 +654,7 @@ public class AccountMapperTest {
 		@Order(5)
 		@DisplayName("正常系：パスワードでのcount")
 		void count_by_password() {
-			Account account = Account.builder().password(new Password("$2a$10$password1")).build();
+			AccountCondition account = AccountCondition.builder().password(new Password("$2a$10$password1")).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(1, actual);
 		}
@@ -661,7 +663,7 @@ public class AccountMapperTest {
 		@Order(6)
 		@DisplayName("正常系：生年月日でのcount")
 		void count_by_birthdate() {
-			Account account = Account.builder().birthdate(new BirthDate(LocalDate.of(1991, 2, 14))).build();
+			AccountCondition account = AccountCondition.builder().birthdate(new BirthDate(LocalDate.of(1991, 2, 14))).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(1, actual);
 		}
@@ -670,7 +672,7 @@ public class AccountMapperTest {
 		@Order(7)
 		@DisplayName("正常系：性別区分コードでのcount")
 		void count_by_sexKbnCode() {
-			Account account = Account.builder().sexKbn(SexEnum.MAN).build();
+			AccountCondition account = AccountCondition.builder().sexKbn(SexEnum.MAN).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(1, actual);
 		}
@@ -679,7 +681,7 @@ public class AccountMapperTest {
 		@Order(8)
 		@DisplayName("正常系：出身都道府県区分コードでのcount")
 		void count_by_birthplacePrefectureKbnCode() {
-			Account account = Account.builder().birthplacePrefectureKbnCode(new BirthplacePrefectureKbnCode("Hokkaido")).build();
+			AccountCondition account = AccountCondition.builder().birthplacePrefectureKbnCode(new BirthplacePrefectureKbnCode("Hokkaido")).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(1, actual);
 		}
@@ -688,7 +690,7 @@ public class AccountMapperTest {
 		@Order(9)
 		@DisplayName("正常系：在住都道府県区分コードでのcount")
 		void count_by_residentPrefectureKbnCode() {
-			Account account = Account.builder().residentPrefectureKbnCode(new ResidentPrefectureKbnCode("Okinawa")).build();
+			AccountCondition account = AccountCondition.builder().residentPrefectureKbnCode(new ResidentPrefectureKbnCode("Okinawa")).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(1, actual);
 		}
@@ -697,7 +699,7 @@ public class AccountMapperTest {
 		@Order(10)
 		@DisplayName("正常系：フリーメモでのcount")
 		void count_by_freeMemo() {
-			Account account = Account.builder().freeMemo(new FreeMemo("フリーメモ")).build();
+			AccountCondition account = AccountCondition.builder().freeMemo(new FreeMemo("フリーメモ")).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(1, actual);
 		}
@@ -706,7 +708,7 @@ public class AccountMapperTest {
 		@Order(11)
 		@DisplayName("正常系：権限区分コードでのcount")
 		void count_by_authorityKbnCode() {
-			Account account = Account.builder().authorityKbn(AuthorityEnum.MINI).build();
+			AccountCondition account = AccountCondition.builder().authorityKbn(AuthorityEnum.MINI).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(1, actual);
 		}
@@ -715,7 +717,7 @@ public class AccountMapperTest {
 		@Order(12)
 		@DisplayName("正常系：最終ログイン日時でのcount")
 		void count_by_lastLoginDatetime() {
-			Account account = Account.builder()
+			AccountCondition account = AccountCondition.builder()
 					.lastLoginDatetime(new LastLoginDatetime(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
 					.build();
 			Integer actual = accountMapper.count(account);
@@ -726,7 +728,7 @@ public class AccountMapperTest {
 		@Order(13)
 		@DisplayName("正常系：ログイン失敗回数でのcount")
 		void count_by_loginFailureCount() {
-			Account account = Account.builder().loginFailureCount(new LoginFailureCount(2)).build();
+			AccountCondition account = AccountCondition.builder().loginFailureCount(new LoginFailureCount(2)).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(1, actual);
 		}
@@ -735,7 +737,7 @@ public class AccountMapperTest {
 		@Order(14)
 		@DisplayName("正常系：countで0件の場合")
 		void count_not_found() {
-			Account account = Account.builder().accountNo(new AccountNo(99L)).build();
+			AccountCondition account = AccountCondition.builder().accountNo(new AccountNo(99L)).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(0, actual);
 		}
@@ -744,7 +746,7 @@ public class AccountMapperTest {
 		@Order(15)
 		@DisplayName("正常系：countで2件以上の場合")
 		void count_accounts() {
-			Account account = Account.builder().authorityKbn(AuthorityEnum.SPECIAL).build();
+			AccountCondition account = AccountCondition.builder().authorityKbn(AuthorityEnum.SPECIAL).build();
 			Integer actual = accountMapper.count(account);
 			assertEquals(2, actual);
 		}
@@ -753,7 +755,7 @@ public class AccountMapperTest {
 		@Order(16)
 		@DisplayName("正常系：複数の条件でcountする場合")
 		void count_some_conditions() {
-			Account account = Account.builder()
+			AccountCondition account = AccountCondition.builder()
 					.accountId(new AccountId("llllllll"))
 					.sexKbn(SexEnum.WOMAN)
 					.birthplacePrefectureKbnCode(new BirthplacePrefectureKbnCode("Okinawa"))
@@ -876,8 +878,8 @@ public class AccountMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのupdate")
 		void update_by_accountNo() {
-			Account conditionAccount = Account.builder().accountNo(new AccountNo(1L)).build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			AccountCondition conditionAccount = AccountCondition.builder().accountNo(new AccountNo(1L)).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(1)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
@@ -907,8 +909,8 @@ public class AccountMapperTest {
 		@Order(2)
 		@DisplayName("正常系：削除フラグでのupdate")
 		void update_by_isDeleted() {
-			Account conditionAccount = Account.builder().isDeleted(new IsDeleted(true)).build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			AccountCondition conditionAccount = AccountCondition.builder().isDeleted(new IsDeleted(true)).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(1)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
@@ -938,8 +940,8 @@ public class AccountMapperTest {
 		@Order(3)
 		@DisplayName("正常系：アカウントIDでのupdate")
 		void update_by_accountId() {
-			Account conditionAccount = Account.builder().accountId(new AccountId("aaaaaaaa")).build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			AccountCondition conditionAccount = AccountCondition.builder().accountId(new AccountId("aaaaaaaa")).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(1)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
@@ -969,8 +971,8 @@ public class AccountMapperTest {
 		@Order(4)
 		@DisplayName("正常系：アカウント名でのupdate")
 		void update_by_accountName() {
-			Account conditionAccount = Account.builder().accountName(new AccountName("AAAAAAAA")).build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			AccountCondition conditionAccount = AccountCondition.builder().accountName(new AccountName("AAAAAAAA")).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(1)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
@@ -1000,8 +1002,8 @@ public class AccountMapperTest {
 		@Order(5)
 		@DisplayName("正常系：パスワードでのupdate")
 		void update_by_password() {
-			Account conditionAccount = Account.builder().password(new Password("$2a$10$password1")).build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			AccountCondition conditionAccount = AccountCondition.builder().password(new Password("$2a$10$password1")).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(1)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
@@ -1031,8 +1033,8 @@ public class AccountMapperTest {
 		@Order(6)
 		@DisplayName("正常系：生年月日でのupdate")
 		void update_by_birthdate() {
-			Account conditionAccount = Account.builder().birthdate(new BirthDate(LocalDate.of(1991, 2, 14))).build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			AccountCondition conditionAccount = AccountCondition.builder().birthdate(new BirthDate(LocalDate.of(1991, 2, 14))).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(1)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
@@ -1062,8 +1064,8 @@ public class AccountMapperTest {
 		@Order(7)
 		@DisplayName("正常系：性別区分コードでのupdate")
 		void update_by_sexKbnCode() {
-			Account conditionAccount = Account.builder().sexKbn(SexEnum.MAN).build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			AccountCondition conditionAccount = AccountCondition.builder().sexKbn(SexEnum.MAN).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(1)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
@@ -1093,8 +1095,8 @@ public class AccountMapperTest {
 		@Order(8)
 		@DisplayName("正常系：出身都道府県区分コードでのupdate")
 		void update_by_birthplacePrefectureKbnCode() {
-			Account conditionAccount = Account.builder().birthplacePrefectureKbnCode(new BirthplacePrefectureKbnCode("Hokkaido")).build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			AccountCondition conditionAccount = AccountCondition.builder().birthplacePrefectureKbnCode(new BirthplacePrefectureKbnCode("Hokkaido")).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(1)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
@@ -1124,8 +1126,8 @@ public class AccountMapperTest {
 		@Order(9)
 		@DisplayName("正常系：在住都道府県区分コードでのupdate")
 		void update_by_residentPrefectureKbnCode() {
-			Account conditionAccount = Account.builder().residentPrefectureKbnCode(new ResidentPrefectureKbnCode("Okinawa")).build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			AccountCondition conditionAccount = AccountCondition.builder().residentPrefectureKbnCode(new ResidentPrefectureKbnCode("Okinawa")).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(1)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
@@ -1155,8 +1157,8 @@ public class AccountMapperTest {
 		@Order(10)
 		@DisplayName("正常系：フリーメモでのupdate")
 		void update_by_freeMemo() {
-			Account conditionAccount = Account.builder().freeMemo(new FreeMemo("フリーメモ")).build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			AccountCondition conditionAccount = AccountCondition.builder().freeMemo(new FreeMemo("フリーメモ")).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(1)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
@@ -1186,8 +1188,8 @@ public class AccountMapperTest {
 		@Order(11)
 		@DisplayName("正常系：権限区分コードでのupdate")
 		void update_by_authorityKbnCode() {
-			Account conditionAccount = Account.builder().authorityKbn(AuthorityEnum.MINI).build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			AccountCondition conditionAccount = AccountCondition.builder().authorityKbn(AuthorityEnum.MINI).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(1)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
@@ -1217,10 +1219,10 @@ public class AccountMapperTest {
 		@Order(12)
 		@DisplayName("正常系：最終ログイン日時でのupdate")
 		void update_by_lastLoginDatetime() {
-			Account conditionAccount = Account.builder()
+			AccountCondition conditionAccount = AccountCondition.builder()
 					.lastLoginDatetime(new LastLoginDatetime(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
 					.build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(1)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
@@ -1250,8 +1252,8 @@ public class AccountMapperTest {
 		@Order(13)
 		@DisplayName("正常系：ログイン失敗回数でのupdate")
 		void update_by_loginFailureCounte() {
-			Account conditionAccount = Account.builder().loginFailureCount(new LoginFailureCount(2)).build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(0)).build();
+			AccountCondition conditionAccount = AccountCondition.builder().loginFailureCount(new LoginFailureCount(2)).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(0)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
@@ -1281,8 +1283,8 @@ public class AccountMapperTest {
 		@Order(14)
 		@DisplayName("正常系：更新対象のレコードなし")
 		void update_not_found() {
-			Account conditionAccount = Account.builder().accountNo(new AccountNo(99L)).build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(0)).build();
+			AccountCondition conditionAccount = AccountCondition.builder().accountNo(new AccountNo(99L)).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(0)).build();
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(0, actual);
 			
@@ -1294,8 +1296,8 @@ public class AccountMapperTest {
 		@Order(15)
 		@DisplayName("正常系：2件以上updateの場合")
 		void update_accounts() {
-			Account conditionAccount = Account.builder().authorityKbn(AuthorityEnum.SPECIAL).build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(1)).build();
+			AccountCondition conditionAccount = AccountCondition.builder().authorityKbn(AuthorityEnum.SPECIAL).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(1)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(2, actual);
@@ -1343,14 +1345,14 @@ public class AccountMapperTest {
 		@Order(16)
 		@DisplayName("正常系：複数の条件でupdateする場合")
 		void update_some_conditions() {
-			Account conditionAccount = Account.builder()
+			AccountCondition conditionAccount = AccountCondition.builder()
 					.accountId(new AccountId("llllllll"))
 					.sexKbn(SexEnum.WOMAN)
 					.birthplacePrefectureKbnCode(new BirthplacePrefectureKbnCode("Okinawa"))
 					.residentPrefectureKbnCode(new ResidentPrefectureKbnCode("Tokyo"))
 					.freeMemo(new FreeMemo("よろしく"))
 					.build();
-			Account targetAccount = Account.builder().loginFailureCount(new LoginFailureCount(0)).build();
+			AccountUpdateTarget targetAccount = AccountUpdateTarget.builder().loginFailureCount(new LoginFailureCount(0)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = accountMapper.update(conditionAccount, targetAccount);
 			assertEquals(1, actual);
@@ -1411,7 +1413,7 @@ public class AccountMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのdelete")
 		void delete_by_accountNo() {
-			Account deleteAccount = Account.builder().accountNo(new AccountNo(1L)).build();
+			AccountCondition deleteAccount = AccountCondition.builder().accountNo(new AccountNo(1L)).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(1, actual);
 			
@@ -1426,7 +1428,7 @@ public class AccountMapperTest {
 		@Order(2)
 		@DisplayName("正常系：削除フラグでのdelete")
 		void delete_by_isDeleted() {
-			Account deleteAccount = Account.builder().isDeleted(new IsDeleted(true)).build();
+			AccountCondition deleteAccount = AccountCondition.builder().isDeleted(new IsDeleted(true)).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(1, actual);
 			
@@ -1441,7 +1443,7 @@ public class AccountMapperTest {
 		@Order(3)
 		@DisplayName("正常系：アカウントIDでのdelete")
 		void delete_by_accountId() {
-			Account deleteAccount = Account.builder().accountId(new AccountId("aaaaaaaa")).build();
+			AccountCondition deleteAccount = AccountCondition.builder().accountId(new AccountId("aaaaaaaa")).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(1, actual);
 			
@@ -1456,7 +1458,7 @@ public class AccountMapperTest {
 		@Order(4)
 		@DisplayName("正常系：アカウント名でのdelete")
 		void delete_by_accountName() {
-			Account deleteAccount = Account.builder().accountName(new AccountName("AAAAAAAA")).build();
+			AccountCondition deleteAccount = AccountCondition.builder().accountName(new AccountName("AAAAAAAA")).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(1, actual);
 			
@@ -1471,7 +1473,7 @@ public class AccountMapperTest {
 		@Order(5)
 		@DisplayName("正常系：パスワードでのdelete")
 		void delete_by_password() {
-			Account deleteAccount = Account.builder().password(new Password("$2a$10$password1")).build();
+			AccountCondition deleteAccount = AccountCondition.builder().password(new Password("$2a$10$password1")).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(1, actual);
 			
@@ -1486,7 +1488,7 @@ public class AccountMapperTest {
 		@Order(6)
 		@DisplayName("正常系：生年月日でのdelete")
 		void delete_by_birthdate() {
-			Account deleteAccount = Account.builder().birthdate(new BirthDate(LocalDate.of(1991, 2, 14))).build();
+			AccountCondition deleteAccount = AccountCondition.builder().birthdate(new BirthDate(LocalDate.of(1991, 2, 14))).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(1, actual);
 			
@@ -1501,7 +1503,7 @@ public class AccountMapperTest {
 		@Order(7)
 		@DisplayName("正常系：性別区分コードでのdelete")
 		void delete_by_sexKbnCode() {
-			Account deleteAccount = Account.builder().sexKbn(SexEnum.MAN).build();
+			AccountCondition deleteAccount = AccountCondition.builder().sexKbn(SexEnum.MAN).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(1, actual);
 			
@@ -1516,7 +1518,7 @@ public class AccountMapperTest {
 		@Order(8)
 		@DisplayName("正常系：出身都道府県区分コードでのdelete")
 		void delete_by_birthplacePrefectureKbnCode() {
-			Account deleteAccount = Account.builder().birthplacePrefectureKbnCode(new BirthplacePrefectureKbnCode("Hokkaido")).build();
+			AccountCondition deleteAccount = AccountCondition.builder().birthplacePrefectureKbnCode(new BirthplacePrefectureKbnCode("Hokkaido")).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(1, actual);
 			
@@ -1531,7 +1533,7 @@ public class AccountMapperTest {
 		@Order(9)
 		@DisplayName("正常系：在住都道府県区分コードでのdelete")
 		void delete_by_residentPrefectureKbnCode() {
-			Account deleteAccount = Account.builder().residentPrefectureKbnCode(new ResidentPrefectureKbnCode("Okinawa")).build();
+			AccountCondition deleteAccount = AccountCondition.builder().residentPrefectureKbnCode(new ResidentPrefectureKbnCode("Okinawa")).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(1, actual);
 			
@@ -1546,7 +1548,7 @@ public class AccountMapperTest {
 		@Order(10)
 		@DisplayName("正常系：フリーメモでのdelete")
 		void delete_by_freeMemo() {
-			Account deleteAccount = Account.builder().freeMemo(new FreeMemo("フリーメモ")).build();
+			AccountCondition deleteAccount = AccountCondition.builder().freeMemo(new FreeMemo("フリーメモ")).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(1, actual);
 			
@@ -1561,7 +1563,7 @@ public class AccountMapperTest {
 		@Order(11)
 		@DisplayName("正常系：権限区分コードでのdelete")
 		void delete_by_authorityKbnCode() {
-			Account deleteAccount = Account.builder().authorityKbn(AuthorityEnum.MINI).build();
+			AccountCondition deleteAccount = AccountCondition.builder().authorityKbn(AuthorityEnum.MINI).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(1, actual);
 			
@@ -1576,7 +1578,7 @@ public class AccountMapperTest {
 		@Order(12)
 		@DisplayName("正常系：最終ログイン日時でのdelete")
 		void delete_by_lastLoginDatetime() {
-			Account deleteAccount = Account.builder()
+			AccountCondition deleteAccount = AccountCondition.builder()
 					.lastLoginDatetime(new LastLoginDatetime(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
 					.build();
 			Integer actual = accountMapper.delete(deleteAccount);
@@ -1593,7 +1595,7 @@ public class AccountMapperTest {
 		@Order(13)
 		@DisplayName("正常系：ログイン失敗回数でのdelete")
 		void delete_by_loginFailureCount() {
-			Account deleteAccount = Account.builder().loginFailureCount(new LoginFailureCount(2)).build();
+			AccountCondition deleteAccount = AccountCondition.builder().loginFailureCount(new LoginFailureCount(2)).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(1, actual);
 			
@@ -1608,7 +1610,7 @@ public class AccountMapperTest {
 		@Order(14)
 		@DisplayName("正常系：削除対象のレコードなし")
 		void delete_not_found() {
-			Account deleteAccount = Account.builder().accountNo(new AccountNo(99L)).build();
+			AccountCondition deleteAccount = AccountCondition.builder().accountNo(new AccountNo(99L)).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(0, actual);
 			
@@ -1623,7 +1625,7 @@ public class AccountMapperTest {
 		@Order(15)
 		@DisplayName("正常系：2件以上deleteする場合")
 		void delete_accounts() {
-			Account deleteAccount = Account.builder().authorityKbn(AuthorityEnum.SPECIAL).build();
+			AccountCondition deleteAccount = AccountCondition.builder().authorityKbn(AuthorityEnum.SPECIAL).build();
 			Integer actual = accountMapper.delete(deleteAccount);
 			assertEquals(2, actual);
 			
@@ -1638,7 +1640,7 @@ public class AccountMapperTest {
 		@Order(16)
 		@DisplayName("正常系：複数の条件でdeleteする場合")
 		void delete_some_conditions() {
-			Account deleteAccount = Account.builder()
+			AccountCondition deleteAccount = AccountCondition.builder()
 					.accountId(new AccountId("llllllll"))
 					.sexKbn(SexEnum.WOMAN)
 					.birthplacePrefectureKbnCode(new BirthplacePrefectureKbnCode("Okinawa"))
@@ -1676,7 +1678,7 @@ public class AccountMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントIDが一致するアカウントが存在する")
 		void isExistAccount_by_accountId_exists() {
-			Account account = Account.builder().accountId(new AccountId("aaaaaaaa")).build();
+			AccountCondition account = AccountCondition.builder().accountId(new AccountId("aaaaaaaa")).build();
 			Boolean isExist = accountMapper.isExistAccount(account);
 			assertTrue(isExist);
 		}
@@ -1685,7 +1687,7 @@ public class AccountMapperTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントIDが一致するアカウントが存在しない")
 		void isExistAccount_by_accountId_not_exist() {
-			Account account = Account.builder().accountId(new AccountId("xxxxxxxx")).build();
+			AccountCondition account = AccountCondition.builder().accountId(new AccountId("xxxxxxxx")).build();
 			Boolean isExist = accountMapper.isExistAccount(account);
 			assertFalse(isExist);
 		}
@@ -1694,7 +1696,7 @@ public class AccountMapperTest {
 		@Order(3)
 		@DisplayName("正常系：アカウント番号以外で、アカウントIDが一致するアカウントが存在しない")
 		void isExistAccount_by_accountId_and_accountNo_exists() {
-			Account account = Account.builder()
+			AccountCondition account = AccountCondition.builder()
 					.accountNo(new AccountNo(1L))
 					.accountId(new AccountId("aaaaaaaa"))
 					.build();
@@ -1705,7 +1707,7 @@ public class AccountMapperTest {
 		@Test
 		@DisplayName("正常系：アカウント番号以外で、アカウントIDが一致するアカウントが存在する")
 		void isExistAccount_by_accountId_and_accountNo_not_exist() {
-			Account account = Account.builder()
+			AccountCondition account = AccountCondition.builder()
 					.accountNo(new AccountNo(1L))
 					.accountId(new AccountId("bbbbbbbb"))
 					.build();

--- a/backend/src/test/java/com/web/gallery/mapper/KbmMstMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/KbmMstMapperTest.java
@@ -34,6 +34,7 @@ import com.web.gallery.domain.common.KbnGroupJapaneseName;
 import com.web.gallery.domain.common.KbnJapaneseName;
 import com.web.gallery.domain.common.SortOrder;
 import com.web.gallery.entity.KbnMst;
+import com.web.gallery.entity.KbnMstCondition;
 
 @MybatisTest
 @ActiveProfiles("test")
@@ -52,7 +53,7 @@ public class KbmMstMapperTest {
 		@Order(1)
 		@DisplayName("正常系：区分クラスコードでのselectで1件以上の場合")
 		void select_by_kbnClassCode() {
-			KbnMst kbnMst = KbnMst.builder().kbnClassCode(new KbnClassCode("sex")).build();
+			KbnMstCondition kbnMst = KbnMstCondition.builder().kbnClassCode(new KbnClassCode("sex")).build();
 			
 			List<KbnMst> actual = kbnMstMapper.select(kbnMst);
 			
@@ -101,7 +102,7 @@ public class KbmMstMapperTest {
 		@Order(2)
 		@DisplayName("正常系：区分コードでのselectで1件以上の場合")
 		void select_by_kbnCode() {
-			KbnMst kbnMst = KbnMst.builder().kbnCode(new KbnCode("man")).build();
+			KbnMstCondition kbnMst = KbnMstCondition.builder().kbnCode(new KbnCode("man")).build();
 			
 			List<KbnMst> actual = kbnMstMapper.select(kbnMst);
 			
@@ -133,7 +134,7 @@ public class KbmMstMapperTest {
 		@Order(3)
 		@DisplayName("正常系：並び順でのselectで1件の場合")
 		void select_by_sortOrder() {
-			KbnMst kbnMst = KbnMst.builder().sortOrder(new SortOrder(47)).build();
+			KbnMstCondition kbnMst = KbnMstCondition.builder().sortOrder(new SortOrder(47)).build();
 			
 			List<KbnMst> actual = kbnMstMapper.select(kbnMst);
 			
@@ -165,7 +166,7 @@ public class KbmMstMapperTest {
 		@Order(4)
 		@DisplayName("正常系：区分グループコードでのselectで1件の場合")
 		void select_by_kbnGroupCode() {
-			KbnMst kbnMst = KbnMst.builder().kbnGroupCode(new KbnGroupCode("Shikoku")).build();
+			KbnMstCondition kbnMst = KbnMstCondition.builder().kbnGroupCode(new KbnGroupCode("Shikoku")).build();
 			
 			List<KbnMst> actual = kbnMstMapper.select(kbnMst);
 			
@@ -245,7 +246,7 @@ public class KbmMstMapperTest {
 		@Order(5)
 		@DisplayName("正常系：区分クラス日本語名でのselectで1件の場合")
 		void select_by_kbnClassJapaneseName() {
-			KbnMst kbnMst = KbnMst.builder().kbnClassJapaneseName(new KbnClassJapaneseName("性別")).build();
+			KbnMstCondition kbnMst = KbnMstCondition.builder().kbnClassJapaneseName(new KbnClassJapaneseName("性別")).build();
 			
 			List<KbnMst> actual = kbnMstMapper.select(kbnMst);
 			
@@ -294,7 +295,7 @@ public class KbmMstMapperTest {
 		@Order(6)
 		@DisplayName("正常系：区分グループ日本語名でのselectで1件の場合")
 		void select_by_kbnGroupJapaneseName() {
-			KbnMst kbnMst = KbnMst.builder().kbnGroupJapaneseName(new KbnGroupJapaneseName("四国")).build();
+			KbnMstCondition kbnMst = KbnMstCondition.builder().kbnGroupJapaneseName(new KbnGroupJapaneseName("四国")).build();
 			
 			List<KbnMst> actual = kbnMstMapper.select(kbnMst);
 			
@@ -374,7 +375,7 @@ public class KbmMstMapperTest {
 		@Order(7)
 		@DisplayName("正常系：区分日本語名でのselectで1件の場合")
 		void select_by_kbnJapaneseName() {
-			KbnMst kbnMst = KbnMst.builder().kbnJapaneseName(new KbnJapaneseName("男性")).build();
+			KbnMstCondition kbnMst = KbnMstCondition.builder().kbnJapaneseName(new KbnJapaneseName("男性")).build();
 			
 			List<KbnMst> actual = kbnMstMapper.select(kbnMst);
 			
@@ -406,7 +407,7 @@ public class KbmMstMapperTest {
 		@Order(8)
 		@DisplayName("正常系：区分クラス英語名でのselectで1件の場合")
 		void select_by_kbnClassEnglishName() {
-			KbnMst kbnMst = KbnMst.builder().kbnClassEnglishName(new KbnClassEnglishName("sex")).build();
+			KbnMstCondition kbnMst = KbnMstCondition.builder().kbnClassEnglishName(new KbnClassEnglishName("sex")).build();
 			
 			List<KbnMst> actual = kbnMstMapper.select(kbnMst);
 			
@@ -455,7 +456,7 @@ public class KbmMstMapperTest {
 		@Order(9)
 		@DisplayName("正常系：区分グループ英語名でのselectで1件の場合")
 		void select_by_kbnGroupEnglishName() {
-			KbnMst kbnMst = KbnMst.builder().kbnGroupEnglishName(new KbnGroupEnglishName("Shikoku")).build();
+			KbnMstCondition kbnMst = KbnMstCondition.builder().kbnGroupEnglishName(new KbnGroupEnglishName("Shikoku")).build();
 			
 			List<KbnMst> actual = kbnMstMapper.select(kbnMst);
 			
@@ -535,7 +536,7 @@ public class KbmMstMapperTest {
 		@Order(10)
 		@DisplayName("正常系：区分英語名でのselectで1件の場合")
 		void select_by_kbnEnglishName() {
-			KbnMst kbnMst = KbnMst.builder().kbnEnglishName(new KbnEnglishName("man")).build();
+			KbnMstCondition kbnMst = KbnMstCondition.builder().kbnEnglishName(new KbnEnglishName("man")).build();
 			
 			List<KbnMst> actual = kbnMstMapper.select(kbnMst);
 			
@@ -567,7 +568,7 @@ public class KbmMstMapperTest {
 		@Order(11)
 		@DisplayName("正常系：説明でのselectで1件の場合")
 		void select_by_explanation() {
-			KbnMst kbnMst = KbnMst.builder().explanation(new Explanation("サイトを管理・運営する人")).build();
+			KbnMstCondition kbnMst = KbnMstCondition.builder().explanation(new Explanation("サイトを管理・運営する人")).build();
 			
 			List<KbnMst> actual = kbnMstMapper.select(kbnMst);
 			
@@ -599,7 +600,7 @@ public class KbmMstMapperTest {
 		@Order(12)
 		@DisplayName("正常系：selectで0件の場合")
 		void select_not_found() {
-			KbnMst kbnMst = KbnMst.builder().kbnCode(new KbnCode("superman")).build();
+			KbnMstCondition kbnMst = KbnMstCondition.builder().kbnCode(new KbnCode("superman")).build();
 			
 			List<KbnMst> actual = kbnMstMapper.select(kbnMst);
 			List<KbnMst> expected = new ArrayList<KbnMst>();
@@ -612,7 +613,7 @@ public class KbmMstMapperTest {
 		@Order(13)
 		@DisplayName("正常系：selectで2件以上の場合")
 		void select_kbnMsts() {
-			KbnMst kbnMst = KbnMst.builder().kbnClassCode(new KbnClassCode("sex")).build();
+			KbnMstCondition kbnMst = KbnMstCondition.builder().kbnClassCode(new KbnClassCode("sex")).build();
 			
 			List<KbnMst> actual = kbnMstMapper.select(kbnMst);
 			
@@ -661,7 +662,7 @@ public class KbmMstMapperTest {
 		@Order(14)
 		@DisplayName("正常系：複数の条件でselectする場合")
 		void select_some_conditions() {
-			KbnMst kbnMst = KbnMst.builder()
+			KbnMstCondition kbnMst = KbnMstCondition.builder()
 					.kbnClassCode(new KbnClassCode("sex"))
 					.kbnCode(new KbnCode("man"))
 					.build();

--- a/backend/src/test/java/com/web/gallery/mapper/PhotoFavoriteMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/PhotoFavoriteMapperTest.java
@@ -23,6 +23,7 @@ import com.web.gallery.domain.common.CreatedAt;
 import com.web.gallery.domain.common.CreatedBy;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.entity.PhotoFavorite;
+import com.web.gallery.entity.PhotoFavoriteCondition;
 
 @MybatisTest
 @ActiveProfiles("test")
@@ -95,7 +96,7 @@ public class PhotoFavoriteMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのdelete")
 		void delete_by_accountNo() {
-			PhotoFavorite deletePhotoFavorite = PhotoFavorite.builder().accountNo(new AccountNo(1L)).build();
+			PhotoFavoriteCondition deletePhotoFavorite = PhotoFavoriteCondition.builder().accountNo(new AccountNo(1L)).build();
 			Integer actual = photoFavoriteMapper.delete(deletePhotoFavorite);
 			assertEquals(2, actual);
 			
@@ -110,7 +111,7 @@ public class PhotoFavoriteMapperTest {
 		@Order(2)
 		@DisplayName("正常系：お気に入り写真アカウント番号でのdelete")
 		void delete_by_favoritePhotoAccountNo() {
-			PhotoFavorite deletePhotoFavorite = PhotoFavorite.builder().favoritePhotoAccountNo(new AccountNo(1L)).build();
+			PhotoFavoriteCondition deletePhotoFavorite = PhotoFavoriteCondition.builder().favoritePhotoAccountNo(new AccountNo(1L)).build();
 			Integer actual = photoFavoriteMapper.delete(deletePhotoFavorite);
 			assertEquals(3, actual);
 			
@@ -125,7 +126,7 @@ public class PhotoFavoriteMapperTest {
 		@Order(3)
 		@DisplayName("正常系：お気に入り写真番号でのdelete")
 		void delete_by_favoritePhotoNo() {
-			PhotoFavorite deletePhotoFavorite = PhotoFavorite.builder().favoritePhotoNo(new PhotoNo(1L)).build();
+			PhotoFavoriteCondition deletePhotoFavorite = PhotoFavoriteCondition.builder().favoritePhotoNo(new PhotoNo(1L)).build();
 			Integer actual = photoFavoriteMapper.delete(deletePhotoFavorite);
 			assertEquals(2, actual);
 			
@@ -140,7 +141,7 @@ public class PhotoFavoriteMapperTest {
 		@Order(4)
 		@DisplayName("正常系：削除対象のレコードなし")
 		void delete_not_found() {
-			PhotoFavorite deletePhotoFavorite = PhotoFavorite.builder().accountNo(new AccountNo(3L)).build();
+			PhotoFavoriteCondition deletePhotoFavorite = PhotoFavoriteCondition.builder().accountNo(new AccountNo(3L)).build();
 			Integer actual = photoFavoriteMapper.delete(deletePhotoFavorite);
 			assertEquals(0, actual);
 			
@@ -155,7 +156,7 @@ public class PhotoFavoriteMapperTest {
 		@Order(5)
 		@DisplayName("正常系：複数の条件でdeleteする場合")
 		void delete_some_conditions() {
-			PhotoFavorite deletePhotoFavorite = PhotoFavorite.builder()
+			PhotoFavoriteCondition deletePhotoFavorite = PhotoFavoriteCondition.builder()
 					.accountNo(new AccountNo(1L))
 					.favoritePhotoAccountNo(new AccountNo(1L))
 					.favoritePhotoNo(new PhotoNo(1L))

--- a/backend/src/test/java/com/web/gallery/mapper/PhotoMstMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/PhotoMstMapperTest.java
@@ -39,6 +39,8 @@ import com.web.gallery.domain.photo.PhotoJapaneseTitle;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.domain.photo.ShutterSpeed;
 import com.web.gallery.entity.PhotoMst;
+import com.web.gallery.entity.PhotoMstCondition;
+import com.web.gallery.entity.PhotoMstUpdateTarget;
 import com.web.gallery.enumeration.DirectionEnum;
 
 @MybatisTest
@@ -61,7 +63,7 @@ public class PhotoMstMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのcountで1件の場合")
 		void count_by_accountNo() {
-			PhotoMst photoMst = PhotoMst.builder().accountNo(new AccountNo(1L)).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().accountNo(new AccountNo(1L)).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(3, actual);
 		}
@@ -70,7 +72,7 @@ public class PhotoMstMapperTest {
 		@Order(2)
 		@DisplayName("正常系：写真番号でのcountで1件の場合")
 		void count_by_photoNo() {
-			PhotoMst photoMst = PhotoMst.builder().photoNo(new PhotoNo(1L)).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().photoNo(new PhotoNo(1L)).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(2, actual);
 		}
@@ -79,7 +81,7 @@ public class PhotoMstMapperTest {
 		@Order(3)
 		@DisplayName("正常系：削除フラグでのcountで1件以上の場合")
 		void count_by_isDeleted() {
-			PhotoMst photoMst = PhotoMst.builder().isDeleted(new IsDeleted(true)).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().isDeleted(new IsDeleted(true)).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(3, actual);
 		}
@@ -88,7 +90,7 @@ public class PhotoMstMapperTest {
 		@Order(4)
 		@DisplayName("正常系：撮影日時でのcountで1件の場合")
 		void count_by_photoAt() {
-			PhotoMst photoMst = PhotoMst.builder()
+			PhotoMstCondition photoMst = PhotoMstCondition.builder()
 					.photoAt(new PhotoAt(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(1, actual);
@@ -98,7 +100,7 @@ public class PhotoMstMapperTest {
 		@Order(5)
 		@DisplayName("正常系：ロケーション番号でのcountで1件の場合")
 		void count_by_locationNo() {
-			PhotoMst photoMst = PhotoMst.builder().locationNo(new LocationNo(1L)).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().locationNo(new LocationNo(1L)).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(1, actual);
 		}
@@ -107,7 +109,7 @@ public class PhotoMstMapperTest {
 		@Order(6)
 		@DisplayName("正常系：画像ファイルパスでのcountで1件の場合")
 		void count_by_imageFilePath() {
-			PhotoMst photoMst = PhotoMst.builder().imageFilePath(new ImageFilePath("https://www.xxx.com/DSC111.jpg")).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().imageFilePath(new ImageFilePath("https://www.xxx.com/DSC111.jpg")).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(1, actual);
 		}
@@ -116,7 +118,7 @@ public class PhotoMstMapperTest {
 		@Order(7)
 		@DisplayName("正常系：写真タイトル日本語でのcountで1件の場合")
 		void count_by_photoJapaneseTitle() {
-			PhotoMst photoMst = PhotoMst.builder().photoJapaneseTitle(new PhotoJapaneseTitle("タイトル11")).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().photoJapaneseTitle(new PhotoJapaneseTitle("タイトル11")).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(1, actual);
 		}
@@ -125,7 +127,7 @@ public class PhotoMstMapperTest {
 		@Order(8)
 		@DisplayName("正常系：写真タイトル英語でのcountで1件の場合")
 		void count_by_photoEnglishTitle() {
-			PhotoMst photoMst = PhotoMst.builder().photoEnglishTitle(new PhotoEnglishTitle("title11")).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().photoEnglishTitle(new PhotoEnglishTitle("title11")).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(1, actual);
 		}
@@ -134,7 +136,7 @@ public class PhotoMstMapperTest {
 		@Order(9)
 		@DisplayName("正常系：キャプションでのcountで1件の場合")
 		void count_by_caption() {
-			PhotoMst photoMst = PhotoMst.builder().caption(new Caption("キャプション11")).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().caption(new Caption("キャプション11")).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(1, actual);
 		}
@@ -143,7 +145,7 @@ public class PhotoMstMapperTest {
 		@Order(10)
 		@DisplayName("正常系：向き区分コードでのcountで1件の場合")
 		void count_by_directionKbnCode() {
-			PhotoMst photoMst = PhotoMst.builder().directionKbn(DirectionEnum.VERTICAL).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().directionKbn(DirectionEnum.VERTICAL).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(1, actual);
 		}
@@ -152,7 +154,7 @@ public class PhotoMstMapperTest {
 		@Order(11)
 		@DisplayName("正常系：焦点距離でのcountで1件の場合")
 		void count_by_focalLength() {
-			PhotoMst photoMst = PhotoMst.builder().focalLength(new FocalLength(24)).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().focalLength(new FocalLength(24)).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(1, actual);
 		}
@@ -161,7 +163,7 @@ public class PhotoMstMapperTest {
 		@Order(12)
 		@DisplayName("正常系：F値でのcountで1件の場合")
 		void count_by_fValue() {
-			PhotoMst photoMst = PhotoMst.builder().fValue(new FValue(BigDecimal.valueOf(8.0))).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().fValue(new FValue(BigDecimal.valueOf(8.0))).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(1, actual);
 		}
@@ -170,7 +172,7 @@ public class PhotoMstMapperTest {
 		@Order(13)
 		@DisplayName("正常系：シャッタースピードでのcountで1件の場合")
 		void count_by_shutterSpeed() {
-			PhotoMst photoMst = PhotoMst.builder().shutterSpeed(new ShutterSpeed(BigDecimal.valueOf(1))).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().shutterSpeed(new ShutterSpeed(BigDecimal.valueOf(1))).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(1, actual);
 		}
@@ -179,7 +181,7 @@ public class PhotoMstMapperTest {
 		@Order(14)
 		@DisplayName("正常系：ISOでのcountで1件の場合")
 		void count_by_iso() {
-			PhotoMst photoMst = PhotoMst.builder().iso(new Iso(100)).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().iso(new Iso(100)).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(1, actual);
 		}
@@ -188,7 +190,7 @@ public class PhotoMstMapperTest {
 		@Order(15)
 		@DisplayName("正常系：countで0件の場合")
 		void count_not_found() {
-			PhotoMst photoMst = PhotoMst.builder().accountNo(new AccountNo(100L)).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().accountNo(new AccountNo(100L)).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(0, actual);
 		}
@@ -197,7 +199,7 @@ public class PhotoMstMapperTest {
 		@Order(16)
 		@DisplayName("正常系：複数の条件でcountする場合")
 		void count_some_conditions() {
-			PhotoMst photoMst = PhotoMst.builder().accountNo(new AccountNo(1L)).photoNo(new PhotoNo(1L)).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().accountNo(new AccountNo(1L)).photoNo(new PhotoNo(1L)).build();
 			Integer actual = photoMstMapper.count(photoMst);
 			assertEquals(1, actual);
 		}
@@ -318,8 +320,8 @@ public class PhotoMstMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのupdate")
 		void update_by_accountNo() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().accountNo(new AccountNo(1L)).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder().accountNo(new AccountNo(1L)).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(3, actual);
@@ -350,8 +352,8 @@ public class PhotoMstMapperTest {
 		@Order(2)
 		@DisplayName("正常系：写真番号でのupdate")
 		void update_by_photoNo() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().photoNo(new PhotoNo(1L)).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder().photoNo(new PhotoNo(1L)).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(2, actual);
@@ -403,8 +405,8 @@ public class PhotoMstMapperTest {
 		@Order(3)
 		@DisplayName("正常系：削除フラグでのupdate")
 		void update_by_isDeleted() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().isDeleted(new IsDeleted(true)).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder().isDeleted(new IsDeleted(true)).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(3, actual);
@@ -437,9 +439,9 @@ public class PhotoMstMapperTest {
 		@Order(4)
 		@DisplayName("正常系：撮影日時でのupdate")
 		void update_by_photoAt() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder()
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder()
 					.photoAt(new PhotoAt(OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)))).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
@@ -471,8 +473,8 @@ public class PhotoMstMapperTest {
 		@Order(5)
 		@DisplayName("正常系：ロケーション番号でのupdate")
 		void update_by_locationNo() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().locationNo(new LocationNo(1L)).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder().locationNo(new LocationNo(1L)).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
@@ -504,8 +506,8 @@ public class PhotoMstMapperTest {
 		@Order(6)
 		@DisplayName("正常系：画像ファイルパスでのupdate")
 		void update_by_imageFilePath() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().imageFilePath(new ImageFilePath("https://www.xxx.com/DSC111.jpg")).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder().imageFilePath(new ImageFilePath("https://www.xxx.com/DSC111.jpg")).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
@@ -537,8 +539,8 @@ public class PhotoMstMapperTest {
 		@Order(7)
 		@DisplayName("正常系：写真タイトル日本語でのupdate")
 		void update_by_photoJapaneseTitle() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().photoJapaneseTitle(new PhotoJapaneseTitle("タイトル11")).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder().photoJapaneseTitle(new PhotoJapaneseTitle("タイトル11")).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
@@ -570,8 +572,8 @@ public class PhotoMstMapperTest {
 		@Order(8)
 		@DisplayName("正常系：写真タイトル英語でのupdate")
 		void update_by_photoEnglishTitle() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().photoEnglishTitle(new PhotoEnglishTitle("title11")).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder().photoEnglishTitle(new PhotoEnglishTitle("title11")).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
@@ -603,8 +605,8 @@ public class PhotoMstMapperTest {
 		@Order(9)
 		@DisplayName("正常系：キャプションでのcountで1件の場合")
 		void update_by_caption() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().caption(new Caption("キャプション11")).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder().caption(new Caption("キャプション11")).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
@@ -636,8 +638,8 @@ public class PhotoMstMapperTest {
 		@Order(10)
 		@DisplayName("正常系：向き区分コードでのupdate")
 		void update_by_directionKbnCode() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().directionKbn(DirectionEnum.VERTICAL).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder().directionKbn(DirectionEnum.VERTICAL).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
@@ -669,8 +671,8 @@ public class PhotoMstMapperTest {
 		@Order(11)
 		@DisplayName("正常系：焦点距離でのupdate")
 		void update_by_focalLength() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().focalLength(new FocalLength(24)).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder().focalLength(new FocalLength(24)).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
@@ -702,8 +704,8 @@ public class PhotoMstMapperTest {
 		@Order(12)
 		@DisplayName("正常系：F値でのupdate")
 		void update_by_fValue() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().fValue(new FValue(BigDecimal.valueOf(8.0))).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder().fValue(new FValue(BigDecimal.valueOf(8.0))).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
@@ -735,8 +737,8 @@ public class PhotoMstMapperTest {
 		@Order(13)
 		@DisplayName("正常系：シャッタースピードでのupdate")
 		void update_by_shutterSpeed() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().shutterSpeed(new ShutterSpeed(BigDecimal.valueOf(1))).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder().shutterSpeed(new ShutterSpeed(BigDecimal.valueOf(1))).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
@@ -768,8 +770,8 @@ public class PhotoMstMapperTest {
 		@Order(14)
 		@DisplayName("正常系：ISOでのupdate")
 		void update_by_iso() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().iso(new Iso(100)).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder().iso(new Iso(100)).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
@@ -801,8 +803,8 @@ public class PhotoMstMapperTest {
 		@Order(15)
 		@DisplayName("正常系：updateで0件の場合")
 		void update_not_found() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().accountNo(new AccountNo(100L)).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder().accountNo(new AccountNo(100L)).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(0, actual);
 			
@@ -814,8 +816,8 @@ public class PhotoMstMapperTest {
 		@Order(16)
 		@DisplayName("正常系：複数の条件でupdateする場合")
 		void update_some_conditions() {
-			PhotoMst conditionPhotoMst = PhotoMst.builder().accountNo(new AccountNo(1L)).photoNo(new PhotoNo(1L)).build();
-			PhotoMst targetPhotoMst = PhotoMst.builder().iso(new Iso(1000)).build();
+			PhotoMstCondition conditionPhotoMst = PhotoMstCondition.builder().accountNo(new AccountNo(1L)).photoNo(new PhotoNo(1L)).build();
+			PhotoMstUpdateTarget targetPhotoMst = PhotoMstUpdateTarget.builder().iso(new Iso(1000)).build();
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
 			Integer actual = photoMstMapper.update(conditionPhotoMst, targetPhotoMst);
 			assertEquals(1, actual);
@@ -854,7 +856,7 @@ public class PhotoMstMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのdeleteで複数件削除される場合")
 		void delete_by_accountNo() {
-			PhotoMst photoMst = PhotoMst.builder().accountNo(new AccountNo(1L)).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().accountNo(new AccountNo(1L)).build();
 			Integer actual = photoMstMapper.delete(photoMst);
 			assertEquals(3, actual);
 
@@ -872,7 +874,7 @@ public class PhotoMstMapperTest {
 		@Order(2)
 		@DisplayName("正常系：写真番号でのdeleteで複数件削除される場合")
 		void delete_by_photoNo() {
-			PhotoMst photoMst = PhotoMst.builder().photoNo(new PhotoNo(1L)).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().photoNo(new PhotoNo(1L)).build();
 			Integer actual = photoMstMapper.delete(photoMst);
 			assertEquals(2, actual);
 
@@ -885,7 +887,7 @@ public class PhotoMstMapperTest {
 		@Order(3)
 		@DisplayName("正常系：アカウント番号と写真番号でのdeleteで1件削除される場合")
 		void delete_by_accountNo_and_photoNo() {
-			PhotoMst photoMst = PhotoMst.builder().accountNo(new AccountNo(1L)).photoNo(new PhotoNo(1L)).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().accountNo(new AccountNo(1L)).photoNo(new PhotoNo(1L)).build();
 			Integer actual = photoMstMapper.delete(photoMst);
 			assertEquals(1, actual);
 
@@ -898,7 +900,7 @@ public class PhotoMstMapperTest {
 		@Order(4)
 		@DisplayName("正常系：該当するレコードがない場合は0件")
 		void delete_not_found() {
-			PhotoMst photoMst = PhotoMst.builder().accountNo(new AccountNo(100L)).build();
+			PhotoMstCondition photoMst = PhotoMstCondition.builder().accountNo(new AccountNo(100L)).build();
 			Integer actual = photoMstMapper.delete(photoMst);
 			assertEquals(0, actual);
 		}
@@ -937,7 +939,7 @@ public class PhotoMstMapperTest {
 		@Order(1)
 		@DisplayName("正常系：画像ファイルパスに該当する写真が1つある場合")
 		void isExistPhoto_photo_found() {
-			PhotoMst photoMst = PhotoMst.builder()
+			PhotoMstCondition photoMst = PhotoMstCondition.builder()
 					.accountNo(new AccountNo(1L))
 					.imageFilePath(new ImageFilePath("DSC111.jpg"))
 					.build();
@@ -948,7 +950,7 @@ public class PhotoMstMapperTest {
 		@Order(2)
 		@DisplayName("正常系：画像ファイルパスに該当する写真が複数ある場合")
 		void isExistPhoto_photos_found() {
-			PhotoMst photoMst = PhotoMst.builder()
+			PhotoMstCondition photoMst = PhotoMstCondition.builder()
 					.accountNo(new AccountNo(2L))
 					.imageFilePath(new ImageFilePath("DSC555.jpg"))
 					.build();
@@ -959,7 +961,7 @@ public class PhotoMstMapperTest {
 		@Order(3)
 		@DisplayName("正常系：画像ファイルパスに該当する写真があるが、削除済みの場合")
 		void isExistPhoto_found_is_deleted() {
-			PhotoMst photoMst = PhotoMst.builder()
+			PhotoMstCondition photoMst = PhotoMstCondition.builder()
 					.accountNo(new AccountNo(1L))
 					.imageFilePath(new ImageFilePath("DSC333.jpg"))
 					.build();
@@ -970,7 +972,7 @@ public class PhotoMstMapperTest {
 		@Order(4)
 		@DisplayName("正常系：画像ファイルパスに該当する写真がない場合")
 		void isExistPhoto_not_found() {
-			PhotoMst photoMst = PhotoMst.builder()
+			PhotoMstCondition photoMst = PhotoMstCondition.builder()
 					.accountNo(new AccountNo(1L))
 					.imageFilePath(new ImageFilePath("DSC999.jpg"))
 					.build();

--- a/backend/src/test/java/com/web/gallery/mapper/PhotoTagMstMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/PhotoTagMstMapperTest.java
@@ -25,6 +25,7 @@ import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.common.CreatedAt;
 import com.web.gallery.domain.common.CreatedBy;
 import com.web.gallery.entity.PhotoTagMst;
+import com.web.gallery.entity.PhotoTagMstCondition;
 import com.web.gallery.domain.photo.TagEnglishName;
 import com.web.gallery.domain.photo.TagJapaneseName;
 import com.web.gallery.domain.photo.TagNo;
@@ -50,7 +51,7 @@ public class PhotoTagMstMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのselectで1件以上の場合")
 		void select_by_accountNo() {
-			PhotoTagMst photoTagMst = PhotoTagMst.builder().accountNo(new AccountNo(1L)).build();
+			PhotoTagMstCondition photoTagMst = PhotoTagMstCondition.builder().accountNo(new AccountNo(1L)).build();
 			List<PhotoTagMst> actual = photoTagMstMapper.select(photoTagMst);
 			actual.forEach(e -> e.setId(null));
 
@@ -115,7 +116,7 @@ public class PhotoTagMstMapperTest {
 		@Order(2)
 		@DisplayName("正常系：写真番号でのselectで1件の場合")
 		void select_by_photoNo() {
-			PhotoTagMst photoTagMst = PhotoTagMst.builder().photoNo(new PhotoNo(1L)).build();
+			PhotoTagMstCondition photoTagMst = PhotoTagMstCondition.builder().photoNo(new PhotoNo(1L)).build();
 			List<PhotoTagMst> actual = photoTagMstMapper.select(photoTagMst);
 			actual.forEach(e -> e.setId(null));
 
@@ -150,7 +151,7 @@ public class PhotoTagMstMapperTest {
 		@Order(3)
 		@DisplayName("正常系：タグ番号でのselectで1件の場合")
 		void select_by_tagNo() {
-			PhotoTagMst photoTagMst = PhotoTagMst.builder().tagNo(new TagNo(1L)).build();
+			PhotoTagMstCondition photoTagMst = PhotoTagMstCondition.builder().tagNo(new TagNo(1L)).build();
 			List<PhotoTagMst> actual = photoTagMstMapper.select(photoTagMst);
 			actual.forEach(e -> e.setId(null));
 
@@ -185,7 +186,7 @@ public class PhotoTagMstMapperTest {
 		@Order(4)
 		@DisplayName("正常系：タグ日本語名でのselectで1件の場合")
 		void select_by_tagJapaneseName() {
-			PhotoTagMst photoTagMst = PhotoTagMst.builder().tagJapaneseName(new TagJapaneseName("太陽")).build();
+			PhotoTagMstCondition photoTagMst = PhotoTagMstCondition.builder().tagJapaneseName(new TagJapaneseName("太陽")).build();
 			List<PhotoTagMst> actual = photoTagMstMapper.select(photoTagMst);
 			actual.forEach(e -> e.setId(null));
 
@@ -220,7 +221,7 @@ public class PhotoTagMstMapperTest {
 		@Order(5)
 		@DisplayName("正常系：タグ英語名でのselectで1件の場合")
 		void select_by_tagEnglishName() {
-			PhotoTagMst photoTagMst = PhotoTagMst.builder().tagEnglishName(new TagEnglishName("sun")).build();
+			PhotoTagMstCondition photoTagMst = PhotoTagMstCondition.builder().tagEnglishName(new TagEnglishName("sun")).build();
 			List<PhotoTagMst> actual = photoTagMstMapper.select(photoTagMst);
 			actual.forEach(e -> e.setId(null));
 
@@ -255,7 +256,7 @@ public class PhotoTagMstMapperTest {
 		@Order(6)
 		@DisplayName("正常系：selectで0件の場合")
 		void select_not_found() {
-			PhotoTagMst photoTagMst = PhotoTagMst.builder().accountNo(new AccountNo(3L)).build();
+			PhotoTagMstCondition photoTagMst = PhotoTagMstCondition.builder().accountNo(new AccountNo(3L)).build();
 			List<PhotoTagMst> actual = photoTagMstMapper.select(photoTagMst);
 			List<PhotoTagMst> expected = new ArrayList<PhotoTagMst>();
 			assertEquals(0, actual.size());
@@ -266,7 +267,7 @@ public class PhotoTagMstMapperTest {
 		@Order(7)
 		@DisplayName("正常系：複数の条件でselectする場合")
 		void select_some_conditions() {
-			PhotoTagMst photoTagMst = PhotoTagMst.builder()
+			PhotoTagMstCondition photoTagMst = PhotoTagMstCondition.builder()
 					.accountNo(new AccountNo(1L))
 					.photoNo(new PhotoNo(1L))
 					.tagNo(new TagNo(1L))
@@ -361,7 +362,7 @@ public class PhotoTagMstMapperTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号でのdelete")
 		void delete_by_accountNo() {
-			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder().accountNo(new AccountNo(1L)).build();
+			PhotoTagMstCondition deletePhotoTagMst = PhotoTagMstCondition.builder().accountNo(new AccountNo(1L)).build();
 			Integer deleteCount = photoTagMstMapper.delete(deletePhotoTagMst);
 			assertEquals(deleteCount, 5);
 			
@@ -376,7 +377,7 @@ public class PhotoTagMstMapperTest {
 		@Order(2)
 		@DisplayName("正常系：写真番号でのdelete")
 		void delete_by_photoNo() {
-			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder().photoNo(new PhotoNo(1L)).build();
+			PhotoTagMstCondition deletePhotoTagMst = PhotoTagMstCondition.builder().photoNo(new PhotoNo(1L)).build();
 			Integer deleteCount = photoTagMstMapper.delete(deletePhotoTagMst);
 			assertEquals(deleteCount, 2);
 			
@@ -391,7 +392,7 @@ public class PhotoTagMstMapperTest {
 		@Order(3)
 		@DisplayName("正常系：タグ番号でのdelete")
 		void delete_by_tagNo() {
-			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder().tagNo(new TagNo(1L)).build();
+			PhotoTagMstCondition deletePhotoTagMst = PhotoTagMstCondition.builder().tagNo(new TagNo(1L)).build();
 			Integer actual = photoTagMstMapper.delete(deletePhotoTagMst);
 			assertEquals(2, actual);
 			
@@ -406,7 +407,7 @@ public class PhotoTagMstMapperTest {
 		@Order(4)
 		@DisplayName("正常系：タグ日本語名でのdelete")
 		void delete_by_tagJapaneseName() {
-			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder().tagJapaneseName(new TagJapaneseName("太陽")).build();
+			PhotoTagMstCondition deletePhotoTagMst = PhotoTagMstCondition.builder().tagJapaneseName(new TagJapaneseName("太陽")).build();
 			Integer actual = photoTagMstMapper.delete(deletePhotoTagMst);
 			assertEquals(2, actual);
 			
@@ -421,7 +422,7 @@ public class PhotoTagMstMapperTest {
 		@Order(5)
 		@DisplayName("正常系：タグ英語名でのdelete")
 		void delete_by_tagEnglishName() {
-			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder().tagEnglishName(new TagEnglishName("sun")).build();
+			PhotoTagMstCondition deletePhotoTagMst = PhotoTagMstCondition.builder().tagEnglishName(new TagEnglishName("sun")).build();
 			Integer actual = photoTagMstMapper.delete(deletePhotoTagMst);
 			assertEquals(2, actual);
 			
@@ -436,7 +437,7 @@ public class PhotoTagMstMapperTest {
 		@Order(6)
 		@DisplayName("正常系：deleteで0件の場合")
 		void delete_not_found() {
-			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder().accountNo(new AccountNo(3L)).build();
+			PhotoTagMstCondition deletePhotoTagMst = PhotoTagMstCondition.builder().accountNo(new AccountNo(3L)).build();
 			Integer actual = photoTagMstMapper.delete(deletePhotoTagMst);
 			assertEquals(0, actual);
 			
@@ -451,7 +452,7 @@ public class PhotoTagMstMapperTest {
 		@Order(7)
 		@DisplayName("正常系：複数の条件でdeleteする場合")
 		void delete_some_conditions() {
-			PhotoTagMst deletePhotoTagMst = PhotoTagMst.builder()
+			PhotoTagMstCondition deletePhotoTagMst = PhotoTagMstCondition.builder()
 					.accountNo(new AccountNo(1L))
 					.photoNo(new PhotoNo(1L))
 					.tagNo(new TagNo(1L))

--- a/backend/src/test/java/com/web/gallery/repository/impl/AccountRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/AccountRepositoryImplTest.java
@@ -42,6 +42,8 @@ import com.web.gallery.domain.common.UpdatedBy;
 import com.web.gallery.domain.common.UpdatedAt;
 import com.web.gallery.domain.common.IsDeleted;
 import com.web.gallery.entity.Account;
+import com.web.gallery.entity.AccountCondition;
+import com.web.gallery.entity.AccountUpdateTarget;
 import com.web.gallery.enumeration.AuthorityEnum;
 import com.web.gallery.enumeration.SexEnum;
 import com.web.gallery.exception.RegistFailureException;
@@ -93,13 +95,13 @@ public class AccountRepositoryImplTest {
 			List<Account> accountList = new ArrayList<Account>();
 			accountList.add(account);
 
-			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
+			ArgumentCaptor<AccountCondition> accountCaptor = ArgumentCaptor.forClass(AccountCondition.class);
 			doReturn(accountList).when(accountMapper).select(accountCaptor.capture());
 
 			AccountModel actual = accountRepositoryImpl.getByAccountNo(new AccountNo(1L));
 
-			verify(accountMapper).select(any(Account.class));
-			Account accountCapture = accountCaptor.getValue();
+			verify(accountMapper).select(any(AccountCondition.class));
+			AccountCondition accountCapture = accountCaptor.getValue();
 			assertEquals(new AccountNo(1L), accountCapture.getAccountNo());
 
 			assertNotNull(actual);
@@ -121,13 +123,13 @@ public class AccountRepositoryImplTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが取得できなかった場合")
 		void getByAccountNo_not_found() {
-			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
+			ArgumentCaptor<AccountCondition> accountCaptor = ArgumentCaptor.forClass(AccountCondition.class);
 			doReturn(new ArrayList<Account>()).when(accountMapper).select(accountCaptor.capture());
 
 			AccountModel actual = accountRepositoryImpl.getByAccountNo(new AccountNo(1L));
 
-			verify(accountMapper).select(any(Account.class));
-			Account accountCapture = accountCaptor.getValue();
+			verify(accountMapper).select(any(AccountCondition.class));
+			AccountCondition accountCapture = accountCaptor.getValue();
 			assertEquals(new AccountNo(1L), accountCapture.getAccountNo());
 			
 			assertNull(actual);
@@ -165,13 +167,13 @@ public class AccountRepositoryImplTest {
 			List<Account> accountList = new ArrayList<Account>();
 			accountList.add(account);
 
-			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
+			ArgumentCaptor<AccountCondition> accountCaptor = ArgumentCaptor.forClass(AccountCondition.class);
 			doReturn(accountList).when(accountMapper).select(accountCaptor.capture());
 
 			AccountModel actual = accountRepositoryImpl.getByAccountId(new AccountId("aaaaaaaa"));
 
-			verify(accountMapper).select(any(Account.class));
-			Account accountCapture = accountCaptor.getValue();
+			verify(accountMapper).select(any(AccountCondition.class));
+			AccountCondition accountCapture = accountCaptor.getValue();
 			assertEquals(new AccountId("aaaaaaaa"), accountCapture.getAccountId());
 
 			assertNotNull(actual);
@@ -193,13 +195,13 @@ public class AccountRepositoryImplTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが取得できなかった場合")
 		void getByAccountId_not_found() {
-			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
+			ArgumentCaptor<AccountCondition> accountCaptor = ArgumentCaptor.forClass(AccountCondition.class);
 			doReturn(new ArrayList<Account>()).when(accountMapper).select(accountCaptor.capture());
-			
+
 			AccountModel actual = accountRepositoryImpl.getByAccountId(new AccountId("aaaaaaaa"));
-			
-			verify(accountMapper).select(any(Account.class));
-			Account accountCapture = accountCaptor.getValue();
+
+			verify(accountMapper).select(any(AccountCondition.class));
+			AccountCondition accountCapture = accountCaptor.getValue();
 			assertEquals(new AccountId("aaaaaaaa"), accountCapture.getAccountId());
 
 			assertNull(actual);
@@ -341,21 +343,18 @@ public class AccountRepositoryImplTest {
 					.accountName(new AccountName("AAAAAAAA"))
 					.build();
 
-			ArgumentCaptor<Account> cndAccountCaptor = ArgumentCaptor.forClass(Account.class);
-			ArgumentCaptor<Account> targetAccountCaptor = ArgumentCaptor.forClass(Account.class);
+			ArgumentCaptor<AccountCondition> cndAccountCaptor = ArgumentCaptor.forClass(AccountCondition.class);
+			ArgumentCaptor<AccountUpdateTarget> targetAccountCaptor = ArgumentCaptor.forClass(AccountUpdateTarget.class);
 			doReturn(1).when(accountMapper).update(cndAccountCaptor.capture(), targetAccountCaptor.capture());
 
 			accountRepositoryImpl.update(accountModel);
 
-			verify(accountMapper).update(any(Account.class), any(Account.class));
-			Account cndAccountCapture = cndAccountCaptor.getValue();
+			verify(accountMapper).update(any(AccountCondition.class), any(AccountUpdateTarget.class));
+			AccountCondition cndAccountCapture = cndAccountCaptor.getValue();
 			assertEquals(new AccountNo(1L), cndAccountCapture.getAccountNo());
 
-			Account targetAccountCapture = targetAccountCaptor.getValue();
-			assertEquals(null, targetAccountCapture.getCreatedBy());
-			assertEquals(null, targetAccountCapture.getCreatedAt());
+			AccountUpdateTarget targetAccountCapture = targetAccountCaptor.getValue();
 			assertEquals(null, targetAccountCapture.getUpdatedBy());
-			assertEquals(null, targetAccountCapture.getUpdatedAt());
 			assertEquals(null, targetAccountCapture.getIsDeleted());
 			assertEquals(new AccountId("aaaaaaaa"), targetAccountCapture.getAccountId());
 			assertEquals(new AccountName("AAAAAAAA"), targetAccountCapture.getAccountName());
@@ -365,7 +364,6 @@ public class AccountRepositoryImplTest {
 			assertEquals(new BirthplacePrefectureKbnCode("none"), targetAccountCapture.getBirthplacePrefectureKbnCode());
 			assertEquals(new ResidentPrefectureKbnCode("none"), targetAccountCapture.getResidentPrefectureKbnCode());
 			assertEquals(new FreeMemo(""), targetAccountCapture.getFreeMemo());
-			assertEquals(null, targetAccountCapture.getAuthorityKbn());
 			assertEquals(new LastLoginDatetime(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9))), targetAccountCapture.getLastLoginDatetime());
 			assertEquals(new LoginFailureCount(0), targetAccountCapture.getLoginFailureCount());
 		}
@@ -388,22 +386,19 @@ public class AccountRepositoryImplTest {
 					.loginFailureCount(new LoginFailureCount(2))
 					.build();
 
-			ArgumentCaptor<Account> cndAccountCaptor = ArgumentCaptor.forClass(Account.class);
-			ArgumentCaptor<Account> targetAccountCaptor = ArgumentCaptor.forClass(Account.class);
+			ArgumentCaptor<AccountCondition> cndAccountCaptor = ArgumentCaptor.forClass(AccountCondition.class);
+			ArgumentCaptor<AccountUpdateTarget> targetAccountCaptor = ArgumentCaptor.forClass(AccountUpdateTarget.class);
 			doReturn(1).when(accountMapper).update(cndAccountCaptor.capture(), targetAccountCaptor.capture());
 			doReturn("$2a$10$password1").when(passwordEncoder).encode("aaaaaaaa");
 
 			accountRepositoryImpl.update(accountModel);
 
-			verify(accountMapper).update(any(Account.class), any(Account.class));
-			Account cndAccountCapture = cndAccountCaptor.getValue();
+			verify(accountMapper).update(any(AccountCondition.class), any(AccountUpdateTarget.class));
+			AccountCondition cndAccountCapture = cndAccountCaptor.getValue();
 			assertEquals(new AccountNo(1L), cndAccountCapture.getAccountNo());
 
-			Account targetAccountCapture = targetAccountCaptor.getValue();
-			assertEquals(null, targetAccountCapture.getCreatedBy());
-			assertEquals(null, targetAccountCapture.getCreatedAt());
+			AccountUpdateTarget targetAccountCapture = targetAccountCaptor.getValue();
 			assertEquals(null, targetAccountCapture.getUpdatedBy());
-			assertEquals(null, targetAccountCapture.getUpdatedAt());
 			assertEquals(null, targetAccountCapture.getIsDeleted());
 			assertEquals(new AccountId("aaaaaaaa"), targetAccountCapture.getAccountId());
 			assertEquals(new AccountName("AAAAAAAA"), targetAccountCapture.getAccountName());
@@ -413,7 +408,6 @@ public class AccountRepositoryImplTest {
 			assertEquals(new BirthplacePrefectureKbnCode("Hokkaido"), targetAccountCapture.getBirthplacePrefectureKbnCode());
 			assertEquals(new ResidentPrefectureKbnCode("Okinawa"), targetAccountCapture.getResidentPrefectureKbnCode());
 			assertEquals(new FreeMemo("フリーメモ"), targetAccountCapture.getFreeMemo());
-			assertEquals(null, targetAccountCapture.getAuthorityKbn());
 			assertEquals(new LastLoginDatetime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9))), targetAccountCapture.getLastLoginDatetime());
 			assertEquals(new LoginFailureCount(2), targetAccountCapture.getLoginFailureCount());
 		}
@@ -428,21 +422,18 @@ public class AccountRepositoryImplTest {
 					.accountName(new AccountName("AAAAAAAA"))
 					.build();
 
-			ArgumentCaptor<Account> cndAccountCaptor = ArgumentCaptor.forClass(Account.class);
-			ArgumentCaptor<Account> targetAccountCaptor = ArgumentCaptor.forClass(Account.class);
+			ArgumentCaptor<AccountCondition> cndAccountCaptor = ArgumentCaptor.forClass(AccountCondition.class);
+			ArgumentCaptor<AccountUpdateTarget> targetAccountCaptor = ArgumentCaptor.forClass(AccountUpdateTarget.class);
 			doReturn(0).when(accountMapper).update(cndAccountCaptor.capture(), targetAccountCaptor.capture());
 
 			assertThrows(UpdateFailureException.class, () -> accountRepositoryImpl.update(accountModel));
 
-			verify(accountMapper).update(any(Account.class), any(Account.class));
-			Account cndAccountCapture = cndAccountCaptor.getValue();
+			verify(accountMapper).update(any(AccountCondition.class), any(AccountUpdateTarget.class));
+			AccountCondition cndAccountCapture = cndAccountCaptor.getValue();
 			assertEquals(new AccountNo(1L), cndAccountCapture.getAccountNo());
 
-			Account targetAccountCapture = targetAccountCaptor.getValue();
-			assertEquals(null, targetAccountCapture.getCreatedBy());
-			assertEquals(null, targetAccountCapture.getCreatedAt());
+			AccountUpdateTarget targetAccountCapture = targetAccountCaptor.getValue();
 			assertEquals(null, targetAccountCapture.getUpdatedBy());
-			assertEquals(null, targetAccountCapture.getUpdatedAt());
 			assertEquals(null, targetAccountCapture.getIsDeleted());
 			assertEquals(new AccountId("aaaaaaaa"), targetAccountCapture.getAccountId());
 			assertEquals(new AccountName("AAAAAAAA"), targetAccountCapture.getAccountName());
@@ -452,7 +443,6 @@ public class AccountRepositoryImplTest {
 			assertEquals(new BirthplacePrefectureKbnCode("none"), targetAccountCapture.getBirthplacePrefectureKbnCode());
 			assertEquals(new ResidentPrefectureKbnCode("none"), targetAccountCapture.getResidentPrefectureKbnCode());
 			assertEquals(new FreeMemo(""), targetAccountCapture.getFreeMemo());
-			assertEquals(null, targetAccountCapture.getAuthorityKbn());
 			assertEquals(new LastLoginDatetime(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9))), targetAccountCapture.getLastLoginDatetime());
 			assertEquals(new LoginFailureCount(0), targetAccountCapture.getLoginFailureCount());
 		}
@@ -470,21 +460,18 @@ public class AccountRepositoryImplTest {
 					.accountNo(new AccountNo(1L))
 					.build();
 
-			ArgumentCaptor<Account> cndAccountCaptor = ArgumentCaptor.forClass(Account.class);
-			ArgumentCaptor<Account> targetAccountCaptor = ArgumentCaptor.forClass(Account.class);
+			ArgumentCaptor<AccountCondition> cndAccountCaptor = ArgumentCaptor.forClass(AccountCondition.class);
+			ArgumentCaptor<AccountUpdateTarget> targetAccountCaptor = ArgumentCaptor.forClass(AccountUpdateTarget.class);
 			doReturn(1).when(accountMapper).update(cndAccountCaptor.capture(), targetAccountCaptor.capture());
 
 			accountRepositoryImpl.updateLoginFailureCount(accountModel);
 
-			verify(accountMapper).update(any(Account.class), any(Account.class));
-			Account cndAccountCapture = cndAccountCaptor.getValue();
+			verify(accountMapper).update(any(AccountCondition.class), any(AccountUpdateTarget.class));
+			AccountCondition cndAccountCapture = cndAccountCaptor.getValue();
 			assertEquals(new AccountNo(1L), cndAccountCapture.getAccountNo());
 
-			Account targetAccountCapture = targetAccountCaptor.getValue();
-			assertEquals(null, targetAccountCapture.getCreatedBy());
-			assertEquals(null, targetAccountCapture.getCreatedAt());
+			AccountUpdateTarget targetAccountCapture = targetAccountCaptor.getValue();
 			assertEquals(null, targetAccountCapture.getUpdatedBy());
-			assertEquals(null, targetAccountCapture.getUpdatedAt());
 			assertEquals(null, targetAccountCapture.getIsDeleted());
 			assertEquals(null, targetAccountCapture.getAccountId());
 			assertEquals(null, targetAccountCapture.getAccountName());
@@ -494,7 +481,6 @@ public class AccountRepositoryImplTest {
 			assertEquals(null, targetAccountCapture.getBirthplacePrefectureKbnCode());
 			assertEquals(null, targetAccountCapture.getResidentPrefectureKbnCode());
 			assertEquals(null, targetAccountCapture.getFreeMemo());
-			assertEquals(null, targetAccountCapture.getAuthorityKbn());
 			assertEquals(null, targetAccountCapture.getLastLoginDatetime());
 			assertEquals(new LoginFailureCount(0), targetAccountCapture.getLoginFailureCount());
 		}
@@ -509,21 +495,18 @@ public class AccountRepositoryImplTest {
 					.loginFailureCount(new LoginFailureCount(2))
 					.build();
 
-			ArgumentCaptor<Account> cndAccountCaptor = ArgumentCaptor.forClass(Account.class);
-			ArgumentCaptor<Account> targetAccountCaptor = ArgumentCaptor.forClass(Account.class);
+			ArgumentCaptor<AccountCondition> cndAccountCaptor = ArgumentCaptor.forClass(AccountCondition.class);
+			ArgumentCaptor<AccountUpdateTarget> targetAccountCaptor = ArgumentCaptor.forClass(AccountUpdateTarget.class);
 			doReturn(1).when(accountMapper).update(cndAccountCaptor.capture(), targetAccountCaptor.capture());
 
 			accountRepositoryImpl.updateLoginFailureCount(accountModel);
 
-			verify(accountMapper).update(any(Account.class), any(Account.class));
-			Account cndAccountCapture = cndAccountCaptor.getValue();
+			verify(accountMapper).update(any(AccountCondition.class), any(AccountUpdateTarget.class));
+			AccountCondition cndAccountCapture = cndAccountCaptor.getValue();
 			assertEquals(new AccountNo(1L), cndAccountCapture.getAccountNo());
 
-			Account targetAccountCapture = targetAccountCaptor.getValue();
-			assertEquals(null, targetAccountCapture.getCreatedBy());
-			assertEquals(null, targetAccountCapture.getCreatedAt());
+			AccountUpdateTarget targetAccountCapture = targetAccountCaptor.getValue();
 			assertEquals(null, targetAccountCapture.getUpdatedBy());
-			assertEquals(null, targetAccountCapture.getUpdatedAt());
 			assertEquals(null, targetAccountCapture.getIsDeleted());
 			assertEquals(null, targetAccountCapture.getAccountId());
 			assertEquals(null, targetAccountCapture.getAccountName());
@@ -533,7 +516,6 @@ public class AccountRepositoryImplTest {
 			assertEquals(null, targetAccountCapture.getBirthplacePrefectureKbnCode());
 			assertEquals(null, targetAccountCapture.getResidentPrefectureKbnCode());
 			assertEquals(null, targetAccountCapture.getFreeMemo());
-			assertEquals(null, targetAccountCapture.getAuthorityKbn());
 			assertEquals(new LastLoginDatetime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9))), targetAccountCapture.getLastLoginDatetime());
 			assertEquals(new LoginFailureCount(2), targetAccountCapture.getLoginFailureCount());
 		}
@@ -546,21 +528,18 @@ public class AccountRepositoryImplTest {
 					.accountNo(new AccountNo(1L))
 					.build();
 
-			ArgumentCaptor<Account> cndAccountCaptor = ArgumentCaptor.forClass(Account.class);
-			ArgumentCaptor<Account> targetAccountCaptor = ArgumentCaptor.forClass(Account.class);
+			ArgumentCaptor<AccountCondition> cndAccountCaptor = ArgumentCaptor.forClass(AccountCondition.class);
+			ArgumentCaptor<AccountUpdateTarget> targetAccountCaptor = ArgumentCaptor.forClass(AccountUpdateTarget.class);
 			doReturn(0).when(accountMapper).update(cndAccountCaptor.capture(), targetAccountCaptor.capture());
 
 			assertThrows(UpdateFailureException.class, () -> accountRepositoryImpl.updateLoginFailureCount(accountModel));
 
-			verify(accountMapper).update(any(Account.class), any(Account.class));
-			Account cndAccountCapture = cndAccountCaptor.getValue();
+			verify(accountMapper).update(any(AccountCondition.class), any(AccountUpdateTarget.class));
+			AccountCondition cndAccountCapture = cndAccountCaptor.getValue();
 			assertEquals(new AccountNo(1L), cndAccountCapture.getAccountNo());
 			
-			Account targetAccountCapture = targetAccountCaptor.getValue();
-			assertEquals(null, targetAccountCapture.getCreatedBy());
-			assertEquals(null, targetAccountCapture.getCreatedAt());
+			AccountUpdateTarget targetAccountCapture = targetAccountCaptor.getValue();
 			assertEquals(null, targetAccountCapture.getUpdatedBy());
-			assertEquals(null, targetAccountCapture.getUpdatedAt());
 			assertEquals(null, targetAccountCapture.getIsDeleted());
 			assertEquals(null, targetAccountCapture.getAccountId());
 			assertEquals(null, targetAccountCapture.getAccountName());
@@ -570,7 +549,6 @@ public class AccountRepositoryImplTest {
 			assertEquals(null, targetAccountCapture.getBirthplacePrefectureKbnCode());
 			assertEquals(null, targetAccountCapture.getResidentPrefectureKbnCode());
 			assertEquals(null, targetAccountCapture.getFreeMemo());
-			assertEquals(null, targetAccountCapture.getAuthorityKbn());
 			assertEquals(null, targetAccountCapture.getLastLoginDatetime());
 			assertEquals(new LoginFailureCount(0), targetAccountCapture.getLoginFailureCount());
 		}
@@ -584,13 +562,13 @@ public class AccountRepositoryImplTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントを物理削除する")
 		void delete_success() {
-			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
+			ArgumentCaptor<AccountCondition> accountCaptor = ArgumentCaptor.forClass(AccountCondition.class);
 			doReturn(1).when(accountMapper).delete(accountCaptor.capture());
 
 			accountRepositoryImpl.delete(new AccountNo(1L));
 
-			verify(accountMapper, times(1)).delete(any(Account.class));
-			Account accountCapture = accountCaptor.getValue();
+			verify(accountMapper, times(1)).delete(any(AccountCondition.class));
+			AccountCondition accountCapture = accountCaptor.getValue();
 			assertEquals(new AccountNo(1L), accountCapture.getAccountNo());
 		}
 	}
@@ -603,13 +581,13 @@ public class AccountRepositoryImplTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントが存在する場合")
 		void isExistAccount_true() {
-			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
+			ArgumentCaptor<AccountCondition> accountCaptor = ArgumentCaptor.forClass(AccountCondition.class);
 			doReturn(true).when(accountMapper).isExistAccount(accountCaptor.capture());
 
 			assertTrue(accountRepositoryImpl.isExistAccount(new AccountNo(1L), new AccountId("aaaaaaaa")));
-			verify(accountMapper, times(1)).isExistAccount(any(Account.class));
+			verify(accountMapper, times(1)).isExistAccount(any(AccountCondition.class));
 
-			Account accountCapture = accountCaptor.getValue();
+			AccountCondition accountCapture = accountCaptor.getValue();
 			assertEquals(new AccountNo(1L), accountCapture.getAccountNo());
 			assertEquals(new AccountId("aaaaaaaa"), accountCapture.getAccountId());
 		}
@@ -618,13 +596,13 @@ public class AccountRepositoryImplTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが存在しない場合")
 		void isExistAccount_false() {
-			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
+			ArgumentCaptor<AccountCondition> accountCaptor = ArgumentCaptor.forClass(AccountCondition.class);
 			doReturn(false).when(accountMapper).isExistAccount(accountCaptor.capture());
 
 			assertFalse(accountRepositoryImpl.isExistAccount(new AccountNo(1L), new AccountId("aaaaaaaa")));
 			verify(accountMapper, times(1)).isExistAccount(any());
 
-			Account accountCapture = accountCaptor.getValue();
+			AccountCondition accountCapture = accountCaptor.getValue();
 			assertEquals(new AccountNo(1L), accountCapture.getAccountNo());
 			assertEquals(new AccountId("aaaaaaaa"), accountCapture.getAccountId());
 		}
@@ -681,12 +659,12 @@ public class AccountRepositoryImplTest {
 			accountList.add(account1);
 			accountList.add(account2);
 
-			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
+			ArgumentCaptor<AccountCondition> accountCaptor = ArgumentCaptor.forClass(AccountCondition.class);
 			doReturn(accountList).when(accountMapper).select(accountCaptor.capture());
 
 			AccountModelList actual = accountRepositoryImpl.getAccountList();
 
-			Account account = accountCaptor.getValue();
+			AccountCondition account = accountCaptor.getValue();
 			assertFalse(account.getIsDeleted().value());
 
 			AccountModel actualAccountModel1 = actual.stream().sorted(Comparator.comparing(m -> m.getAccountNo().value())).toList().getFirst();
@@ -724,13 +702,13 @@ public class AccountRepositoryImplTest {
 		void getAccountList_not_found() {
 			List<Account> expected = new ArrayList<Account>();
 
-			ArgumentCaptor<Account> accountCaptor = ArgumentCaptor.forClass(Account.class);
+			ArgumentCaptor<AccountCondition> accountCaptor = ArgumentCaptor.forClass(AccountCondition.class);
 			doReturn(expected).when(accountMapper).select(accountCaptor.capture());
 
 			AccountModelList actual = accountRepositoryImpl.getAccountList();
 			assertEquals(expected.size(), actual.size());
 
-			Account account = accountCaptor.getValue();
+			AccountCondition account = accountCaptor.getValue();
 			assertFalse(account.getIsDeleted().value());
 		}
 	}

--- a/backend/src/test/java/com/web/gallery/repository/impl/KbnMstRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/KbnMstRepositoryImplTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.web.gallery.entity.KbnMst;
+import com.web.gallery.entity.KbnMstCondition;
 import com.web.gallery.domain.common.KbnClassCode;
 import com.web.gallery.domain.common.KbnCode;
 import com.web.gallery.domain.common.SortOrder;
@@ -81,12 +82,12 @@ public class KbnMstRepositoryImplTest {
 					.explanation(new Explanation("沖縄は南国"))
 					.build());
 			
-			ArgumentCaptor<KbnMst> kbnMstCaptor = ArgumentCaptor.forClass(KbnMst.class);
+			ArgumentCaptor<KbnMstCondition> kbnMstCaptor = ArgumentCaptor.forClass(KbnMstCondition.class);
 			doReturn(expected).when(kbnMstMapper).select(kbnMstCaptor.capture());
 			
 			KbnMstModelList actual = kbnMstRepositoryImpl.get(new KbnClassCode(kbnClassCode));
 			
-			KbnMst kbnMstCapture = kbnMstCaptor.getValue();
+			KbnMstCondition kbnMstCapture = kbnMstCaptor.getValue();
 			assertEquals(new KbnClassCode(kbnClassCode), kbnMstCapture.getKbnClassCode());
 			
 			assertEquals(expected.size(), actual.size());
@@ -110,12 +111,12 @@ public class KbnMstRepositoryImplTest {
 			String kbnClassCode = "prefecture";
 			
 			List<KbnMst> expected = new ArrayList<KbnMst>();
-			ArgumentCaptor<KbnMst> kbnMstCaptor = ArgumentCaptor.forClass(KbnMst.class);
+			ArgumentCaptor<KbnMstCondition> kbnMstCaptor = ArgumentCaptor.forClass(KbnMstCondition.class);
 			doReturn(expected).when(kbnMstMapper).select(kbnMstCaptor.capture());
 			
 			KbnMstModelList actual = kbnMstRepositoryImpl.get(new KbnClassCode(kbnClassCode));
 
-			KbnMst kbnMstCapture = kbnMstCaptor.getValue();
+			KbnMstCondition kbnMstCapture = kbnMstCaptor.getValue();
 			assertEquals(new KbnClassCode(kbnClassCode), kbnMstCapture.getKbnClassCode());
 			assertEquals(0, actual.size());
 		}

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImplTest.java
@@ -50,6 +50,7 @@ import com.web.gallery.dto.PhotoDetailGetDto;
 import com.web.gallery.dto.PhotoDto;
 import com.web.gallery.dto.PhotoListGetDto;
 import com.web.gallery.entity.PhotoTagMst;
+import com.web.gallery.entity.PhotoTagMstCondition;
 import com.web.gallery.enumeration.DirectionEnum;
 import com.web.gallery.exception.PhotoNotFoundException;
 import com.web.gallery.mapper.PhotoDetailMapper;
@@ -91,7 +92,7 @@ public class PhotoDetailRepositoryImplTest {
 
 			List<PhotoTagMst> photoTagMstList = new ArrayList<PhotoTagMst>();
 
-			ArgumentCaptor<PhotoTagMst> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMst.class);
+			ArgumentCaptor<PhotoTagMstCondition> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMstCondition.class);
 			doReturn(photoTagMstList).when(photoTagMstMapper).select(photoTagMstCaptor.capture());
 
 			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
@@ -102,7 +103,7 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals(1L, photoListGetDtoCapture.getAccountNo());
 			assertEquals(1L, photoListGetDtoCapture.getPhotoAccountNo());
 
-			PhotoTagMst photoTagMstCapture = photoTagMstCaptor.getValue();
+			PhotoTagMstCondition photoTagMstCapture = photoTagMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoTagMstCapture.getAccountNo());
 		}
 
@@ -143,7 +144,7 @@ public class PhotoDetailRepositoryImplTest {
 
 			List<PhotoTagMst> photoTagMstList = new ArrayList<PhotoTagMst>();
 
-			ArgumentCaptor<PhotoTagMst> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMst.class);
+			ArgumentCaptor<PhotoTagMstCondition> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMstCondition.class);
 			doReturn(photoTagMstList).when(photoTagMstMapper).select(photoTagMstCaptor.capture());
 
 			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
@@ -170,7 +171,7 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals(1L, photoListGetDtoCapture.getAccountNo());
 			assertEquals(1L, photoListGetDtoCapture.getPhotoAccountNo());
 
-			PhotoTagMst photoTagMstCapture = photoTagMstCaptor.getValue();
+			PhotoTagMstCondition photoTagMstCapture = photoTagMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoTagMstCapture.getAccountNo());
 		}
 		
@@ -225,7 +226,7 @@ public class PhotoDetailRepositoryImplTest {
 					.tagEnglishName(new TagEnglishName("sea"))
 					.build());
 
-			ArgumentCaptor<PhotoTagMst> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMst.class);
+			ArgumentCaptor<PhotoTagMstCondition> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMstCondition.class);
 			doReturn(photoTagMstList).when(photoTagMstMapper).select(photoTagMstCaptor.capture());
 
 			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
@@ -260,7 +261,7 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals(1L, photoListGetDtoCapture.getAccountNo());
 			assertEquals(1L, photoListGetDtoCapture.getPhotoAccountNo());
 
-			PhotoTagMst photoTagMstCapture = photoTagMstCaptor.getValue();
+			PhotoTagMstCondition photoTagMstCapture = photoTagMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoTagMstCapture.getAccountNo());
 		}
 	}
@@ -304,7 +305,7 @@ public class PhotoDetailRepositoryImplTest {
 
 			List<PhotoTagMst> photoTagMstList = new ArrayList<PhotoTagMst>();
 
-			ArgumentCaptor<PhotoTagMst> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMst.class);
+			ArgumentCaptor<PhotoTagMstCondition> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMstCondition.class);
 			doReturn(photoTagMstList).when(photoTagMstMapper).select(photoTagMstCaptor.capture());
 
 			PhotoDetailModel actual = photoDetailRepositoryImpl.getPhotoDetail(photoDetailGetModel);
@@ -334,7 +335,7 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals(1L, photoDetailGetDtoCapture.getPhotoAccountNo());
 			assertEquals(1L, photoDetailGetDtoCapture.getPhotoNo());
 
-			PhotoTagMst photoTagMstCapture = photoTagMstCaptor.getValue();
+			PhotoTagMstCondition photoTagMstCapture = photoTagMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoTagMstCapture.getAccountNo());
 			assertEquals(1L, photoTagMstCapture.getPhotoNo().value());
 			assertNull(photoTagMstCapture.getTagNo());
@@ -391,7 +392,7 @@ public class PhotoDetailRepositoryImplTest {
 					.tagEnglishName(new TagEnglishName("sea"))
 					.build());
 
-			ArgumentCaptor<PhotoTagMst> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMst.class);
+			ArgumentCaptor<PhotoTagMstCondition> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMstCondition.class);
 			doReturn(photoTagMstList).when(photoTagMstMapper).select(photoTagMstCaptor.capture());
 
 			PhotoDetailModel actual = photoDetailRepositoryImpl.getPhotoDetail(photoDetailGetModel);
@@ -422,7 +423,7 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals(1L, photoDetailGetDtoCapture.getPhotoAccountNo());
 			assertEquals(1L, photoDetailGetDtoCapture.getPhotoNo());
 
-			PhotoTagMst photoTagMstCapture = photoTagMstCaptor.getValue();
+			PhotoTagMstCondition photoTagMstCapture = photoTagMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoTagMstCapture.getAccountNo());
 			assertEquals(1L, photoTagMstCapture.getPhotoNo().value());
 			assertNull(photoTagMstCapture.getTagNo());
@@ -444,7 +445,7 @@ public class PhotoDetailRepositoryImplTest {
 			doReturn(null).when(photoDetailMapper).getPhotoDetail(photoDetailGetDtoCaptor.capture());
 			
 			assertThrows(PhotoNotFoundException.class, () -> photoDetailRepositoryImpl.getPhotoDetail(photoDetailGetModel));
-			verify(photoTagMstMapper, times(0)).select(any(PhotoTagMst.class));
+			verify(photoTagMstMapper, times(0)).select(any(PhotoTagMstCondition.class));
 		}
 	}
 }

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoFavoriteRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoFavoriteRepositoryImplTest.java
@@ -22,6 +22,7 @@ import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.common.CreatedBy;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.entity.PhotoFavorite;
+import com.web.gallery.entity.PhotoFavoriteCondition;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.mapper.PhotoFavoriteMapper;
@@ -104,18 +105,16 @@ public class PhotoFavoriteRepositoryImplTest {
 					.favoritePhotoNo(new PhotoNo(1L))
 					.build();
 			
-			ArgumentCaptor<PhotoFavorite> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavorite.class);
+			ArgumentCaptor<PhotoFavoriteCondition> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavoriteCondition.class);
 			doReturn(1).when(photoFavoriteMapper).delete(photoFavoriteCaptor.capture());
 			
 			photoFavoriteRepositoryImpl.delete(favoriteDeleteModel);
 			
-			verify(photoFavoriteMapper).delete(any(PhotoFavorite.class));
-			PhotoFavorite photoFavorite = photoFavoriteCaptor.getValue();
+			verify(photoFavoriteMapper).delete(any(PhotoFavoriteCondition.class));
+			PhotoFavoriteCondition photoFavorite = photoFavoriteCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoFavorite.getAccountNo());
 			assertEquals(new AccountNo(1L), photoFavorite.getFavoritePhotoAccountNo());
 			assertEquals(1L, photoFavorite.getFavoritePhotoNo().value());
-			assertNull(photoFavorite.getCreatedBy());
-			assertNull(photoFavorite.getCreatedAt());
 		}
 		
 		@Test
@@ -128,18 +127,16 @@ public class PhotoFavoriteRepositoryImplTest {
 					.favoritePhotoNo(new PhotoNo(1L))
 					.build();
 			
-			ArgumentCaptor<PhotoFavorite> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavorite.class);
+			ArgumentCaptor<PhotoFavoriteCondition> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavoriteCondition.class);
 			doReturn(0).when(photoFavoriteMapper).delete(photoFavoriteCaptor.capture());
 			
 			assertThrows(UpdateFailureException.class, () -> photoFavoriteRepositoryImpl.delete(favoriteDeleteModel));
 			
-			verify(photoFavoriteMapper).delete(any(PhotoFavorite.class));
-			PhotoFavorite photoFavorite = photoFavoriteCaptor.getValue();
+			verify(photoFavoriteMapper).delete(any(PhotoFavoriteCondition.class));
+			PhotoFavoriteCondition photoFavorite = photoFavoriteCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoFavorite.getAccountNo());
 			assertEquals(new AccountNo(1L), photoFavorite.getFavoritePhotoAccountNo());
 			assertEquals(1L, photoFavorite.getFavoritePhotoNo().value());
-			assertNull(photoFavorite.getCreatedBy());
-			assertNull(photoFavorite.getCreatedAt());
 		}
 	}
 	
@@ -156,18 +153,16 @@ public class PhotoFavoriteRepositoryImplTest {
 					.favoritePhotoNo(new PhotoNo(1L))
 					.build();
 
-			ArgumentCaptor<PhotoFavorite> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavorite.class);
+			ArgumentCaptor<PhotoFavoriteCondition> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavoriteCondition.class);
 			doReturn(1).when(photoFavoriteMapper).delete(photoFavoriteCaptor.capture());
 
 			photoFavoriteRepositoryImpl.clear(favoriteDeleteModel);
 			
-			verify(photoFavoriteMapper).delete(any(PhotoFavorite.class));
-			PhotoFavorite photoFavorite = photoFavoriteCaptor.getValue();
+			verify(photoFavoriteMapper).delete(any(PhotoFavoriteCondition.class));
+			PhotoFavoriteCondition photoFavorite = photoFavoriteCaptor.getValue();
 			assertNull(photoFavorite.getAccountNo());
 			assertEquals(new AccountNo(1L), photoFavorite.getFavoritePhotoAccountNo());
 			assertEquals(1L, photoFavorite.getFavoritePhotoNo().value());
-			assertNull(photoFavorite.getCreatedBy());
-			assertNull(photoFavorite.getCreatedAt());
 		}
 	}
 
@@ -179,13 +174,13 @@ public class PhotoFavoriteRepositoryImplTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号で自分が登録したお気に入りを全件削除する")
 		void deleteByAccountNo_success() {
-			ArgumentCaptor<PhotoFavorite> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavorite.class);
+			ArgumentCaptor<PhotoFavoriteCondition> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavoriteCondition.class);
 			doReturn(1).when(photoFavoriteMapper).delete(photoFavoriteCaptor.capture());
 
 			photoFavoriteRepositoryImpl.deleteByAccountNo(new AccountNo(1L));
 
-			verify(photoFavoriteMapper).delete(any(PhotoFavorite.class));
-			PhotoFavorite photoFavorite = photoFavoriteCaptor.getValue();
+			verify(photoFavoriteMapper).delete(any(PhotoFavoriteCondition.class));
+			PhotoFavoriteCondition photoFavorite = photoFavoriteCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoFavorite.getAccountNo());
 			assertNull(photoFavorite.getFavoritePhotoAccountNo());
 			assertNull(photoFavorite.getFavoritePhotoNo());
@@ -200,13 +195,13 @@ public class PhotoFavoriteRepositoryImplTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号で自分の写真に対する他人のお気に入りを全件削除する")
 		void deleteByFavoritePhotoAccountNo_success() {
-			ArgumentCaptor<PhotoFavorite> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavorite.class);
+			ArgumentCaptor<PhotoFavoriteCondition> photoFavoriteCaptor = ArgumentCaptor.forClass(PhotoFavoriteCondition.class);
 			doReturn(1).when(photoFavoriteMapper).delete(photoFavoriteCaptor.capture());
 
 			photoFavoriteRepositoryImpl.deleteByFavoritePhotoAccountNo(new AccountNo(1L));
 
-			verify(photoFavoriteMapper).delete(any(PhotoFavorite.class));
-			PhotoFavorite photoFavorite = photoFavoriteCaptor.getValue();
+			verify(photoFavoriteMapper).delete(any(PhotoFavoriteCondition.class));
+			PhotoFavoriteCondition photoFavorite = photoFavoriteCaptor.getValue();
 			assertNull(photoFavorite.getAccountNo());
 			assertEquals(new AccountNo(1L), photoFavorite.getFavoritePhotoAccountNo());
 			assertNull(photoFavorite.getFavoritePhotoNo());

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoMstRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoMstRepositoryImplTest.java
@@ -41,6 +41,8 @@ import com.web.gallery.domain.photo.FValue;
 import com.web.gallery.domain.photo.ShutterSpeed;
 import com.web.gallery.domain.photo.Iso;
 import com.web.gallery.entity.PhotoMst;
+import com.web.gallery.entity.PhotoMstCondition;
+import com.web.gallery.entity.PhotoMstUpdateTarget;
 import com.web.gallery.enumeration.DirectionEnum;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
@@ -205,21 +207,17 @@ public class PhotoMstRepositoryImplTest {
 					.imageFilePath(new ImageFilePath(imageFilePath))
 					.build();
 			
-			ArgumentCaptor<PhotoMst> cndPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
-			ArgumentCaptor<PhotoMst> targetPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
+			ArgumentCaptor<PhotoMstCondition> cndPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMstCondition.class);
+			ArgumentCaptor<PhotoMstUpdateTarget> targetPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMstUpdateTarget.class);
 			
 			doReturn(1).when(photoMstMapper).update(cndPhotoMstCaptor.capture(), targetPhotoMstCaptor.capture());
 			
 			photoMstRepositoryImpl.update(photoDetailModel);
 			
-			verify(photoMstMapper).update(any(PhotoMst.class), any(PhotoMst.class));
-			PhotoMst cndPhotoMst = cndPhotoMstCaptor.getValue();
+			verify(photoMstMapper).update(any(PhotoMstCondition.class), any(PhotoMstUpdateTarget.class));
+			PhotoMstCondition cndPhotoMst = cndPhotoMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), cndPhotoMst.getAccountNo());
 			assertEquals(1L, cndPhotoMst.getPhotoNo().value());
-			assertNull(cndPhotoMst.getCreatedBy());
-			assertNull(cndPhotoMst.getCreatedAt());
-			assertNull(cndPhotoMst.getUpdatedBy());
-			assertNull(cndPhotoMst.getUpdatedAt());
 			assertNull(cndPhotoMst.getIsDeleted());
 			assertNull(cndPhotoMst.getPhotoAt());
 			assertNull(cndPhotoMst.getLocationNo());
@@ -233,13 +231,8 @@ public class PhotoMstRepositoryImplTest {
 			assertNull(cndPhotoMst.getShutterSpeed());
 			assertNull(cndPhotoMst.getIso());
 			
-			PhotoMst targetPhotoMst = targetPhotoMstCaptor.getValue();
-			assertNull(targetPhotoMst.getAccountNo());
-			assertNull(targetPhotoMst.getPhotoNo());
-			assertNull(targetPhotoMst.getCreatedBy());
-			assertNull(targetPhotoMst.getCreatedAt());
+			PhotoMstUpdateTarget targetPhotoMst = targetPhotoMstCaptor.getValue();
 			assertEquals(new UpdatedBy(1L), targetPhotoMst.getUpdatedBy());
-			assertNull(targetPhotoMst.getUpdatedAt());
 			assertFalse(targetPhotoMst.getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9)), targetPhotoMst.getPhotoAt().value());
 			assertEquals(0L, targetPhotoMst.getLocationNo().value());
@@ -276,21 +269,17 @@ public class PhotoMstRepositoryImplTest {
 					.iso(new Iso(100))
 					.build();
 			
-			ArgumentCaptor<PhotoMst> cndPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
-			ArgumentCaptor<PhotoMst> targetPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
+			ArgumentCaptor<PhotoMstCondition> cndPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMstCondition.class);
+			ArgumentCaptor<PhotoMstUpdateTarget> targetPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMstUpdateTarget.class);
 			
 			doReturn(1).when(photoMstMapper).update(cndPhotoMstCaptor.capture(), targetPhotoMstCaptor.capture());
 			
 			photoMstRepositoryImpl.update(photoDetailModel);
 			
-			verify(photoMstMapper).update(any(PhotoMst.class), any(PhotoMst.class));
-			PhotoMst cndPhotoMst = cndPhotoMstCaptor.getValue();
+			verify(photoMstMapper).update(any(PhotoMstCondition.class), any(PhotoMstUpdateTarget.class));
+			PhotoMstCondition cndPhotoMst = cndPhotoMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), cndPhotoMst.getAccountNo());
 			assertEquals(1L, cndPhotoMst.getPhotoNo().value());
-			assertNull(cndPhotoMst.getCreatedBy());
-			assertNull(cndPhotoMst.getCreatedAt());
-			assertNull(cndPhotoMst.getUpdatedBy());
-			assertNull(cndPhotoMst.getUpdatedAt());
 			assertNull(cndPhotoMst.getIsDeleted());
 			assertNull(cndPhotoMst.getPhotoAt());
 			assertNull(cndPhotoMst.getLocationNo());
@@ -304,13 +293,8 @@ public class PhotoMstRepositoryImplTest {
 			assertNull(cndPhotoMst.getShutterSpeed());
 			assertNull(cndPhotoMst.getIso());
 			
-			PhotoMst targetPhotoMst = targetPhotoMstCaptor.getValue();
-			assertNull(targetPhotoMst.getAccountNo());
-			assertNull(targetPhotoMst.getPhotoNo());
-			assertNull(targetPhotoMst.getCreatedBy());
-			assertNull(targetPhotoMst.getCreatedAt());
+			PhotoMstUpdateTarget targetPhotoMst = targetPhotoMstCaptor.getValue();
 			assertEquals(new UpdatedBy(1L), targetPhotoMst.getUpdatedBy());
-			assertNull(targetPhotoMst.getUpdatedAt());
 			assertFalse(targetPhotoMst.getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0)), targetPhotoMst.getPhotoAt().value());
 			assertEquals(1L, targetPhotoMst.getLocationNo().value());
@@ -337,21 +321,17 @@ public class PhotoMstRepositoryImplTest {
 					.imageFilePath(new ImageFilePath(imageFilePath))
 					.build();
 			
-			ArgumentCaptor<PhotoMst> cndPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
-			ArgumentCaptor<PhotoMst> targetPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
+			ArgumentCaptor<PhotoMstCondition> cndPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMstCondition.class);
+			ArgumentCaptor<PhotoMstUpdateTarget> targetPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMstUpdateTarget.class);
 			
 			doReturn(0).when(photoMstMapper).update(cndPhotoMstCaptor.capture(), targetPhotoMstCaptor.capture());
 			
 			assertThrows(UpdateFailureException.class, () -> photoMstRepositoryImpl.update(photoDetailModel));
 			
-			verify(photoMstMapper).update(any(PhotoMst.class), any(PhotoMst.class));
-			PhotoMst cndPhotoMst = cndPhotoMstCaptor.getValue();
+			verify(photoMstMapper).update(any(PhotoMstCondition.class), any(PhotoMstUpdateTarget.class));
+			PhotoMstCondition cndPhotoMst = cndPhotoMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), cndPhotoMst.getAccountNo());
 			assertEquals(1L, cndPhotoMst.getPhotoNo().value());
-			assertNull(cndPhotoMst.getCreatedBy());
-			assertNull(cndPhotoMst.getCreatedAt());
-			assertNull(cndPhotoMst.getUpdatedBy());
-			assertNull(cndPhotoMst.getUpdatedAt());
 			assertNull(cndPhotoMst.getIsDeleted());
 			assertNull(cndPhotoMst.getPhotoAt());
 			assertNull(cndPhotoMst.getLocationNo());
@@ -365,13 +345,8 @@ public class PhotoMstRepositoryImplTest {
 			assertNull(cndPhotoMst.getShutterSpeed());
 			assertNull(cndPhotoMst.getIso());
 			
-			PhotoMst targetPhotoMst = targetPhotoMstCaptor.getValue();
-			assertNull(targetPhotoMst.getAccountNo());
-			assertNull(targetPhotoMst.getPhotoNo());
-			assertNull(targetPhotoMst.getCreatedBy());
-			assertNull(targetPhotoMst.getCreatedAt());
+			PhotoMstUpdateTarget targetPhotoMst = targetPhotoMstCaptor.getValue();
 			assertEquals(new UpdatedBy(1L), targetPhotoMst.getUpdatedBy());
-			assertNull(targetPhotoMst.getUpdatedAt());
 			assertFalse(targetPhotoMst.getIsDeleted().value());
 			assertEquals(OffsetDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9)), targetPhotoMst.getPhotoAt().value());
 			assertEquals(0L, targetPhotoMst.getLocationNo().value());
@@ -403,21 +378,17 @@ public class PhotoMstRepositoryImplTest {
 					.imageFilePath(new ImageFilePath(imageFilePath))
 					.build();
 			
-			ArgumentCaptor<PhotoMst> cndPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
-			ArgumentCaptor<PhotoMst> targetPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
+			ArgumentCaptor<PhotoMstCondition> cndPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMstCondition.class);
+			ArgumentCaptor<PhotoMstUpdateTarget> targetPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMstUpdateTarget.class);
 			
 			doReturn(1).when(photoMstMapper).update(cndPhotoMstCaptor.capture(), targetPhotoMstCaptor.capture());
 			
 			photoMstRepositoryImpl.delete(photoDeleteModel);
 			
-			verify(photoMstMapper).update(any(PhotoMst.class), any(PhotoMst.class));
-			PhotoMst cndPhotoMst = cndPhotoMstCaptor.getValue();
+			verify(photoMstMapper).update(any(PhotoMstCondition.class), any(PhotoMstUpdateTarget.class));
+			PhotoMstCondition cndPhotoMst = cndPhotoMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), cndPhotoMst.getAccountNo());
 			assertEquals(1L, cndPhotoMst.getPhotoNo().value());
-			assertNull(cndPhotoMst.getCreatedBy());
-			assertNull(cndPhotoMst.getCreatedAt());
-			assertNull(cndPhotoMst.getUpdatedBy());
-			assertNull(cndPhotoMst.getUpdatedAt());
 			assertNull(cndPhotoMst.getIsDeleted());
 			assertNull(cndPhotoMst.getPhotoAt());
 			assertNull(cndPhotoMst.getLocationNo());
@@ -431,13 +402,8 @@ public class PhotoMstRepositoryImplTest {
 			assertNull(cndPhotoMst.getShutterSpeed());
 			assertNull(cndPhotoMst.getIso());
 			
-			PhotoMst targetPhotoMst = targetPhotoMstCaptor.getValue();
-			assertNull(targetPhotoMst.getAccountNo());
-			assertNull(targetPhotoMst.getPhotoNo());
-			assertNull(targetPhotoMst.getCreatedBy());
-			assertNull(targetPhotoMst.getCreatedAt());
+			PhotoMstUpdateTarget targetPhotoMst = targetPhotoMstCaptor.getValue();
 			assertEquals(new UpdatedBy(1L), targetPhotoMst.getUpdatedBy());
-			assertNull(targetPhotoMst.getUpdatedAt());
 			assertTrue(targetPhotoMst.getIsDeleted().value());
 			assertNull(targetPhotoMst.getPhotoAt());
 			assertNull(targetPhotoMst.getLocationNo());
@@ -464,21 +430,17 @@ public class PhotoMstRepositoryImplTest {
 					.imageFilePath(new ImageFilePath(imageFilePath))
 					.build();
 			
-			ArgumentCaptor<PhotoMst> cndPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
-			ArgumentCaptor<PhotoMst> targetPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
+			ArgumentCaptor<PhotoMstCondition> cndPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMstCondition.class);
+			ArgumentCaptor<PhotoMstUpdateTarget> targetPhotoMstCaptor = ArgumentCaptor.forClass(PhotoMstUpdateTarget.class);
 			
 			doReturn(0).when(photoMstMapper).update(cndPhotoMstCaptor.capture(), targetPhotoMstCaptor.capture());
 			
 			assertThrows(UpdateFailureException.class, () -> photoMstRepositoryImpl.delete(photoDeleteModel));
 			
-			verify(photoMstMapper).update(any(PhotoMst.class), any(PhotoMst.class));
-			PhotoMst cndPhotoMst = cndPhotoMstCaptor.getValue();
+			verify(photoMstMapper).update(any(PhotoMstCondition.class), any(PhotoMstUpdateTarget.class));
+			PhotoMstCondition cndPhotoMst = cndPhotoMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), cndPhotoMst.getAccountNo());
 			assertEquals(1L, cndPhotoMst.getPhotoNo().value());
-			assertNull(cndPhotoMst.getCreatedBy());
-			assertNull(cndPhotoMst.getCreatedAt());
-			assertNull(cndPhotoMst.getUpdatedBy());
-			assertNull(cndPhotoMst.getUpdatedAt());
 			assertNull(cndPhotoMst.getIsDeleted());
 			assertNull(cndPhotoMst.getPhotoAt());
 			assertNull(cndPhotoMst.getLocationNo());
@@ -492,13 +454,8 @@ public class PhotoMstRepositoryImplTest {
 			assertNull(cndPhotoMst.getShutterSpeed());
 			assertNull(cndPhotoMst.getIso());
 			
-			PhotoMst targetPhotoMst = targetPhotoMstCaptor.getValue();
-			assertNull(targetPhotoMst.getAccountNo());
-			assertNull(targetPhotoMst.getPhotoNo());
-			assertNull(targetPhotoMst.getCreatedBy());
-			assertNull(targetPhotoMst.getCreatedAt());
+			PhotoMstUpdateTarget targetPhotoMst = targetPhotoMstCaptor.getValue();
 			assertEquals(new UpdatedBy(1L), targetPhotoMst.getUpdatedBy());
-			assertNull(targetPhotoMst.getUpdatedAt());
 			assertTrue(targetPhotoMst.getIsDeleted().value());
 			assertNull(targetPhotoMst.getPhotoAt());
 			assertNull(targetPhotoMst.getLocationNo());
@@ -556,11 +513,11 @@ public class PhotoMstRepositoryImplTest {
 					.imageFilePath(new ImageFilePath(""))
 					.build();
 					
-			ArgumentCaptor<PhotoMst> photoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
+			ArgumentCaptor<PhotoMstCondition> photoMstCaptor = ArgumentCaptor.forClass(PhotoMstCondition.class);
 			doReturn(false).when(photoMstMapper).isExistPhoto(photoMstCaptor.capture());
 			assertFalse(photoMstRepositoryImpl.isExistPhoto(photoDetailModel));
-			
-			PhotoMst photoMst = photoMstCaptor.getValue();
+
+			PhotoMstCondition photoMst = photoMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoMst.getAccountNo());
 			assertEquals("DSC111.jpg", photoMst.getImageFilePath().value());
 		}
@@ -582,11 +539,11 @@ public class PhotoMstRepositoryImplTest {
 					.imageFilePath(new ImageFilePath(""))
 					.build();
 					
-			ArgumentCaptor<PhotoMst> photoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
+			ArgumentCaptor<PhotoMstCondition> photoMstCaptor = ArgumentCaptor.forClass(PhotoMstCondition.class);
 			doReturn(true).when(photoMstMapper).isExistPhoto(photoMstCaptor.capture());
 			assertTrue(photoMstRepositoryImpl.isExistPhoto(photoDetailModel));
-			
-			PhotoMst photoMst = photoMstCaptor.getValue();
+
+			PhotoMstCondition photoMst = photoMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoMst.getAccountNo());
 		}
 	}
@@ -599,18 +556,14 @@ public class PhotoMstRepositoryImplTest {
 		@Order(1)
 		@DisplayName("正常系")
 		void count_success() {
-			ArgumentCaptor<PhotoMst> photoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
+			ArgumentCaptor<PhotoMstCondition> photoMstCaptor = ArgumentCaptor.forClass(PhotoMstCondition.class);
 			doReturn(3).when(photoMstMapper).count(photoMstCaptor.capture());
-			
+
 			assertEquals(3, photoMstRepositoryImpl.count(new AccountNo(1L)));
-			
-			PhotoMst photoMst = photoMstCaptor.getValue();
+
+			PhotoMstCondition photoMst = photoMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoMst.getAccountNo());
 			assertNull(photoMst.getPhotoNo());
-			assertNull(photoMst.getCreatedBy());
-			assertNull(photoMst.getCreatedAt());
-			assertNull(photoMst.getUpdatedBy());
-			assertNull(photoMst.getUpdatedAt());
 			assertFalse(photoMst.getIsDeleted().value());
 			assertNull(photoMst.getPhotoAt());
 			assertNull(photoMst.getLocationNo());
@@ -634,13 +587,13 @@ public class PhotoMstRepositoryImplTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号で写真マスタを物理削除する")
 		void deleteByAccountNo_success() {
-			ArgumentCaptor<PhotoMst> photoMstCaptor = ArgumentCaptor.forClass(PhotoMst.class);
+			ArgumentCaptor<PhotoMstCondition> photoMstCaptor = ArgumentCaptor.forClass(PhotoMstCondition.class);
 			doReturn(1).when(photoMstMapper).delete(photoMstCaptor.capture());
 
 			photoMstRepositoryImpl.deleteByAccountNo(new AccountNo(1L));
 
-			verify(photoMstMapper).delete(any(PhotoMst.class));
-			PhotoMst photoMst = photoMstCaptor.getValue();
+			verify(photoMstMapper).delete(any(PhotoMstCondition.class));
+			PhotoMstCondition photoMst = photoMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoMst.getAccountNo());
 			assertNull(photoMst.getPhotoNo());
 		}

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoTagMstRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoTagMstRepositoryImplTest.java
@@ -25,6 +25,7 @@ import com.web.gallery.domain.photo.TagNo;
 import com.web.gallery.domain.photo.TagJapaneseName;
 import com.web.gallery.domain.photo.TagEnglishName;
 import com.web.gallery.entity.PhotoTagMst;
+import com.web.gallery.entity.PhotoTagMstCondition;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.mapper.PhotoTagMstMapper;
 import com.web.gallery.model.PhotoTagDeleteModel;
@@ -113,18 +114,16 @@ public class PhotoTagMstRepositoryImplTest {
 					.photoNo(new PhotoNo(1L))
 					.build();
 			
-			ArgumentCaptor<PhotoTagMst> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMst.class);
+			ArgumentCaptor<PhotoTagMstCondition> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMstCondition.class);
 			doReturn(1).when(photoTagMstMapper).delete(photoTagMstCaptor.capture());
 			
 			photoTagMstRepositoryImpl.clear(photoTagDeleteModel);
 			
-			verify(photoTagMstMapper).delete(any(PhotoTagMst.class));
-			PhotoTagMst photoTagMst = photoTagMstCaptor.getValue();
+			verify(photoTagMstMapper).delete(any(PhotoTagMstCondition.class));
+			PhotoTagMstCondition photoTagMst = photoTagMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoTagMst.getAccountNo());
 			assertEquals(1L, photoTagMst.getPhotoNo().value());
 			assertNull(photoTagMst.getTagNo());
-			assertNull(photoTagMst.getCreatedBy());
-			assertNull(photoTagMst.getCreatedAt());
 			assertNull(photoTagMst.getTagJapaneseName());
 			assertNull(photoTagMst.getTagEnglishName());
 		}
@@ -138,13 +137,13 @@ public class PhotoTagMstRepositoryImplTest {
 		@Order(1)
 		@DisplayName("正常系：アカウント番号で写真タグを全件削除する")
 		void deleteByAccountNo_success() {
-			ArgumentCaptor<PhotoTagMst> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMst.class);
+			ArgumentCaptor<PhotoTagMstCondition> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMstCondition.class);
 			doReturn(1).when(photoTagMstMapper).delete(photoTagMstCaptor.capture());
 
 			photoTagMstRepositoryImpl.deleteByAccountNo(new AccountNo(1L));
 
-			verify(photoTagMstMapper).delete(any(PhotoTagMst.class));
-			PhotoTagMst photoTagMst = photoTagMstCaptor.getValue();
+			verify(photoTagMstMapper).delete(any(PhotoTagMstCondition.class));
+			PhotoTagMstCondition photoTagMst = photoTagMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoTagMst.getAccountNo());
 			assertNull(photoTagMst.getPhotoNo());
 			assertNull(photoTagMst.getTagNo());


### PR DESCRIPTION
# 概要

## 背景

コードレビューにて、`PhotoMst`が「永続化Entity」「クエリ条件（`condition()`, `conditionForExistCheck()`等）」「更新対象コマンド（`targetForUpdate()`, `targetForDelete()`）」の3役を1クラスで兼務しており、単一責任原則に反しているという指摘があった。特に`update()`メソッドは`PhotoMst`のインスタンスを条件用・更新対象用の2つ渡す形になっており、呼び出し側を見ないとどのフィールドが条件用でどれが更新用か分からない状態だった。

同様のパターンが`Account`・`KbnMst`・`PhotoFavorite`・`PhotoTagMst`にも存在したため、追加で対応した。

## 変更内容

### PhotoMst

- `entity/PhotoMstCondition.java`を新設し、`count`/`update`/`delete`/`isExistPhoto`のWHERE句専用クラスとして分離
- `entity/PhotoMstUpdateTarget.java`を新設し、`update`のSET句専用クラスとして分離
- `entity/PhotoMst.java`から条件・更新対象系のファクトリメソッドを削除し、resultMap用・登録用(`fromForRegist`)のみを持つ本来の永続化Entityに整理
- `mapper/PhotoMstMapper.java`・`PhotoMstMapper.xml`・`repository/impl/PhotoMstRepositoryImpl.java`を新クラスに合わせて修正
- 関連するユニットテスト（`PhotoMstMapperTest`, `PhotoMstRepositoryImplTest`）を新クラスの型に追随

### Account（同様に`update`がcondition/target二重引数だったため、Condition/UpdateTargetの両方を分離）

- `entity/AccountCondition.java`・`entity/AccountUpdateTarget.java`を新設
- `entity/Account.java`から条件・更新対象系のファクトリメソッドを削除し、登録用(`from`)のみを持つEntityに整理
- `mapper/AccountMapper.java`・`AccountMapper.xml`・`repository/impl/AccountRepositoryImpl.java`を新クラスに合わせて修正

### KbnMst / PhotoFavorite / PhotoTagMst（`update`操作がないため、Conditionクラスのみ分離）

- `entity/KbnMstCondition.java`・`entity/PhotoFavoriteCondition.java`・`entity/PhotoTagMstCondition.java`を新設
- 各Entityから条件系のファクトリメソッドを削除し、登録用ファクトリのみを持つEntityに整理
- 対応する`mapper/*.java`・`*Mapper.xml`・`repository/impl/*RepositoryImpl.java`（`PhotoDetailRepositoryImpl`含む）を新クラスに合わせて修正

いずれもAPI仕様・DBスキーマの変更は無く、内部実装のリファクタのみ。


# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `./backend/gradlew -p backend bootRun` で backend の起動が成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認


# 懸念事項

- frontendに影響する変更はないため、`bootRun`は未実施。
- `.claude/rules/entity.md`では「Entityはドメインクラス（値オブジェクト）・Modelクラスを使用しない」とされているが、既存の各Entity実装自体がこのルールと乖離しており、新設したCondition/UpdateTargetクラスも同様に値オブジェクト・Modelクラスに依存している。ルール自体の見直しは本PRのスコープ外としている。
- `AccountUpdateTarget`には元々`Account.fromForUpdate()`が設定していなかった`authorityKbn`フィールドを追加している（XML側の`target.authorityKbn`参照に対応するため必須）。値は従来通りセットしておらず、挙動は変更していない。
