### PR TITLE
refactor: 写真一覧取得のフィルタリング・ソートをSQL側に移行する

### DIFF
--- a/backend/src/main/java/com/web/gallery/dto/PhotoListGetDto.java
+++ b/backend/src/main/java/com/web/gallery/dto/PhotoListGetDto.java
@@ -1,7 +1,9 @@
 package com.web.gallery.dto;
 
+import java.util.List;
 import java.util.Objects;
 
+import com.web.gallery.enumeration.DirectionEnum;
 import com.web.gallery.model.PhotoGetModel;
 
 import lombok.Data;
@@ -18,6 +20,22 @@ public class PhotoListGetDto {
 	private Long photoAccountNo;
 
 	/**
+	 * 向き区分（絞り込み不要の場合はnull）
+	 * <p>
+	 * {@link DirectionEnum}
+	 */
+	private DirectionEnum directionKbn;
+
+	/** お気に入りの写真のみに絞り込むならtrue */
+	private Boolean isFavoriteOnly;
+
+	/** タグワードリスト（絞り込み不要の場合は空リストまたは空文字を含むリスト） */
+	private List<String> tagList;
+
+	/** 並び順（"PHOTO_AT" / "FAVORITE" / "SEASON"） */
+	private String sortBy;
+
+	/**
 	 * PhotoGetModelからPhotoListGetDtoを生成する
 	 *
 	 * @param	model	{@link PhotoGetModel}
@@ -27,6 +45,10 @@ public class PhotoListGetDto {
 		PhotoListGetDto dto = new PhotoListGetDto();
 		dto.setAccountNo(Objects.nonNull(model.getAccountNo()) ? model.getAccountNo().value() : null);
 		dto.setPhotoAccountNo(model.getPhotoAccountNo().value());
+		dto.setDirectionKbn(DirectionEnum.NONE.equals(model.getDirectionKbn()) ? null : model.getDirectionKbn());
+		dto.setIsFavoriteOnly(Objects.nonNull(model.getIsFavoriteOnly()) && model.getIsFavoriteOnly().value());
+		dto.setTagList(model.getTagList());
+		dto.setSortBy(Objects.nonNull(model.getSortBy()) ? model.getSortBy().name() : null);
 		return dto;
 	}
 }

--- a/backend/src/main/java/com/web/gallery/model/PhotoGetModel.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoGetModel.java
@@ -1,6 +1,11 @@
 package com.web.gallery.model;
 
+import java.util.List;
+
 import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.photo.IsFavoriteOnly;
+import com.web.gallery.enumeration.DirectionEnum;
+import com.web.gallery.enumeration.SortPhotoEnum;
 
 import lombok.Builder;
 import lombok.NonNull;
@@ -20,16 +25,43 @@ public class PhotoGetModel {
 	private AccountNo photoAccountNo;
 
 	/**
-	 * アカウント番号と写真アカウント番号からPhotoGetModelを生成する
-	 *
-	 * @param	accountNo		ログイン中のアカウントNo
-	 * @param	photoAccountNo	写真のアカウントNo
-	 * @return					{@link PhotoGetModel}
+	 * 向き区分
+	 * <p>
+	 * {@link DirectionEnum}
 	 */
-	public static PhotoGetModel of(AccountNo accountNo, AccountNo photoAccountNo) {
+	@NonNull
+	private DirectionEnum directionKbn;
+
+	/** お気に入り写真のみ */
+	private IsFavoriteOnly isFavoriteOnly;
+
+	/** タグワードリスト */
+	@NonNull
+	private List<String> tagList;
+
+	/**
+	 * 並び順
+	 * <p>
+	 * {@link SortPhotoEnum}
+	 */
+	@NonNull
+	private SortPhotoEnum sortBy;
+
+	/**
+	 * PhotoListGetModelと写真のアカウント番号からPhotoGetModelを生成する
+	 *
+	 * @param	photoListGetModel	{@link PhotoListGetModel}
+	 * @param	photoAccountNo		写真のアカウントNo
+	 * @return						{@link PhotoGetModel}
+	 */
+	public static PhotoGetModel of(PhotoListGetModel photoListGetModel, AccountNo photoAccountNo) {
 		return PhotoGetModel.builder()
-				.accountNo(accountNo)
+				.accountNo(photoListGetModel.getAccountNo())
 				.photoAccountNo(photoAccountNo)
+				.directionKbn(photoListGetModel.getDirectionKbn())
+				.isFavoriteOnly(photoListGetModel.getIsFavoriteOnly())
+				.tagList(photoListGetModel.getTagList())
+				.sortBy(photoListGetModel.getSortBy())
 				.build();
 	}
 }

--- a/backend/src/main/java/com/web/gallery/model/PhotoModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoModelList.java
@@ -8,7 +8,6 @@ import java.util.stream.Stream;
 
 import com.web.gallery.dto.PhotoDto;
 import com.web.gallery.entity.PhotoTagMst;
-import com.web.gallery.enumeration.DirectionEnum;
 
 /**
  * PhotoModelのコレクションを表すクラス
@@ -61,49 +60,6 @@ public record PhotoModelList(List<PhotoModel> photoModelList) implements Iterabl
 	 */
 	public PhotoModelList sorted(Comparator<PhotoModel> comparator) {
 		return PhotoModelList.of(photoModelList.stream().sorted(comparator).toList());
-	}
-
-	/**
-	 * 向き区分でフィルタリングしたPhotoModelListを生成する<p>
-	 * 条件がNONEの場合はフィルタリングしない
-	 *
-	 * @param	conditionDirectionKbn	フィルター条件の向き区分
-	 * @return							{@link PhotoModelList}
-	 */
-	public PhotoModelList filterByDirectionKbn(DirectionEnum conditionDirectionKbn) {
-		if (DirectionEnum.NONE.equals(conditionDirectionKbn)) return this;
-
-		return PhotoModelList.of(photoModelList.stream()
-				.filter(photoModel -> photoModel.getDirectionKbn().equals(conditionDirectionKbn))
-				.toList());
-	}
-
-	/**
-	 * お気に入りでフィルタリングしたPhotoModelListを生成する<p>
-	 * isFavoriteOnlyがfalseの場合はフィルタリングしない
-	 *
-	 * @param	isFavoriteOnly	お気に入りに絞るならtrue
-	 * @return					{@link PhotoModelList}
-	 */
-	public PhotoModelList filterByFavorite(Boolean isFavoriteOnly) {
-		if (!isFavoriteOnly) return this;
-
-		return PhotoModelList.of(photoModelList.stream()
-				.filter(photoModel -> photoModel.getIsFavorite().value())
-				.toList());
-	}
-
-	/**
-	 * タグでフィルタリングしたPhotoModelListを生成する<p>
-	 * タグが複数ある場合、すべてのタグを持つ写真にフィルタリングする
-	 *
-	 * @param	tags	フィルター条件のタグのリスト
-	 * @return			{@link PhotoModelList}
-	 */
-	public PhotoModelList filterByTags(List<String> tags) {
-		return PhotoModelList.of(photoModelList.stream()
-				.filter(photoModel -> photoModel.getPhotoTagModelList().containsAllTags(tags))
-				.toList());
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/model/PhotoTagModelList.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoTagModelList.java
@@ -1,13 +1,11 @@
 package com.web.gallery.model;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import com.web.gallery.constant.Consts;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.entity.PhotoTagMst;
@@ -77,23 +75,6 @@ public record PhotoTagModelList(List<PhotoTagModel> photoTagModelList) implement
 					photoTagModel.getAccountNo().value().equals(accountNo.value()) &&
 					Objects.equals(photoTagModel.getPhotoNo().value(), photoNo.value()))
 				.toList());
-	}
-
-	/**
-	 * 指定のタグをすべて保持しているかどうかを判定する<p>
-	 * タグが未指定の場合はtrueを返す
-	 *
-	 * @param	tags	判定対象のタグのリスト
-	 * @return			すべてのタグを保持している場合はtrue
-	 */
-	public Boolean containsAllTags(List<String> tags) {
-		if (tags.isEmpty() || Consts.STRING_EMPTY.equals(tags.getFirst())) return true;
-
-		List<String> photoTags = new ArrayList<String>();
-		photoTags.addAll(photoTagModelList.stream().map(photoTagModel -> photoTagModel.getTagJapaneseName().value()).toList());
-		photoTags.addAll(photoTagModelList.stream().map(photoTagModel -> photoTagModel.getTagEnglishName().value()).toList());
-
-		return photoTags.containsAll(tags);
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
@@ -80,13 +80,12 @@ public class PhotoServiceImpl implements PhotoService {
 
 		PhotoModelList photoModelList
 			= photoDetailRepository.getPhotoList(
-					PhotoGetModel.of(photoListGetModel.getAccountNo(), accountModel.getAccountNo()));
+					PhotoGetModel.of(photoListGetModel, accountModel.getAccountNo()));
 
-		return photoModelList
-					.filterByDirectionKbn(photoListGetModel.getDirectionKbn())
-					.filterByFavorite(photoListGetModel.getIsFavoriteOnly().value())
-					.filterByTags(photoListGetModel.getTagList())
-					.sorted(getComparator(photoListGetModel.getSortBy()));
+		if(SortPhotoEnum.SEASON.equals(photoListGetModel.getSortBy())) {
+			return photoModelList.sorted(getSeasonComparator());
+		}
+		return photoModelList;
 	}
 
 	/**
@@ -190,33 +189,24 @@ public class PhotoServiceImpl implements PhotoService {
 	}
 
 	/**
-	 * 写真一覧の並び順のComparatorを取得する
+	 * 写真一覧の季節・時期順のComparatorを取得する<p>
+	 * 月日ベースの近似ソートのため、SQLのORDER BYではなくアプリケーション層で計算する
 	 *
-	 * @param	sortBy	{@link SortPhotoEnum}
-	 * @return			{@link PhotoModel}のComparator
+	 * @return	{@link PhotoModel}のComparator
 	 */
-	private Comparator<PhotoModel> getComparator(SortPhotoEnum sortBy) {
-		switch(sortBy) {
-			case PHOTO_AT:
-				return Comparator.comparing(photoModel -> photoModel.getPhotoAt().value(), Comparator.reverseOrder());
-			case FAVORITE:
-				return Comparator.comparing((PhotoModel photoModel) -> photoModel.getFavoriteCount().value()).reversed();
-			case SEASON:
-				return new Comparator<PhotoModel>() {
-					@Override
-					public int compare(PhotoModel photoModelA, PhotoModel photoModelB) {
-						OffsetDateTime photoAtA = photoModelA.getPhotoAt().value().withOffsetSameInstant(Consts.JST);
-						OffsetDateTime photoAtB = photoModelB.getPhotoAt().value().withOffsetSameInstant(Consts.JST);
+	private Comparator<PhotoModel> getSeasonComparator() {
+		return new Comparator<PhotoModel>() {
+			@Override
+			public int compare(PhotoModel photoModelA, PhotoModel photoModelB) {
+				OffsetDateTime photoAtA = photoModelA.getPhotoAt().value().withOffsetSameInstant(Consts.JST);
+				OffsetDateTime photoAtB = photoModelB.getPhotoAt().value().withOffsetSameInstant(Consts.JST);
 
-						LocalDate dateA = LocalDate.of(2000, photoAtA.getMonth().getValue(), photoAtA.getDayOfMonth());
-						LocalDate dateB = LocalDate.of(2000, photoAtB.getMonth().getValue(), photoAtB.getDayOfMonth());
+				LocalDate dateA = LocalDate.of(2000, photoAtA.getMonth().getValue(), photoAtA.getDayOfMonth());
+				LocalDate dateB = LocalDate.of(2000, photoAtB.getMonth().getValue(), photoAtB.getDayOfMonth());
 
-						return (int) ChronoUnit.DAYS.between(dateA, dateB);
-					}
-				};
-			default:
-				return Comparator.comparing(photoModel -> photoModel.getPhotoAt().value(), Comparator.reverseOrder());
-		}
+				return (int) ChronoUnit.DAYS.between(dateA, dateB);
+			}
+		};
 	}
 
 	/**

--- a/backend/src/main/resources/com/web/gallery/mapper/PhotoDetailMapper.xml
+++ b/backend/src/main/resources/com/web/gallery/mapper/PhotoDetailMapper.xml
@@ -85,7 +85,7 @@
 			photo_mst.account_no = #{photoAccountNo} AND
 			photo_mst.is_deleted = false
 			<if test="directionKbn != null">
-				AND photo_mst.direction_kbn = #{directionKbn, typeHandler=com.web.gallery.type_handler.DirectionEnumTypeHandler}
+				AND photo_mst.direction_kbn = #{directionKbn}::photo.direction_enum
 			</if>
 			<if test="isFavoriteOnly != null and isFavoriteOnly">
 				AND isFavorite.favorite_photo_account_no IS NOT NULL
@@ -106,10 +106,10 @@
 			</if>
 		<choose>
 			<when test="sortBy == 'FAVORITE'">
-				ORDER BY favoriteCount DESC
+				ORDER BY favoriteCount DESC, photo_mst.photo_no ASC
 			</when>
 			<otherwise>
-				ORDER BY photo_mst.photo_at DESC
+				ORDER BY photo_mst.photo_at DESC, photo_mst.photo_no ASC
 			</otherwise>
 		</choose>
 	</select>

--- a/backend/src/main/resources/com/web/gallery/mapper/PhotoDetailMapper.xml
+++ b/backend/src/main/resources/com/web/gallery/mapper/PhotoDetailMapper.xml
@@ -84,6 +84,34 @@
 		WHERE
 			photo_mst.account_no = #{photoAccountNo} AND
 			photo_mst.is_deleted = false
+			<if test="directionKbn != null">
+				AND photo_mst.direction_kbn = #{directionKbn, typeHandler=com.web.gallery.type_handler.DirectionEnumTypeHandler}
+			</if>
+			<if test="isFavoriteOnly != null and isFavoriteOnly">
+				AND isFavorite.favorite_photo_account_no IS NOT NULL
+			</if>
+			<if test="tagList != null and !tagList.isEmpty() and tagList[0] != ''">
+				<foreach item="tag" collection="tagList">
+					AND EXISTS (
+						SELECT
+							1
+						FROM
+							photo.photo_tag_mst photo_tag_mst
+						WHERE
+							photo_tag_mst.account_no = photo_mst.account_no AND
+							photo_tag_mst.photo_no = photo_mst.photo_no AND
+							(photo_tag_mst.tag_japanese_name = #{tag} OR photo_tag_mst.tag_english_name = #{tag})
+					)
+				</foreach>
+			</if>
+		<choose>
+			<when test="sortBy == 'FAVORITE'">
+				ORDER BY favoriteCount DESC
+			</when>
+			<otherwise>
+				ORDER BY photo_mst.photo_at DESC
+			</otherwise>
+		</choose>
 	</select>
 
 	<select id="getPhotoDetail" parameterType="com.web.gallery.dto.PhotoDetailGetDto" resultMap="PhotoDetailDtoResultMap">

--- a/backend/src/test/java/com/web/gallery/model/PhotoModelListTest.java
+++ b/backend/src/test/java/com/web/gallery/model/PhotoModelListTest.java
@@ -4,14 +4,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Comparator;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.web.gallery.domain.account.AccountNo;
@@ -40,67 +37,18 @@ public class PhotoModelListTest {
 				.build();
 	}
 
-	@Nested
-	@Order(1)
-	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-	class filterByDirectionKbn {
-		@Test
-		@Order(1)
-		@DisplayName("正常系：抽出条件が未指定の場合はフィルタリングしないこと")
-		void filterByDirectionKbn_not_condition() {
-			PhotoModelList photoModelList = PhotoModelList.of(List.of(
-					createPhotoModel(1L, DirectionEnum.VERTICAL, false),
-					createPhotoModel(2L, DirectionEnum.HORIZONTAL, false)));
+	@Test
+	@DisplayName("正常系：指定のComparatorでソートされること")
+	void sorted_success() {
+		PhotoModelList photoModelList = PhotoModelList.of(List.of(
+				createPhotoModel(1L, DirectionEnum.VERTICAL, false),
+				createPhotoModel(2L, DirectionEnum.HORIZONTAL, false)));
 
-			PhotoModelList actual = photoModelList.filterByDirectionKbn(DirectionEnum.NONE);
+		PhotoModelList actual = photoModelList.sorted(
+				Comparator.comparing((PhotoModel photoModel) -> photoModel.getPhotoNo().value(), Comparator.reverseOrder()));
 
-			assertEquals(2, actual.size());
-		}
-
-		@Test
-		@Order(2)
-		@DisplayName("正常系：抽出条件と一致するものだけに絞り込まれること")
-		void filterByDirectionKbn_match_condition() {
-			PhotoModelList photoModelList = PhotoModelList.of(List.of(
-					createPhotoModel(1L, DirectionEnum.VERTICAL, false),
-					createPhotoModel(2L, DirectionEnum.HORIZONTAL, false)));
-
-			PhotoModelList actual = photoModelList.filterByDirectionKbn(DirectionEnum.VERTICAL);
-
-			assertEquals(1, actual.size());
-			assertEquals(new PhotoNo(1L), actual.get(0).getPhotoNo());
-		}
-	}
-
-	@Nested
-	@Order(2)
-	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-	class filterByFavorite {
-		@Test
-		@Order(1)
-		@DisplayName("正常系：お気に入りのみが指定されていない場合はフィルタリングしないこと")
-		void filterByFavorite_not_condition() {
-			PhotoModelList photoModelList = PhotoModelList.of(List.of(
-					createPhotoModel(1L, DirectionEnum.VERTICAL, true),
-					createPhotoModel(2L, DirectionEnum.VERTICAL, false)));
-
-			PhotoModelList actual = photoModelList.filterByFavorite(false);
-
-			assertEquals(2, actual.size());
-		}
-
-		@Test
-		@Order(2)
-		@DisplayName("正常系：お気に入りのみが指定されている場合はお気に入りの写真のみに絞り込まれること")
-		void filterByFavorite_match_condition() {
-			PhotoModelList photoModelList = PhotoModelList.of(List.of(
-					createPhotoModel(1L, DirectionEnum.VERTICAL, true),
-					createPhotoModel(2L, DirectionEnum.VERTICAL, false)));
-
-			PhotoModelList actual = photoModelList.filterByFavorite(true);
-
-			assertEquals(1, actual.size());
-			assertEquals(new PhotoNo(1L), actual.get(0).getPhotoNo());
-		}
+		assertEquals(2, actual.size());
+		assertEquals(new PhotoNo(2L), actual.get(0).getPhotoNo());
+		assertEquals(new PhotoNo(1L), actual.get(1).getPhotoNo());
 	}
 }

--- a/backend/src/test/java/com/web/gallery/model/PhotoTagModelListTest.java
+++ b/backend/src/test/java/com/web/gallery/model/PhotoTagModelListTest.java
@@ -2,7 +2,6 @@ package com.web.gallery.model;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -24,97 +23,6 @@ public class PhotoTagModelListTest {
 
 	@Nested
 	@Order(1)
-	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-	class containsAllTags {
-		@Test
-		@Order(1)
-		@DisplayName("正常系：tagsが0件の場合")
-		void containsAllTags_tags_empty() {
-			assertTrue(PhotoTagModelList.empty().containsAllTags(new ArrayList<String>()));
-		}
-
-		@Test
-		@Order(2)
-		@DisplayName("正常系：tagsの1件目が''の場合")
-		void containsAllTags_tags_blank() {
-			List<String> tags = new ArrayList<String>();
-			tags.add("");
-			assertTrue(PhotoTagModelList.empty().containsAllTags(tags));
-		}
-
-		@Test
-		@Order(3)
-		@DisplayName("正常系：tagsのすべてが含まれる場合")
-		void containsAllTags_contain_all_tag() {
-			PhotoTagModelList photoTagModelList = PhotoTagModelList.of(List.of(
-					PhotoTagModel.builder()
-							.accountNo(new AccountNo(1L))
-							.photoNo(new PhotoNo(1L))
-							.tagNo(new TagNo(1L))
-							.tagJapaneseName(new TagJapaneseName("太陽"))
-							.tagEnglishName(new TagEnglishName("sun"))
-							.build(),
-					PhotoTagModel.builder()
-							.accountNo(new AccountNo(1L))
-							.photoNo(new PhotoNo(1L))
-							.tagNo(new TagNo(1L))
-							.tagJapaneseName(new TagJapaneseName("月"))
-							.tagEnglishName(new TagEnglishName("moon"))
-							.build(),
-					PhotoTagModel.builder()
-							.accountNo(new AccountNo(1L))
-							.photoNo(new PhotoNo(1L))
-							.tagNo(new TagNo(1L))
-							.tagJapaneseName(new TagJapaneseName("海"))
-							.tagEnglishName(new TagEnglishName("sea"))
-							.build()));
-
-			List<String> tags = new ArrayList<String>();
-			tags.add("太陽");
-			tags.add("sun");
-			tags.add("sea");
-
-			assertTrue(photoTagModelList.containsAllTags(tags));
-		}
-
-		@Test
-		@Order(4)
-		@DisplayName("正常系：tagsのすべてが含まれない場合")
-		void containsAllTags_not_contain_all_tag() {
-			PhotoTagModelList photoTagModelList = PhotoTagModelList.of(List.of(
-					PhotoTagModel.builder()
-							.accountNo(new AccountNo(1L))
-							.photoNo(new PhotoNo(1L))
-							.tagNo(new TagNo(1L))
-							.tagJapaneseName(new TagJapaneseName("太陽"))
-							.tagEnglishName(new TagEnglishName("sun"))
-							.build(),
-					PhotoTagModel.builder()
-							.accountNo(new AccountNo(1L))
-							.photoNo(new PhotoNo(1L))
-							.tagNo(new TagNo(1L))
-							.tagJapaneseName(new TagJapaneseName("月"))
-							.tagEnglishName(new TagEnglishName("moon"))
-							.build(),
-					PhotoTagModel.builder()
-							.accountNo(new AccountNo(1L))
-							.photoNo(new PhotoNo(1L))
-							.tagNo(new TagNo(1L))
-							.tagJapaneseName(new TagJapaneseName("海"))
-							.tagEnglishName(new TagEnglishName("sea"))
-							.build()));
-
-			List<String> tags = new ArrayList<String>();
-			tags.add("太陽");
-			tags.add("sum");
-			tags.add("wood");
-
-			assertFalse(photoTagModelList.containsAllTags(tags));
-		}
-	}
-
-	@Nested
-	@Order(2)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	class filterByPhoto {
 		@Test

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImplTest.java
@@ -49,8 +49,10 @@ import com.web.gallery.dto.PhotoDetailDto;
 import com.web.gallery.dto.PhotoDetailGetDto;
 import com.web.gallery.dto.PhotoDto;
 import com.web.gallery.dto.PhotoListGetDto;
+import com.web.gallery.domain.photo.IsFavoriteOnly;
 import com.web.gallery.entity.PhotoTagMst;
 import com.web.gallery.enumeration.DirectionEnum;
+import com.web.gallery.enumeration.SortPhotoEnum;
 import com.web.gallery.exception.PhotoNotFoundException;
 import com.web.gallery.mapper.PhotoDetailMapper;
 import com.web.gallery.mapper.PhotoTagMstMapper;
@@ -82,6 +84,10 @@ public class PhotoDetailRepositoryImplTest {
 			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
 					.accountNo(new AccountNo(1L))
 					.photoAccountNo(new AccountNo(1L))
+					.directionKbn(DirectionEnum.NONE)
+					.isFavoriteOnly(new IsFavoriteOnly(false))
+					.tagList(List.of())
+					.sortBy(SortPhotoEnum.PHOTO_AT)
 					.build();
 
 			List<PhotoDto> photoDtoList = new ArrayList<PhotoDto>();
@@ -101,6 +107,10 @@ public class PhotoDetailRepositoryImplTest {
 			PhotoListGetDto photoListGetDtoCapture = photoListGetDtoCaptor.getValue();
 			assertEquals(1L, photoListGetDtoCapture.getAccountNo());
 			assertEquals(1L, photoListGetDtoCapture.getPhotoAccountNo());
+			assertNull(photoListGetDtoCapture.getDirectionKbn());
+			assertFalse(photoListGetDtoCapture.getIsFavoriteOnly());
+			assertEquals(List.of(), photoListGetDtoCapture.getTagList());
+			assertEquals("PHOTO_AT", photoListGetDtoCapture.getSortBy());
 
 			PhotoTagMst photoTagMstCapture = photoTagMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoTagMstCapture.getAccountNo());
@@ -113,6 +123,10 @@ public class PhotoDetailRepositoryImplTest {
 			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
 					.accountNo(new AccountNo(1L))
 					.photoAccountNo(new AccountNo(1L))
+					.directionKbn(DirectionEnum.NONE)
+					.isFavoriteOnly(new IsFavoriteOnly(false))
+					.tagList(List.of())
+					.sortBy(SortPhotoEnum.PHOTO_AT)
 					.build();
 			
 			List<PhotoDto> photoDtoList = new ArrayList<PhotoDto>();
@@ -169,6 +183,10 @@ public class PhotoDetailRepositoryImplTest {
 			PhotoListGetDto photoListGetDtoCapture = photoListGetDtoCaptor.getValue();
 			assertEquals(1L, photoListGetDtoCapture.getAccountNo());
 			assertEquals(1L, photoListGetDtoCapture.getPhotoAccountNo());
+			assertNull(photoListGetDtoCapture.getDirectionKbn());
+			assertFalse(photoListGetDtoCapture.getIsFavoriteOnly());
+			assertEquals(List.of(), photoListGetDtoCapture.getTagList());
+			assertEquals("PHOTO_AT", photoListGetDtoCapture.getSortBy());
 
 			PhotoTagMst photoTagMstCapture = photoTagMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoTagMstCapture.getAccountNo());
@@ -181,6 +199,10 @@ public class PhotoDetailRepositoryImplTest {
 			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
 					.accountNo(new AccountNo(1L))
 					.photoAccountNo(new AccountNo(1L))
+					.directionKbn(DirectionEnum.NONE)
+					.isFavoriteOnly(new IsFavoriteOnly(false))
+					.tagList(List.of())
+					.sortBy(SortPhotoEnum.PHOTO_AT)
 					.build();
 			
 			List<PhotoDto> photoDtoList = new ArrayList<PhotoDto>();
@@ -259,6 +281,10 @@ public class PhotoDetailRepositoryImplTest {
 			PhotoListGetDto photoListGetDtoCapture = photoListGetDtoCaptor.getValue();
 			assertEquals(1L, photoListGetDtoCapture.getAccountNo());
 			assertEquals(1L, photoListGetDtoCapture.getPhotoAccountNo());
+			assertNull(photoListGetDtoCapture.getDirectionKbn());
+			assertFalse(photoListGetDtoCapture.getIsFavoriteOnly());
+			assertEquals(List.of(), photoListGetDtoCapture.getTagList());
+			assertEquals("PHOTO_AT", photoListGetDtoCapture.getSortBy());
 
 			PhotoTagMst photoTagMstCapture = photoTagMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoTagMstCapture.getAccountNo());

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoDetailRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoDetailRepositoryImplIntegrationTest.java
@@ -235,6 +235,28 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 			assertEquals(2L, actual.get(1).getPhotoNo().value());
 			assertEquals(1, actual.get(1).getFavoriteCount().value());
 		}
+
+		@Test
+		@Order(8)
+		@DisplayName("正常系：撮影日時の降順に並び替えられること")
+		void getPhotoList_sortBy_photoAt() {
+			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
+					.accountNo(new AccountNo(1L))
+					.photoAccountNo(new AccountNo(1L))
+					.directionKbn(DirectionEnum.NONE)
+					.isFavoriteOnly(new IsFavoriteOnly(false))
+					.tagList(List.of())
+					.sortBy(SortPhotoEnum.PHOTO_AT)
+					.build();
+
+			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
+
+			assertEquals(2, actual.size());
+			assertEquals(2L, actual.get(0).getPhotoNo().value());
+			assertEquals(OffsetDateTime.of(2021, 2, 1, 9, 0, 0, 0, Consts.JST), actual.get(0).getPhotoAt().value());
+			assertEquals(1L, actual.get(1).getPhotoNo().value());
+			assertEquals(OffsetDateTime.of(2021, 1, 1, 9, 0, 0, 0, Consts.JST), actual.get(1).getPhotoAt().value());
+		}
 	}
 
 	@Nested

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoDetailRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoDetailRepositoryImplIntegrationTest.java
@@ -41,7 +41,9 @@ import com.web.gallery.domain.photo.Iso;
 import com.web.gallery.domain.photo.TagNo;
 import com.web.gallery.domain.photo.TagJapaneseName;
 import com.web.gallery.domain.photo.TagEnglishName;
+import com.web.gallery.domain.photo.IsFavoriteOnly;
 import com.web.gallery.enumeration.DirectionEnum;
+import com.web.gallery.enumeration.SortPhotoEnum;
 import com.web.gallery.exception.PhotoNotFoundException;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
@@ -69,6 +71,10 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
 					.accountNo(new AccountNo(1L))
 					.photoAccountNo(new AccountNo(3L))
+					.directionKbn(DirectionEnum.NONE)
+					.isFavoriteOnly(new IsFavoriteOnly(false))
+					.tagList(List.of())
+					.sortBy(SortPhotoEnum.PHOTO_AT)
 					.build();
 			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
 			assertEquals(0, actual.size());
@@ -81,16 +87,20 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
 					.accountNo(new AccountNo(1L))
 					.photoAccountNo(new AccountNo(2L))
+					.directionKbn(DirectionEnum.NONE)
+					.isFavoriteOnly(new IsFavoriteOnly(false))
+					.tagList(List.of())
+					.sortBy(SortPhotoEnum.PHOTO_AT)
 					.build();
 
 			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
 
 			assertEquals(2, actual.size());
 			assertEquals(new AccountNo(2L), actual.get(0).getAccountNo());
-			assertEquals(1L, actual.get(0).getPhotoNo().value());
+			assertEquals(2L, actual.get(0).getPhotoNo().value());
 			assertEquals(0, actual.get(0).getPhotoTagModelList().size());
 			assertEquals(new AccountNo(2L), actual.get(1).getAccountNo());
-			assertEquals(2L, actual.get(1).getPhotoNo().value());
+			assertEquals(1L, actual.get(1).getPhotoNo().value());
 			assertEquals(0, actual.get(1).getPhotoTagModelList().size());
 		}
 		
@@ -101,47 +111,132 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
 					.accountNo(new AccountNo(1L))
 					.photoAccountNo(new AccountNo(1L))
+					.directionKbn(DirectionEnum.NONE)
+					.isFavoriteOnly(new IsFavoriteOnly(false))
+					.tagList(List.of())
+					.sortBy(SortPhotoEnum.PHOTO_AT)
 					.build();
-			
+
 			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
-			
+
 			assertEquals(2, actual.size());
-			
+
 			assertEquals(new AccountNo(1L), actual.get(0).getAccountNo());
-			assertEquals(1L, actual.get(0).getPhotoNo().value());
-			assertEquals(2, actual.get(0).getPhotoTagModelList().size());
+			assertEquals(2L, actual.get(0).getPhotoNo().value());
+			assertEquals(3, actual.get(0).getPhotoTagModelList().size());
 			assertEquals(new AccountNo(1L), actual.get(0).getPhotoTagModelList().get(0).getAccountNo());
-			assertEquals(1L, actual.get(0).getPhotoTagModelList().get(0).getPhotoNo().value());
+			assertEquals(2L, actual.get(0).getPhotoTagModelList().get(0).getPhotoNo().value());
 			assertEquals(1L, actual.get(0).getPhotoTagModelList().get(0).getTagNo().value());
 			assertEquals("太陽", actual.get(0).getPhotoTagModelList().get(0).getTagJapaneseName().value());
 			assertEquals("sun", actual.get(0).getPhotoTagModelList().get(0).getTagEnglishName().value());
 			assertEquals(new AccountNo(1L), actual.get(0).getPhotoTagModelList().get(1).getAccountNo());
-			assertEquals(1L, actual.get(0).getPhotoTagModelList().get(1).getPhotoNo().value());
+			assertEquals(2L, actual.get(0).getPhotoTagModelList().get(1).getPhotoNo().value());
 			assertEquals(2L, actual.get(0).getPhotoTagModelList().get(1).getTagNo().value());
-			assertEquals("青空", actual.get(0).getPhotoTagModelList().get(1).getTagJapaneseName().value());
-			assertEquals("bluesky", actual.get(0).getPhotoTagModelList().get(1).getTagEnglishName().value());
-			
+			assertEquals("曇天", actual.get(0).getPhotoTagModelList().get(1).getTagJapaneseName().value());
+			assertEquals("cloudy", actual.get(0).getPhotoTagModelList().get(1).getTagEnglishName().value());
+			assertEquals(new AccountNo(1L), actual.get(0).getPhotoTagModelList().get(2).getAccountNo());
+			assertEquals(2L, actual.get(0).getPhotoTagModelList().get(2).getPhotoNo().value());
+			assertEquals(3L, actual.get(0).getPhotoTagModelList().get(2).getTagNo().value());
+			assertEquals("花", actual.get(0).getPhotoTagModelList().get(2).getTagJapaneseName().value());
+			assertEquals("flower", actual.get(0).getPhotoTagModelList().get(2).getTagEnglishName().value());
+
 			assertEquals(new AccountNo(1L), actual.get(1).getAccountNo());
-			assertEquals(2L, actual.get(1).getPhotoNo().value());
-			assertEquals(3, actual.get(1).getPhotoTagModelList().size());
+			assertEquals(1L, actual.get(1).getPhotoNo().value());
+			assertEquals(2, actual.get(1).getPhotoTagModelList().size());
 			assertEquals(new AccountNo(1L), actual.get(1).getPhotoTagModelList().get(0).getAccountNo());
-			assertEquals(2L, actual.get(1).getPhotoTagModelList().get(0).getPhotoNo().value());
+			assertEquals(1L, actual.get(1).getPhotoTagModelList().get(0).getPhotoNo().value());
 			assertEquals(1L, actual.get(1).getPhotoTagModelList().get(0).getTagNo().value());
 			assertEquals("太陽", actual.get(1).getPhotoTagModelList().get(0).getTagJapaneseName().value());
 			assertEquals("sun", actual.get(1).getPhotoTagModelList().get(0).getTagEnglishName().value());
 			assertEquals(new AccountNo(1L), actual.get(1).getPhotoTagModelList().get(1).getAccountNo());
-			assertEquals(2L, actual.get(1).getPhotoTagModelList().get(1).getPhotoNo().value());
+			assertEquals(1L, actual.get(1).getPhotoTagModelList().get(1).getPhotoNo().value());
 			assertEquals(2L, actual.get(1).getPhotoTagModelList().get(1).getTagNo().value());
-			assertEquals("曇天", actual.get(1).getPhotoTagModelList().get(1).getTagJapaneseName().value());
-			assertEquals("cloudy", actual.get(1).getPhotoTagModelList().get(1).getTagEnglishName().value());
-			assertEquals(new AccountNo(1L), actual.get(1).getPhotoTagModelList().get(2).getAccountNo());
-			assertEquals(2L, actual.get(1).getPhotoTagModelList().get(2).getPhotoNo().value());
-			assertEquals(3L, actual.get(1).getPhotoTagModelList().get(2).getTagNo().value());
-			assertEquals("花", actual.get(1).getPhotoTagModelList().get(2).getTagJapaneseName().value());
-			assertEquals("flower", actual.get(1).getPhotoTagModelList().get(2).getTagEnglishName().value());
+			assertEquals("青空", actual.get(1).getPhotoTagModelList().get(1).getTagJapaneseName().value());
+			assertEquals("bluesky", actual.get(1).getPhotoTagModelList().get(1).getTagEnglishName().value());
+		}
+
+		@Test
+		@Order(4)
+		@DisplayName("正常系：向き区分で絞り込まれること")
+		void getPhotoList_filterByDirectionKbn() {
+			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
+					.accountNo(new AccountNo(1L))
+					.photoAccountNo(new AccountNo(1L))
+					.directionKbn(DirectionEnum.VERTICAL)
+					.isFavoriteOnly(new IsFavoriteOnly(false))
+					.tagList(List.of())
+					.sortBy(SortPhotoEnum.PHOTO_AT)
+					.build();
+
+			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
+
+			assertEquals(1, actual.size());
+			assertEquals(1L, actual.get(0).getPhotoNo().value());
+			assertEquals(DirectionEnum.VERTICAL, actual.get(0).getDirectionKbn());
+		}
+
+		@Test
+		@Order(5)
+		@DisplayName("正常系：お気に入りのみに絞り込まれること")
+		void getPhotoList_filterByFavorite() {
+			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
+					.accountNo(new AccountNo(1L))
+					.photoAccountNo(new AccountNo(1L))
+					.directionKbn(DirectionEnum.NONE)
+					.isFavoriteOnly(new IsFavoriteOnly(true))
+					.tagList(List.of())
+					.sortBy(SortPhotoEnum.PHOTO_AT)
+					.build();
+
+			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
+
+			assertEquals(1, actual.size());
+			assertEquals(1L, actual.get(0).getPhotoNo().value());
+			assertTrue(actual.get(0).getIsFavorite().value());
+		}
+
+		@Test
+		@Order(6)
+		@DisplayName("正常系：タグをすべて保持する写真のみに絞り込まれること")
+		void getPhotoList_filterByTags() {
+			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
+					.accountNo(new AccountNo(1L))
+					.photoAccountNo(new AccountNo(1L))
+					.directionKbn(DirectionEnum.NONE)
+					.isFavoriteOnly(new IsFavoriteOnly(false))
+					.tagList(List.of("太陽", "青空"))
+					.sortBy(SortPhotoEnum.PHOTO_AT)
+					.build();
+
+			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
+
+			assertEquals(1, actual.size());
+			assertEquals(1L, actual.get(0).getPhotoNo().value());
+		}
+
+		@Test
+		@Order(7)
+		@DisplayName("正常系：お気に入り数の降順に並び替えられること")
+		void getPhotoList_sortBy_favorite() {
+			PhotoGetModel photoSelectModel = PhotoGetModel.builder()
+					.accountNo(new AccountNo(1L))
+					.photoAccountNo(new AccountNo(1L))
+					.directionKbn(DirectionEnum.NONE)
+					.isFavoriteOnly(new IsFavoriteOnly(false))
+					.tagList(List.of())
+					.sortBy(SortPhotoEnum.FAVORITE)
+					.build();
+
+			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
+
+			assertEquals(2, actual.size());
+			assertEquals(1L, actual.get(0).getPhotoNo().value());
+			assertEquals(2, actual.get(0).getFavoriteCount().value());
+			assertEquals(2L, actual.get(1).getPhotoNo().value());
+			assertEquals(1, actual.get(1).getFavoriteCount().value());
 		}
 	}
-	
+
 	@Nested
 	@Order(2)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
@@ -262,13 +262,13 @@ public class PhotoServiceImplTest {
 		void getPhotoList_not_found() {
 			String accountId = "aaaaaaaa";
 			List<String> tags = new ArrayList<String>();
-			
+
 			AccountModel account = AccountModel.builder().accountNo(new AccountNo(1L)).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
-			
+
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
 			doReturn(PhotoModelList.empty()).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
-			
+
 			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
 					.accountNo(new AccountNo(2L))
 					.photoAccountId(new AccountId(accountId))
@@ -277,102 +277,108 @@ public class PhotoServiceImplTest {
 					.tagList(tags)
 					.sortBy(SortPhotoEnum.PHOTO_AT)
 					.build();
-			
+
 			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
 			assertTrue(actual.isEmpty());
 			verify(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
 			verify(photoDetailRepositoryImpl).getPhotoList(any(PhotoGetModel.class));
-			
+
 			PhotoGetModel photoGetModel = photoGetModelCaptor.getValue();
 			assertEquals(new AccountNo(2L), photoGetModel.getAccountNo());
 			assertEquals(new AccountNo(1L), photoGetModel.getPhotoAccountNo());
+			assertEquals(DirectionEnum.NONE, photoGetModel.getDirectionKbn());
+			assertFalse(photoGetModel.getIsFavoriteOnly().value());
+			assertEquals(tags, photoGetModel.getTagList());
+			assertEquals(SortPhotoEnum.PHOTO_AT, photoGetModel.getSortBy());
 		}
-		
+
 		@Test
 		@Order(2)
-		@DisplayName("正常系：写真が存在した場合で、撮影日順に並び替え")
-		void getPhotoList_sortBy_photoAt() {
+		@DisplayName("正常系：sortByがSEASON以外の場合、フィルタリング・ソート済みのRepositoryの取得結果をそのまま返すこと")
+		void getPhotoList_passThrough_when_sortBy_is_not_season() {
 			String accountId = "aaaaaaaa";
 			List<String> tags = Arrays.asList("太陽", "海");
-			
+
 			AccountModel account = AccountModel.builder().accountNo(new AccountNo(1L)).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
-			
+
+			PhotoModelList repositoryResult = createPhotoModelList();
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
-			doReturn(createPhotoModelList()).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
-			
+			doReturn(repositoryResult).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
+
 			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
 					.accountNo(new AccountNo(2L))
 					.photoAccountId(new AccountId(accountId))
 					.directionKbn(DirectionEnum.VERTICAL)
-					.isFavoriteOnly(new IsFavoriteOnly(false))
-					.tagList(tags)
-					.sortBy(SortPhotoEnum.PHOTO_AT)
-					.build();
-			
-			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
-			assertEquals(3, actual.size());
-			assertEquals(3L, actual.get(0).getPhotoNo().value());
-			assertEquals(2L, actual.get(1).getPhotoNo().value());
-			assertEquals(1L, actual.get(2).getPhotoNo().value());
-			
-			verify(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
-			verify(photoDetailRepositoryImpl).getPhotoList(any(PhotoGetModel.class));
-			
-			PhotoGetModel photoGetModel = photoGetModelCaptor.getValue();
-			assertEquals(new AccountNo(2L), photoGetModel.getAccountNo());
-			assertEquals(new AccountNo(1L), photoGetModel.getPhotoAccountNo());
-		}
-		
-		@Test
-		@Order(3)
-		@DisplayName("正常系：写真が存在した場合で、お気に入り数順に並び替え")
-		void getPhotoList_sortBy_Favorite() {
-			String accountId = "aaaaaaaa";
-			List<String> tags = Arrays.asList("太陽", "海");
-			
-			AccountModel account = AccountModel.builder().accountNo(new AccountNo(1L)).build();
-			doReturn(account).when(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
-			
-			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
-			doReturn(createPhotoModelList()).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
-			
-			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
-					.accountNo(new AccountNo(2L))
-					.photoAccountId(new AccountId(accountId))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.isFavoriteOnly(new IsFavoriteOnly(false))
+					.isFavoriteOnly(new IsFavoriteOnly(true))
 					.tagList(tags)
 					.sortBy(SortPhotoEnum.FAVORITE)
 					.build();
-			
+
 			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
-			assertEquals(3, actual.size());
-			assertEquals(2L, actual.get(0).getPhotoNo().value());
-			assertEquals(3L, actual.get(1).getPhotoNo().value());
-			assertEquals(1L, actual.get(2).getPhotoNo().value());
-			
+			assertEquals(repositoryResult.toList(), actual.toList());
+
 			verify(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
 			verify(photoDetailRepositoryImpl).getPhotoList(any(PhotoGetModel.class));
-			
+
 			PhotoGetModel photoGetModel = photoGetModelCaptor.getValue();
 			assertEquals(new AccountNo(2L), photoGetModel.getAccountNo());
 			assertEquals(new AccountNo(1L), photoGetModel.getPhotoAccountNo());
+			assertEquals(DirectionEnum.VERTICAL, photoGetModel.getDirectionKbn());
+			assertTrue(photoGetModel.getIsFavoriteOnly().value());
+			assertEquals(tags, photoGetModel.getTagList());
+			assertEquals(SortPhotoEnum.FAVORITE, photoGetModel.getSortBy());
 		}
-		
+
 		@Test
-		@Order(4)
-		@DisplayName("正常系：写真が存在した場合で、季節・時期順に並び替え")
+		@Order(3)
+		@DisplayName("正常系：sortByがSEASONの場合、季節・時期順に並び替えられること")
 		void getPhotoList_sortBy_season() {
 			String accountId = "aaaaaaaa";
 			List<String> tags = Arrays.asList("太陽", "海");
-			
+
 			AccountModel account = AccountModel.builder().accountNo(new AccountNo(1L)).build();
 			doReturn(account).when(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
-			
+
+			// SQL側で絞り込み済みの想定で、季節順とは異なる並びでRepositoryの結果をモックする
+			List<PhotoModel> repositoryResultList = new ArrayList<PhotoModel>();
+			repositoryResultList.add(PhotoModel.builder()
+					.accountNo(new AccountNo(1L))
+					.photoNo(new PhotoNo(3L))
+					.favoriteCount(new FavoriteCount(2))
+					.isFavorite(new IsFavorite(false))
+					.photoAt(new PhotoAt(OffsetDateTime.of(2002, 3, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
+					.imageFilePath(new ImageFilePath("DSC333.jpg"))
+					.caption(new Caption("キャプション3"))
+					.directionKbn(DirectionEnum.VERTICAL)
+					.photoTagModelList(PhotoTagModelList.empty())
+					.build());
+			repositoryResultList.add(PhotoModel.builder()
+					.accountNo(new AccountNo(1L))
+					.photoNo(new PhotoNo(1L))
+					.favoriteCount(new FavoriteCount(1))
+					.isFavorite(new IsFavorite(false))
+					.photoAt(new PhotoAt(OffsetDateTime.of(2000, 12, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
+					.imageFilePath(new ImageFilePath("DSC111.jpg"))
+					.caption(new Caption("キャプション1"))
+					.directionKbn(DirectionEnum.VERTICAL)
+					.photoTagModelList(PhotoTagModelList.empty())
+					.build());
+			repositoryResultList.add(PhotoModel.builder()
+					.accountNo(new AccountNo(1L))
+					.photoNo(new PhotoNo(2L))
+					.favoriteCount(new FavoriteCount(3))
+					.isFavorite(new IsFavorite(false))
+					.photoAt(new PhotoAt(OffsetDateTime.of(2001, 6, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
+					.imageFilePath(new ImageFilePath("DSC222.jpg"))
+					.caption(new Caption("キャプション2"))
+					.directionKbn(DirectionEnum.VERTICAL)
+					.photoTagModelList(PhotoTagModelList.empty())
+					.build());
+
 			ArgumentCaptor<PhotoGetModel> photoGetModelCaptor = ArgumentCaptor.forClass(PhotoGetModel.class);
-			doReturn(createPhotoModelList()).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
-			
+			doReturn(PhotoModelList.of(repositoryResultList)).when(photoDetailRepositoryImpl).getPhotoList(photoGetModelCaptor.capture());
+
 			PhotoListGetModel photoListGetModel = PhotoListGetModel.builder()
 					.accountNo(new AccountNo(2L))
 					.photoAccountId(new AccountId(accountId))
@@ -381,19 +387,20 @@ public class PhotoServiceImplTest {
 					.tagList(tags)
 					.sortBy(SortPhotoEnum.SEASON)
 					.build();
-			
+
 			PhotoModelList actual = photoServiceImpl.getPhotoList(photoListGetModel);
 			assertEquals(3, actual.size());
 			assertEquals(1L, actual.get(0).getPhotoNo().value());
 			assertEquals(2L, actual.get(1).getPhotoNo().value());
 			assertEquals(3L, actual.get(2).getPhotoNo().value());
-			
+
 			verify(accountRepositoryImpl).getByAccountId(new AccountId(accountId));
 			verify(photoDetailRepositoryImpl).getPhotoList(any(PhotoGetModel.class));
-			
+
 			PhotoGetModel photoGetModel = photoGetModelCaptor.getValue();
 			assertEquals(new AccountNo(2L), photoGetModel.getAccountNo());
 			assertEquals(new AccountNo(1L), photoGetModel.getPhotoAccountNo());
+			assertEquals(SortPhotoEnum.SEASON, photoGetModel.getSortBy());
 		}
 	}
 	
@@ -1112,17 +1119,17 @@ public class PhotoServiceImplTest {
 	@Nested
 	@Order(6)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-	class getComparator {
+	class getSeasonComparator {
 		@Test
 		@Order(1)
 		@SuppressWarnings("unchecked")
-		@DisplayName("正常系：photoAtの場合")
-		void getComparator_photoAt() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
-			Method getComparator = PhotoServiceImpl.class.getDeclaredMethod("getComparator", SortPhotoEnum.class);
-			getComparator.setAccessible(true);
-			
-			Comparator<PhotoModel> actual = (Comparator<PhotoModel>) getComparator.invoke(photoServiceImpl, SortPhotoEnum.PHOTO_AT);
-			
+		@DisplayName("正常系：季節・時期順に並び替えられること")
+		void getSeasonComparator_success() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
+			Method getSeasonComparator = PhotoServiceImpl.class.getDeclaredMethod("getSeasonComparator");
+			getSeasonComparator.setAccessible(true);
+
+			Comparator<PhotoModel> actual = (Comparator<PhotoModel>) getSeasonComparator.invoke(photoServiceImpl);
+
 			List<PhotoModel> photoModelList = new ArrayList<PhotoModel>();
 			photoModelList.add(PhotoModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1179,238 +1186,13 @@ public class PhotoServiceImplTest {
 					.directionKbn(DirectionEnum.VERTICAL)
 					.photoTagModelList(PhotoTagModelList.empty())
 					.build());
-			
-			List<PhotoModel> actualData = photoModelList.stream().sorted(actual).toList();
-			assertEquals(5L, actualData.get(0).getPhotoNo().value());
-			assertEquals(3L, actualData.get(1).getPhotoNo().value());
-			assertEquals(2L, actualData.get(2).getPhotoNo().value());
-			assertEquals(1L, actualData.get(3).getPhotoNo().value());
-			assertEquals(4L, actualData.get(4).getPhotoNo().value());
-		}
-		
-		@Test
-		@Order(2)
-		@SuppressWarnings("unchecked")
-		@DisplayName("正常系：favoriteの場合")
-		void getComparator_favorite() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
-			Method getComparator = PhotoServiceImpl.class.getDeclaredMethod("getComparator", SortPhotoEnum.class);
-			getComparator.setAccessible(true);
-			
-			Comparator<PhotoModel> actual = (Comparator<PhotoModel>) getComparator.invoke(photoServiceImpl, SortPhotoEnum.FAVORITE);
-			
-			List<PhotoModel> photoModelList = new ArrayList<PhotoModel>();
-			photoModelList.add(PhotoModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(1L))
-					.favoriteCount(new FavoriteCount(1))
-					.isFavorite(new IsFavorite(false))
-					.photoAt(new PhotoAt(OffsetDateTime.of(2002, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
-					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC111.jpg"))
-					.caption(new Caption("キャプション1"))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(PhotoTagModelList.empty())
-					.build());
-			photoModelList.add(PhotoModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(2L))
-					.favoriteCount(new FavoriteCount(3))
-					.isFavorite(new IsFavorite(false))
-					.photoAt(new PhotoAt(OffsetDateTime.of(2002, 2, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
-					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC222.jpg"))
-					.caption(new Caption("キャプション2"))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(PhotoTagModelList.empty())
-					.build());
-			photoModelList.add(PhotoModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(3L))
-					.favoriteCount(new FavoriteCount(2))
-					.isFavorite(new IsFavorite(false))
-					.photoAt(new PhotoAt(OffsetDateTime.of(2002, 3, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
-					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC333.jpg"))
-					.caption(new Caption("キャプション3"))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(PhotoTagModelList.empty())
-					.build());
-			photoModelList.add(PhotoModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(4L))
-					.favoriteCount(new FavoriteCount(2))
-					.isFavorite(new IsFavorite(false))
-					.photoAt(new PhotoAt(OffsetDateTime.of(2001, 3, 31, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
-					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC444.jpg"))
-					.caption(new Caption("キャプション4"))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(PhotoTagModelList.empty())
-					.build());
-			photoModelList.add(PhotoModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(5L))
-					.favoriteCount(new FavoriteCount(3))
-					.isFavorite(new IsFavorite(false))
-					.photoAt(new PhotoAt(OffsetDateTime.of(2003, 3, 31, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
-					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC555.jpg"))
-					.caption(new Caption("キャプション5"))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(PhotoTagModelList.empty())
-					.build());
-			
-			List<PhotoModel> actualData = photoModelList.stream().sorted(actual).toList();
-			assertEquals(2L, actualData.get(0).getPhotoNo().value());
-			assertEquals(5L, actualData.get(1).getPhotoNo().value());
-			assertEquals(3L, actualData.get(2).getPhotoNo().value());
-			assertEquals(4L, actualData.get(3).getPhotoNo().value());
-			assertEquals(1L, actualData.get(4).getPhotoNo().value());
-		}
-		
-		@Test
-		@Order(3)
-		@SuppressWarnings("unchecked")
-		@DisplayName("正常系：seasonの場合")
-		void getComparator_season() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
-			Method getComparator = PhotoServiceImpl.class.getDeclaredMethod("getComparator", SortPhotoEnum.class);
-			getComparator.setAccessible(true);
-			
-			Comparator<PhotoModel> actual = (Comparator<PhotoModel>) getComparator.invoke(photoServiceImpl, SortPhotoEnum.SEASON);
-			
-			List<PhotoModel> photoModelList = new ArrayList<PhotoModel>();
-			photoModelList.add(PhotoModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(1L))
-					.favoriteCount(new FavoriteCount(1))
-					.isFavorite(new IsFavorite(false))
-					.photoAt(new PhotoAt(OffsetDateTime.of(2002, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
-					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC111.jpg"))
-					.caption(new Caption("キャプション1"))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(PhotoTagModelList.empty())
-					.build());
-			photoModelList.add(PhotoModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(2L))
-					.favoriteCount(new FavoriteCount(3))
-					.isFavorite(new IsFavorite(false))
-					.photoAt(new PhotoAt(OffsetDateTime.of(2002, 2, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
-					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC222.jpg"))
-					.caption(new Caption("キャプション2"))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(PhotoTagModelList.empty())
-					.build());
-			photoModelList.add(PhotoModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(3L))
-					.favoriteCount(new FavoriteCount(2))
-					.isFavorite(new IsFavorite(false))
-					.photoAt(new PhotoAt(OffsetDateTime.of(2002, 3, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
-					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC333.jpg"))
-					.caption(new Caption("キャプション3"))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(PhotoTagModelList.empty())
-					.build());
-			photoModelList.add(PhotoModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(4L))
-					.favoriteCount(new FavoriteCount(2))
-					.isFavorite(new IsFavorite(false))
-					.photoAt(new PhotoAt(OffsetDateTime.of(2001, 3, 31, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
-					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC444.jpg"))
-					.caption(new Caption("キャプション4"))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(PhotoTagModelList.empty())
-					.build());
-			photoModelList.add(PhotoModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(5L))
-					.favoriteCount(new FavoriteCount(3))
-					.isFavorite(new IsFavorite(false))
-					.photoAt(new PhotoAt(OffsetDateTime.of(2003, 3, 31, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
-					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC555.jpg"))
-					.caption(new Caption("キャプション5"))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(PhotoTagModelList.empty())
-					.build());
-			
+
 			List<PhotoModel> actualData = photoModelList.stream().sorted(actual).toList();
 			assertEquals(4L, actualData.get(0).getPhotoNo().value());
 			assertEquals(5L, actualData.get(1).getPhotoNo().value());
 			assertEquals(3L, actualData.get(2).getPhotoNo().value());
 			assertEquals(2L, actualData.get(3).getPhotoNo().value());
 			assertEquals(1L, actualData.get(4).getPhotoNo().value());
-		}
-		
-		@Test
-		@Order(4)
-		@SuppressWarnings("unchecked")
-		@DisplayName("正常系：それ以外の場合")
-		void getComparator_others() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
-			Method getComparator = PhotoServiceImpl.class.getDeclaredMethod("getComparator", SortPhotoEnum.class);
-			getComparator.setAccessible(true);
-			
-			Comparator<PhotoModel> actual = (Comparator<PhotoModel>) getComparator.invoke(photoServiceImpl, SortPhotoEnum.PHOTO_AT);
-			
-			List<PhotoModel> photoModelList = new ArrayList<PhotoModel>();
-			photoModelList.add(PhotoModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(1L))
-					.favoriteCount(new FavoriteCount(1))
-					.isFavorite(new IsFavorite(false))
-					.photoAt(new PhotoAt(OffsetDateTime.of(2002, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
-					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC111.jpg"))
-					.caption(new Caption("キャプション1"))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(PhotoTagModelList.empty())
-					.build());
-			photoModelList.add(PhotoModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(2L))
-					.favoriteCount(new FavoriteCount(3))
-					.isFavorite(new IsFavorite(false))
-					.photoAt(new PhotoAt(OffsetDateTime.of(2002, 2, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
-					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC222.jpg"))
-					.caption(new Caption("キャプション2"))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(PhotoTagModelList.empty())
-					.build());
-			photoModelList.add(PhotoModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(3L))
-					.favoriteCount(new FavoriteCount(2))
-					.isFavorite(new IsFavorite(false))
-					.photoAt(new PhotoAt(OffsetDateTime.of(2002, 3, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
-					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC333.jpg"))
-					.caption(new Caption("キャプション3"))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(PhotoTagModelList.empty())
-					.build());
-			photoModelList.add(PhotoModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(4L))
-					.favoriteCount(new FavoriteCount(2))
-					.isFavorite(new IsFavorite(false))
-					.photoAt(new PhotoAt(OffsetDateTime.of(2001, 3, 31, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
-					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC444.jpg"))
-					.caption(new Caption("キャプション4"))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(PhotoTagModelList.empty())
-					.build());
-			photoModelList.add(PhotoModel.builder()
-					.accountNo(new AccountNo(1L))
-					.photoNo(new PhotoNo(5L))
-					.favoriteCount(new FavoriteCount(3))
-					.isFavorite(new IsFavorite(false))
-					.photoAt(new PhotoAt(OffsetDateTime.of(2003, 3, 31, 0, 0, 0, 0, ZoneOffset.ofHours(0))))
-					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC555.jpg"))
-					.caption(new Caption("キャプション5"))
-					.directionKbn(DirectionEnum.VERTICAL)
-					.photoTagModelList(PhotoTagModelList.empty())
-					.build());
-			
-			List<PhotoModel> actualData = photoModelList.stream().sorted(actual).toList();
-			assertEquals(5L, actualData.get(0).getPhotoNo().value());
-			assertEquals(3L, actualData.get(1).getPhotoNo().value());
-			assertEquals(2L, actualData.get(2).getPhotoNo().value());
-			assertEquals(1L, actualData.get(3).getPhotoNo().value());
-			assertEquals(4L, actualData.get(4).getPhotoNo().value());
 		}
 	}
 	


### PR DESCRIPTION
# 概要

## 背景

`PhotoServiceImpl.getPhotoList()`で、DBから全件取得した後にJavaでフィルタリング・ソートを行っていた。
データ量が増加した場合にメモリ逼迫とパフォーマンス劣化が発生する懸念があるため、
コードレビューの指摘（1-1）を受けてSQL側に処理を移行する。

## 変更内容

- 向き区分・お気に入り・タグの絞り込みと、撮影日時/お気に入り数の並び替えを、MyBatis XML（`PhotoDetailMapper.xml`）のWHERE句・ORDER BYに移行
  - タグの複数条件（AND）はEXISTSサブクエリ + `<foreach>`で実現
  - `direction_kbn`はPostgreSQLのカスタムenum型のため、既存の`PhotoMstMapper.xml`に倣い`::photo.direction_enum`キャストを付与
  - お気に入り数/撮影日時が同値の場合の順序を決定的にするため、`photo_no`昇順を第2ソートキーとして追加（既存のJava実装の安定ソートと同じ並び順を維持）
- 季節・時期順ソートのみ、タイムゾーン変換の複雑さから引き続きアプリケーション層（`PhotoServiceImpl.getSeasonComparator()`）で実施
- 上記に伴い不要になった`PhotoModelList.filterByDirectionKbn/filterByFavorite/filterByTags`と`PhotoTagModelList.containsAllTags`を削除
- 関連するユニットテスト・統合テストを更新し、SQLフィルタ・ソートを検証するテストケースを追加

# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `./backend/gradlew -p backend bootRun` で backend の起動が成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認

# 懸念事項

- タグ絞り込みのEXISTSサブクエリはタグ数分ネストするため、`photo_tag_mst(account_no, photo_no)`への複合インデックスの有無を確認いただきたい
- タグ一覧の取得自体（`PhotoDetailRepositoryImpl.getPhotoList()`でのN+1相当の問題）は別途対応予定（今回のスコープ外）