### PR TITLE
refactor: 写真番号の採番ロジックをRepositoryからドメインクラスへ移動する

### DIFF
--- a/backend/src/main/java/com/web/gallery/domain/photo/PhotoNo.java
+++ b/backend/src/main/java/com/web/gallery/domain/photo/PhotoNo.java
@@ -1,6 +1,7 @@
 package com.web.gallery.domain.photo;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 /**
  * 写真番号の値オブジェクト
@@ -21,5 +22,15 @@ public record PhotoNo(Long value) implements Serializable {
 		if (value <= 0) {
 			throw new IllegalArgumentException("写真番号は正の値である必要があります");
 		}
+	}
+
+	/**
+	 * 現在登録されている最大写真番号から、新規採番する写真番号を生成する
+	 *
+	 * @param	maxPhotoNo	現在登録されている最大写真番号（未登録の場合はnull）
+	 * @return				新規採番した写真番号
+	 */
+	public static PhotoNo next(Long maxPhotoNo) {
+		return new PhotoNo(Optional.ofNullable(maxPhotoNo).map(num -> num + 1).orElse(1L));
 	}
 }

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
@@ -1,7 +1,5 @@
 package com.web.gallery.repository.impl;
 
-import java.util.Optional;
-
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Repository;
 
@@ -93,8 +91,8 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 */
 	@Override
 	public PhotoNo getNewPhotoNo(AccountNo accountNo) {
-		Long photoNo = photoMstMapper.getMaxPhotoNo(accountNo.value());
-		return new PhotoNo(Optional.ofNullable(photoNo).map(num -> num + 1).orElse(1L));
+		Long maxPhotoNo = photoMstMapper.getMaxPhotoNo(accountNo.value());
+		return PhotoNo.next(maxPhotoNo);
 	}
 
 	/**


### PR DESCRIPTION
# 概要

## 背景

バックエンドコードレビューにて、`PhotoMstRepositoryImpl`がデータアクセスに加えて写真番号(photoNo)の採番ロジック(現在の最大値+1の計算)を含んでおり、Repository層の責務が過剰であるという指摘があった。

## 変更内容

- `PhotoNo`ドメインクラスに、最大写真番号から新規採番する`next(Long maxPhotoNo)`ファクトリメソッドを追加
- `PhotoMstRepositoryImpl.getNewPhotoNo`から採番計算ロジックを除去し、`PhotoNo.next()`を呼び出すのみに変更(Repositoryはmapperの結果を渡すだけの純粋なデータアクセスに専念)

# 検証事項

- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認

# 懸念事項

特になし。既存の`getNewPhotoNo`のメソッドシグネチャ・振る舞いは変更していないため、呼び出し元(`PhotoServiceImpl`)への影響はない。