### PR TITLE
refactor: ErrorEnumに例外生成ファクトリメソッドを追加し例外生成ロジックを集約する

### DIFF
--- a/backend/src/main/java/com/web/gallery/aspect/AdminAuthorityAspect.java
+++ b/backend/src/main/java/com/web/gallery/aspect/AdminAuthorityAspect.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 
 import com.web.gallery.enumeration.AuthorityEnum;
 import com.web.gallery.enumeration.ErrorEnum;
-import com.web.gallery.exception.ForbiddenAccountException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.helper.SessionHelper;
 
 import lombok.RequiredArgsConstructor;
@@ -24,12 +24,12 @@ public class AdminAuthorityAspect {
 	/**
 	 * 管理者権限のバリデーションを行う
 	 *
-	 * @throws	ForbiddenAccountException	管理者権限がない場合
+	 * @throws	GalleryException	管理者権限がない場合
 	 */
 	@Before("@annotation(com.web.gallery.annotation.RequireAdminAuthority)")
-	public void validateAdminAuthority() throws ForbiddenAccountException {
+	public void validateAdminAuthority() throws GalleryException {
 		if (sessionHelper.getAuthorityKbn() != AuthorityEnum.ADMINISTRATOR) {
-			throw new ForbiddenAccountException(ErrorEnum.NOT_AUTHORIZED_TO_ADMIN);
+			throw ErrorEnum.NOT_AUTHORIZED_TO_ADMIN.toException();
 		}
 	}
 }

--- a/backend/src/main/java/com/web/gallery/controller/AccountRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/AccountRestController.java
@@ -28,10 +28,8 @@ import com.web.gallery.controller.response.AccountUpdateResponse;
 import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.enumeration.ErrorEnum;
-import com.web.gallery.exception.BadRequestException;
-import com.web.gallery.exception.ForbiddenAccountException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
-import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.helper.SessionHelper;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.service.impl.AccountServiceImpl;
@@ -79,7 +77,7 @@ public class AccountRestController {
 	 *
 	 * @param	accountId	アカウントID
 	 * @return				{@link AccountDetailResponse}
-	 * @throws	ForbiddenAccountException	認証ユーザーと異なるアカウントIDの場合
+	 * @throws	GalleryException	認証ユーザーと異なるアカウントIDの場合
 	 */
 	@Operation(summary = "アカウント詳細取得", description = "指定したアカウントの詳細情報を取得する")
 	@ApiResponse(responseCode = "200", description = "取得成功")
@@ -87,10 +85,10 @@ public class AccountRestController {
 	@SecurityRequirement(name = "Bearer")
 	@GetMapping(ApiRoutes.API_ACCOUNT)
 	public ResponseEntity<AccountDetailResponse> getAccount(
-			@PathVariable String accountId) throws ForbiddenAccountException {
+			@PathVariable String accountId) throws GalleryException {
 
 		if (!accountId.equals(sessionHelper.getAccountId())) {
-			throw new ForbiddenAccountException(ErrorEnum.NOT_AUTHORIZED_TO_EDIT_ACCOUNT);
+			throw ErrorEnum.NOT_AUTHORIZED_TO_EDIT_ACCOUNT.toException();
 		}
 
 		AccountModel accountModel = accountServiceImpl.getAccountById(new AccountId(accountId));
@@ -106,8 +104,9 @@ public class AccountRestController {
 	 * @param	accountRegistRequest	{@link AccountRegistRequest}
 	 * @param	result					AccountRegistRequestのバインディング結果
 	 * @return							{@link AccountRegistResponse}
-	 * @throws	BadRequestException 	リクエストパラメータが不正の場合
-	 * @throws	RegistFailureException 	一意制約違反でアカウントの登録に失敗した場合
+	 * @throws	GalleryException		以下のいずれかに該当する場合
+	 *                              	・リクエストパラメータが不正の場合
+	 *                              	・一意制約違反でアカウントの登録に失敗した場合
 	 */
 	@Operation(summary = "アカウント登録", description = "新規アカウントを登録する")
 	@ApiResponse(responseCode = "200", description = "登録成功")
@@ -116,14 +115,14 @@ public class AccountRestController {
 	@PostMapping(ApiRoutes.API_ACCOUNTS)
 	public ResponseEntity<AccountRegistResponse> register(
 			@RequestBody @Validated AccountRegistRequest accountRegistRequest,
-			BindingResult result) throws BadRequestException, RegistFailureException {
-		
+			BindingResult result) throws GalleryException {
+
 		if(result.hasErrors()) {
 			for(FieldError error : result.getFieldErrors()) {
 				log.info("Invalid input. (Field: {}, Value: {}, Message: {})",
 						error.getField(), error.getRejectedValue(), error.getDefaultMessage());
 			}
-			throw new BadRequestException(ErrorEnum.INVALID_INPUT);
+			throw ErrorEnum.INVALID_INPUT.toException();
 		}
 		
 		AccountModel accountModel = AccountModel.from(accountRegistRequest);
@@ -139,8 +138,9 @@ public class AccountRestController {
 	 * @param	accountUpdateRequest	{@link AccountUpdateRequest}
 	 * @param	result					AccountUpdateRequestのバインディング結果
 	 * @return							{@link AccountUpdateResponse}
-	 * @throws	BadRequestException		リクエストパラメータが不正の場合
-	 * @throws	UpdateFailureException	更新に失敗した場合
+	 * @throws	GalleryException		以下のいずれかに該当する場合
+	 *                              	・リクエストパラメータが不正の場合
+	 *                              	・更新に失敗した場合
 	 */
 	@Operation(summary = "アカウント更新", description = "アカウント情報を更新する")
 	@ApiResponse(responseCode = "200", description = "更新成功")
@@ -152,23 +152,23 @@ public class AccountRestController {
 	public ResponseEntity<AccountUpdateResponse> update(
 			@PathVariable String accountId,
 			@RequestBody @Validated AccountUpdateRequest accountUpdateRequest,
-			BindingResult result) throws BadRequestException, UpdateFailureException {
-		
+			BindingResult result) throws GalleryException {
+
 		if(result.hasErrors()) {
 			for(FieldError error : result.getFieldErrors()) {
 				log.info("Invalid input. (Field: {}, Value: {}, Message: {})",
 						error.getField(), error.getRejectedValue(), error.getDefaultMessage());
 			}
-			
+
 			List<String> fieldList
 				= result.getFieldErrors().stream().map(FieldError::getField).distinct().toList();
-			
-			if(!(fieldList.size() == 1 && 
-					"newPassword".equals(fieldList.getFirst()) && 
+
+			if(!(fieldList.size() == 1 &&
+					"newPassword".equals(fieldList.getFirst()) &&
 				accountUpdateRequest.getNewPassword().isEmpty())) {
 					// 新しいパスワードが空欄で他にパラメータ不正がない場合は、スキップ
 					// 新しいパスワード以外や新しいパスワードの入力に不正がある場合は、例外
-					throw new BadRequestException(ErrorEnum.INVALID_INPUT);
+					throw ErrorEnum.INVALID_INPUT.toException();
 			}
 		}
 		
@@ -188,7 +188,7 @@ public class AccountRestController {
 	 *
 	 * @param	accountId				アカウントID
 	 * @return							{@link ResponseEntity}
-	 * @throws	ForbiddenAccountException	認証ユーザーと異なるアカウントIDの場合
+	 * @throws	GalleryException		認証ユーザーと異なるアカウントIDの場合
 	 */
 	@Operation(summary = "アカウント削除", description = "アカウントと関連データをすべて物理削除する")
 	@ApiResponse(responseCode = "200", description = "削除成功")
@@ -196,10 +196,10 @@ public class AccountRestController {
 	@SecurityRequirement(name = "Bearer")
 	@DeleteMapping(ApiRoutes.API_ACCOUNT)
 	public ResponseEntity<Void> deleteAccount(
-			@PathVariable String accountId) throws ForbiddenAccountException {
+			@PathVariable String accountId) throws GalleryException {
 
 		if (!accountId.equals(sessionHelper.getAccountId())) {
-			throw new ForbiddenAccountException(ErrorEnum.NOT_AUTHORIZED_TO_EDIT_ACCOUNT);
+			throw ErrorEnum.NOT_AUTHORIZED_TO_EDIT_ACCOUNT.toException();
 		}
 
 		accountServiceImpl.deleteAccount(new AccountNo(sessionHelper.getAccountNo()), new AccountId(accountId));

--- a/backend/src/main/java/com/web/gallery/controller/AdminAccountRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/AdminAccountRestController.java
@@ -14,8 +14,7 @@ import com.web.gallery.constant.MessageConst;
 import com.web.gallery.controller.response.AdminAccountListItemResponse;
 import com.web.gallery.controller.response.AdminAccountLockResponse;
 import com.web.gallery.domain.account.AccountNo;
-import com.web.gallery.exception.ForbiddenAccountException;
-import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.service.impl.AccountServiceImpl;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,7 +38,7 @@ public class AdminAccountRestController {
 	 * 管理者用アカウント一覧取得
 	 *
 	 * @return	{@link AdminAccountListItemResponse}のリスト
-	 * @throws	ForbiddenAccountException	管理者権限がない場合
+	 * @throws	GalleryException	管理者権限がない場合
 	 */
 	@Operation(summary = "管理者用アカウント一覧取得", description = "削除済みを含む全アカウントの一覧を取得する")
 	@ApiResponse(responseCode = "200", description = "取得成功")
@@ -47,7 +46,7 @@ public class AdminAccountRestController {
 	@RequireAdminAuthority
 	@GetMapping(ApiRoutes.API_ADMIN_ACCOUNTS)
 	public ResponseEntity<List<AdminAccountListItemResponse>> getAdminAccountList()
-			throws ForbiddenAccountException {
+			throws GalleryException {
 
 		List<AdminAccountListItemResponse> responseList = accountServiceImpl.getAccountListForAdmin().stream()
 				.map(AdminAccountListItemResponse::from)
@@ -61,8 +60,9 @@ public class AdminAccountRestController {
 	 *
 	 * @param	accountNo	アカウント番号
 	 * @return				{@link AdminAccountLockResponse}
-	 * @throws	ForbiddenAccountException	管理者権限がない場合
-	 * @throws	UpdateFailureException		更新に失敗した場合
+	 * @throws	GalleryException	以下のいずれかに該当する場合
+	 *                          	・管理者権限がない場合
+	 *                          	・更新に失敗した場合
 	 */
 	@Operation(summary = "アカウントロック解除", description = "指定したアカウントのロックを解除する")
 	@ApiResponse(responseCode = "200", description = "ロック解除成功")
@@ -70,7 +70,7 @@ public class AdminAccountRestController {
 	@RequireAdminAuthority
 	@PutMapping(ApiRoutes.API_ADMIN_ACCOUNT_UNLOCK)
 	public ResponseEntity<AdminAccountLockResponse> unlockAccount(
-			@PathVariable Long accountNo) throws ForbiddenAccountException, UpdateFailureException {
+			@PathVariable Long accountNo) throws GalleryException {
 
 		accountServiceImpl.unlockAccount(new AccountNo(accountNo));
 
@@ -82,8 +82,9 @@ public class AdminAccountRestController {
 	 *
 	 * @param	accountNo	アカウント番号
 	 * @return				{@link AdminAccountLockResponse}
-	 * @throws	ForbiddenAccountException	管理者権限がない場合
-	 * @throws	UpdateFailureException		更新に失敗した場合
+	 * @throws	GalleryException	以下のいずれかに該当する場合
+	 *                          	・管理者権限がない場合
+	 *                          	・更新に失敗した場合
 	 */
 	@Operation(summary = "アカウント強制ロック", description = "指定したアカウントを強制的にロックする")
 	@ApiResponse(responseCode = "200", description = "ロック成功")
@@ -91,7 +92,7 @@ public class AdminAccountRestController {
 	@RequireAdminAuthority
 	@PutMapping(ApiRoutes.API_ADMIN_ACCOUNT_LOCK)
 	public ResponseEntity<AdminAccountLockResponse> lockAccount(
-			@PathVariable Long accountNo) throws ForbiddenAccountException, UpdateFailureException {
+			@PathVariable Long accountNo) throws GalleryException {
 
 		accountServiceImpl.lockAccount(new AccountNo(accountNo));
 

--- a/backend/src/main/java/com/web/gallery/controller/AuthRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/AuthRestController.java
@@ -22,7 +22,7 @@ import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.Password;
 import com.web.gallery.domain.auth.RefreshTokenValue;
 import com.web.gallery.enumeration.ErrorEnum;
-import com.web.gallery.exception.BadRequestException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.AuthTokenModel;
 import com.web.gallery.service.AuthService;
 
@@ -56,7 +56,7 @@ public class AuthRestController {
 	 * @param	authLoginRequest	{@link AuthLoginRequest}
 	 * @param	result				AuthLoginRequestのバインディング結果
 	 * @return						{@link AuthLoginResponse}
-	 * @throws	BadRequestException	リクエストパラメータが不正の場合
+	 * @throws	GalleryException	リクエストパラメータが不正の場合
 	 */
 	@Operation(summary = "ログイン", description = "アカウントIDとパスワードで認証し、JWTトークンを発行する")
 	@ApiResponse(responseCode = "200", description = "認証成功")
@@ -66,10 +66,10 @@ public class AuthRestController {
 	@PostMapping(ApiRoutes.API_AUTH_LOGIN)
 	public ResponseEntity<AuthLoginResponse> login(
 			@RequestBody @Validated AuthLoginRequest authLoginRequest,
-			BindingResult result) throws BadRequestException {
+			BindingResult result) throws GalleryException {
 
 		if (result.hasErrors()) {
-			throw new BadRequestException(ErrorEnum.INVALID_INPUT);
+			throw ErrorEnum.INVALID_INPUT.toException();
 		}
 
 		AuthTokenModel tokenModel = authService.login(

--- a/backend/src/main/java/com/web/gallery/controller/PhotoFavoriteController.java
+++ b/backend/src/main/java/com/web/gallery/controller/PhotoFavoriteController.java
@@ -14,9 +14,7 @@ import com.web.gallery.controller.request.PhotoFavoriteDeleteRequest;
 import com.web.gallery.controller.request.PhotoFavoriteRegistRequest;
 import com.web.gallery.controller.response.PhotoFavoriteResponse;
 import com.web.gallery.enumeration.ErrorEnum;
-import com.web.gallery.exception.BadRequestException;
-import com.web.gallery.exception.RegistFailureException;
-import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.helper.SessionHelper;
 import com.web.gallery.model.PhotoFavoriteModel;
 import com.web.gallery.service.PhotoFavoriteService;
@@ -50,8 +48,9 @@ public class PhotoFavoriteController {
 	 * @param	photoFavoriteRegistRequest	{@link PhotoFavoriteRegistRequest}
 	 * @param	result						PhotoFavoriteRegistRequestのバインディング結果
 	 * @return	PhotoFavoriteResponse		{@link PhotoFavoriteResponse}
-	 * @throws	BadRequestException 		リクエストパラメータが不正の場合
-	 * @throws	RegistFailureException 		お気に入りの登録に失敗した場合
+	 * @throws	GalleryException			以下のいずれかに該当する場合
+	 *                              		・リクエストパラメータが不正の場合
+	 *                              		・お気に入りの登録に失敗した場合
 	 */
 	@Operation(summary = "お気に入り登録", description = "指定した写真をお気に入りに登録する")
 	@ApiResponse(responseCode = "200", description = "登録成功")
@@ -60,12 +59,12 @@ public class PhotoFavoriteController {
 	@PostMapping(ApiRoutes.API_FAVORITES)
 	public ResponseEntity<PhotoFavoriteResponse> addFavorite(
 			@RequestBody @Validated PhotoFavoriteRegistRequest photoFavoriteRegistRequest,
-			BindingResult result) throws BadRequestException, RegistFailureException {
-		
+			BindingResult result) throws GalleryException {
+
 		if(result.hasErrors()) {
 			log.info("Invalid input. (FavoritePhotoAccountNo: {}, FavoritePhotoNo: {})",
 					photoFavoriteRegistRequest.getFavoritePhotoAccountNo(), photoFavoriteRegistRequest.getFavoritePhotoNo());
-			throw new BadRequestException(ErrorEnum.INVALID_INPUT);
+			throw ErrorEnum.INVALID_INPUT.toException();
 		}
 		
 		photoFavoriteService.addFavorite(PhotoFavoriteModel.from(photoFavoriteRegistRequest, sessionHelper.getAccountNo()));
@@ -79,8 +78,9 @@ public class PhotoFavoriteController {
 	 * @param	photoFavoriteDeleteRequest	{@link PhotoFavoriteDeleteRequest}
 	 * @param	result						PhotoFavoriteDeleteRequestのバインディング結果
 	 * @return	PhotoFavoriteResponse		{@link PhotoFavoriteResponse}
-	 * @throws	BadRequestException 		リクエストパラメータが不正の場合
-	 * @throws	UpdateFailureException 		お気に入りの解除に失敗した場合
+	 * @throws	GalleryException			以下のいずれかに該当する場合
+	 *                              		・リクエストパラメータが不正の場合
+	 *                              		・お気に入りの解除に失敗した場合
 	 */
 	@Operation(summary = "お気に入り解除", description = "指定した写真のお気に入りを解除する")
 	@ApiResponse(responseCode = "200", description = "解除成功")
@@ -89,12 +89,12 @@ public class PhotoFavoriteController {
 	@DeleteMapping(ApiRoutes.API_FAVORITES)
 	public ResponseEntity<PhotoFavoriteResponse> deleteFavorite(
 			@RequestBody @Validated PhotoFavoriteDeleteRequest photoFavoriteDeleteRequest,
-			BindingResult result) throws BadRequestException, UpdateFailureException {
+			BindingResult result) throws GalleryException {
 
 		if(result.hasErrors()) {
 			log.info("Invalid input. (FavoritePhotoAccountNo: {}, FavoritePhotoNo: {})",
 					photoFavoriteDeleteRequest.getFavoritePhotoAccountNo(), photoFavoriteDeleteRequest.getFavoritePhotoNo());
-			throw new BadRequestException(ErrorEnum.INVALID_INPUT);
+			throw ErrorEnum.INVALID_INPUT.toException();
 		}
 		
 		photoFavoriteService.deleteFavorite(PhotoFavoriteModel.from(photoFavoriteDeleteRequest, sessionHelper.getAccountNo()));

--- a/backend/src/main/java/com/web/gallery/controller/PhotoRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/PhotoRestController.java
@@ -32,13 +32,7 @@ import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.enumeration.ErrorEnum;
-import com.web.gallery.exception.BadRequestException;
-import com.web.gallery.exception.FileDuplicateException;
-import com.web.gallery.exception.ForbiddenAccountException;
-import com.web.gallery.exception.PhotoNotAdditableException;
-import com.web.gallery.exception.PhotoNotFoundException;
-import com.web.gallery.exception.RegistFailureException;
-import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.helper.SessionHelper;
 import com.web.gallery.model.PhotoDeleteModel;
 import com.web.gallery.model.PhotoDeleteModelList;
@@ -120,7 +114,7 @@ public class PhotoRestController {
 	 * @param	photoNo				写真番号
 	 * @param	accountNo			写真所有者のアカウント番号
 	 * @return						{@link PhotoDetailGetResponse}
-	 * @throws	PhotoNotFoundException	写真が存在しない場合
+	 * @throws	GalleryException	写真が存在しない場合
 	 */
 	@Operation(summary = "写真詳細取得", description = "写真の詳細情報（EXIF・タグを含む）を取得する")
 	@ApiResponse(responseCode = "200", description = "取得成功")
@@ -129,7 +123,7 @@ public class PhotoRestController {
 	public ResponseEntity<PhotoDetailGetResponse> getPhotoDetail(
 			@PathVariable String photoAccountId,
 			@PathVariable Long photoNo,
-			Long accountNo) throws PhotoNotFoundException {
+			Long accountNo) throws GalleryException {
 
 		PhotoDetailModel photoDetailModel = photoService.getPhotoDetail(
 				PhotoDetailGetModel.of(sessionHelper.getAccountNo(), accountNo, photoNo));
@@ -143,13 +137,14 @@ public class PhotoRestController {
 	 * @param	photoAccountId				ページ所有者のアカウントID
 	 * @param	photoSaveRequest			{@link PhotoSaveRequest}
 	 * @param	result						PhotoSaveRequestのバインディング結果
-	 * @return								{@link PhotoEditResponse}
-	 * @throws	ForbiddenAccountException 	写真の所有者以外がリクエストした場合
-	 * @throws	PhotoNotAdditableException	写真の登録枚数の上限に達している場合
-	 * @throws	BadRequestException 		リクエストパラメータが不正の場合
-	 * @throws	FileDuplicateException 		保存するファイルが重複した場合
-	 * @throws	RegistFailureException 		写真の登録に失敗した場合
-	 * @throws	UpdateFailureException 		写真の更新に失敗した場合
+	 * @return							{@link PhotoEditResponse}
+	 * @throws	GalleryException		以下のいずれかに該当する場合
+	 *                              	・写真の所有者以外がリクエストした場合
+	 *                              	・写真の登録枚数の上限に達している場合
+	 *                              	・リクエストパラメータが不正の場合
+	 *                              	・保存するファイルが重複した場合
+	 *                              	・写真の登録に失敗した場合
+	 *                              	・写真の更新に失敗した場合
 	 */
 	@Operation(summary = "写真保存", description = "写真を新規登録または更新する")
 	@ApiResponse(responseCode = "200", description = "保存成功")
@@ -159,28 +154,28 @@ public class PhotoRestController {
 	@SecurityRequirement(name = "Bearer")
 	@RequestMapping(value = ApiRoutes.API_PHOTOS, method = {RequestMethod.POST, RequestMethod.PUT})
 	public ResponseEntity<PhotoEditResponse> savePhoto(
-			@PathVariable String photoAccountId, 
-			@ModelAttribute @Validated PhotoSaveRequest photoSaveRequest, 
-			BindingResult result) throws FileDuplicateException, ForbiddenAccountException, RegistFailureException, UpdateFailureException, BadRequestException, PhotoNotAdditableException {
-		
+			@PathVariable String photoAccountId,
+			@ModelAttribute @Validated PhotoSaveRequest photoSaveRequest,
+			BindingResult result) throws GalleryException {
+
 		if(!photoAccountId.equals(sessionHelper.getAccountId())) {
-			throw new ForbiddenAccountException(ErrorEnum.NOT_AUTHORIZED_TO_EDIT_PHOTO);
+			throw ErrorEnum.NOT_AUTHORIZED_TO_EDIT_PHOTO.toException();
 		}
 
 		if(Objects.isNull(photoSaveRequest.getPhotoNo()) && photoService.isReachedUpperLimit(new AccountNo(sessionHelper.getAccountNo()))) {
-			throw new PhotoNotAdditableException(ErrorEnum.REACHED_REGISTRATION_LIMIT);
+			throw ErrorEnum.REACHED_REGISTRATION_LIMIT.toException();
 		}
-		
-		if(Objects.isNull(photoSaveRequest.getImageFile()) && 
+
+		if(Objects.isNull(photoSaveRequest.getImageFile()) &&
 				(Objects.isNull(photoSaveRequest.getImageFilePath()) || Consts.STRING_EMPTY.equals(photoSaveRequest.getImageFilePath()))) {
-			throw new BadRequestException(ErrorEnum.INVALID_INPUT);
+			throw ErrorEnum.INVALID_INPUT.toException();
 		}
-		
+
 		for(FieldError error : result.getFieldErrors()) {
 			if(!error.isBindingFailure()) {
 				log.info("Invalid input. (Field: {}, Value: {}, Message: {})",
 						error.getField(), error.getRejectedValue(), error.getDefaultMessage());
-				throw new BadRequestException(ErrorEnum.INVALID_INPUT);
+				throw ErrorEnum.INVALID_INPUT.toException();
 			}
 		};
 		
@@ -197,10 +192,11 @@ public class PhotoRestController {
 	 * @param photoAccountId				ページ所有者のアカウントID
 	 * @param photoDeleteRequest			{@link PhotoDeleteRequest}
 	 * @param result						PhotoDeleteRequestのバインディング結果
-	 * @return								{@link PhotoEditResponse}
-	 * @throws BadRequestException 			リクエストパラメータが不正の場合
-	 * @throws ForbiddenAccountException 	写真の所有者以外がリクエストした場合
-	 * @throws UpdateFailureException 		写真の削除に失敗した場合
+	 * @return							{@link PhotoEditResponse}
+	 * @throws GalleryException			以下のいずれかに該当する場合
+	 *                              	・リクエストパラメータが不正の場合
+	 *                              	・写真の所有者以外がリクエストした場合
+	 *                              	・写真の削除に失敗した場合
 	 */
 	@Operation(summary = "写真削除", description = "指定した写真を削除する")
 	@ApiResponse(responseCode = "200", description = "削除成功")
@@ -210,18 +206,18 @@ public class PhotoRestController {
 	@SecurityRequirement(name = "Bearer")
 	@DeleteMapping(ApiRoutes.API_PHOTOS)
 	public ResponseEntity<PhotoEditResponse> deletePhoto(
-			@PathVariable String photoAccountId, 
-			@RequestBody @Validated PhotoDeleteRequest photoDeleteRequest, 
-			BindingResult result) throws BadRequestException, ForbiddenAccountException, UpdateFailureException {
-		
+			@PathVariable String photoAccountId,
+			@RequestBody @Validated PhotoDeleteRequest photoDeleteRequest,
+			BindingResult result) throws GalleryException {
+
 		if(!photoAccountId.equals(sessionHelper.getAccountId())) {
-			throw new ForbiddenAccountException(ErrorEnum.NOT_AUTHORIZED_TO_EDIT_PHOTO);
+			throw ErrorEnum.NOT_AUTHORIZED_TO_EDIT_PHOTO.toException();
 		}
-		
+
 		if(result.hasErrors()) {
 			log.info("Invalid input. (AccountNo: {}, PhotoNo: {}, ImageFilePath: {})",
 					photoDeleteRequest.getAccountNo(), photoDeleteRequest.getPhotoNo(), photoDeleteRequest.getImageFilePath());
-			throw new BadRequestException(ErrorEnum.INVALID_INPUT);
+			throw ErrorEnum.INVALID_INPUT.toException();
 		}
 		
 		PhotoDeleteModelList photoDeleteModelList = PhotoDeleteModelList.of(List.of(PhotoDeleteModel.from(photoDeleteRequest)));

--- a/backend/src/main/java/com/web/gallery/enumeration/ErrorEnum.java
+++ b/backend/src/main/java/com/web/gallery/enumeration/ErrorEnum.java
@@ -1,131 +1,229 @@
 package com.web.gallery.enumeration;
 
 import com.web.gallery.constant.MessageConst;
+import com.web.gallery.exception.BadRequestException;
+import com.web.gallery.exception.FileDuplicateException;
+import com.web.gallery.exception.ForbiddenAccountException;
+import com.web.gallery.exception.GalleryException;
+import com.web.gallery.exception.PhotoNotAdditableException;
+import com.web.gallery.exception.PhotoNotFoundException;
+import com.web.gallery.exception.RegistFailureException;
+import com.web.gallery.exception.UpdateFailureException;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
  * エラーに関する情報を管理するEnumクラス
  */
 @Getter
-@AllArgsConstructor
 public enum ErrorEnum {
 	/**
 	 * エラーコード：E-C-0000
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_INVALID_INPUT}
 	 */
-	INVALID_INPUT("E-C-0000", MessageConst.ERR_INVALID_INPUT),
-	
+	INVALID_INPUT("E-C-0000", MessageConst.ERR_INVALID_INPUT) {
+		@Override
+		public GalleryException toException() {
+			return new BadRequestException(this);
+		}
+	},
+
 	/**
 	 * エラーコード：E-C-0001
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_FAIL_TO_REGIST_ACCOUNT}
 	 */
-	FAIL_TO_REGIST_ACCOUNT("E-C-0001", MessageConst.ERR_FAIL_TO_REGIST_ACCOUNT),
+	FAIL_TO_REGIST_ACCOUNT("E-C-0001", MessageConst.ERR_FAIL_TO_REGIST_ACCOUNT) {
+		@Override
+		public GalleryException toException() {
+			return new RegistFailureException(this);
+		}
+	},
 
 	/**
 	 * エラーコード：E-C-0002
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_FAIL_TO_UPDATE_ACCOUNT}
 	 */
-	FAIL_TO_UPDATE_ACCOUNT("E-C-0002", MessageConst.ERR_FAIL_TO_UPDATE_ACCOUNT),
-	
+	FAIL_TO_UPDATE_ACCOUNT("E-C-0002", MessageConst.ERR_FAIL_TO_UPDATE_ACCOUNT) {
+		@Override
+		public GalleryException toException() {
+			return new UpdateFailureException(this);
+		}
+	},
+
 	/**
 	 * エラーコード：E-C-0003
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_NOT_AUTHORIZED_TO_EDIT_ACCOUNT}
 	 */
-	NOT_AUTHORIZED_TO_EDIT_ACCOUNT("E-C-0003", MessageConst.ERR_NOT_AUTHORIZED_TO_EDIT_ACCOUNT),
-	
+	NOT_AUTHORIZED_TO_EDIT_ACCOUNT("E-C-0003", MessageConst.ERR_NOT_AUTHORIZED_TO_EDIT_ACCOUNT) {
+		@Override
+		public GalleryException toException() {
+			return new ForbiddenAccountException(this);
+		}
+	},
+
 	/**
 	 * エラーコード：E-P-0001
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_FAIL_TO_REGIST_PHOTO}
 	 */
-	FAIL_TO_REGIST_PHOTO("E-P-0001", MessageConst.ERR_FAIL_TO_REGIST_PHOTO),
-	
+	FAIL_TO_REGIST_PHOTO("E-P-0001", MessageConst.ERR_FAIL_TO_REGIST_PHOTO) {
+		@Override
+		public GalleryException toException() {
+			return new RegistFailureException(this);
+		}
+	},
+
 	/**
 	 * エラーコード：E-P-0002
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_FAIL_TO_UPDATE_PHOTO}
 	 */
-	FAIL_TO_UPDATE_PHOTO("E-P-0002", MessageConst.ERR_FAIL_TO_UPDATE_PHOTO),
-	
+	FAIL_TO_UPDATE_PHOTO("E-P-0002", MessageConst.ERR_FAIL_TO_UPDATE_PHOTO) {
+		@Override
+		public GalleryException toException() {
+			return new UpdateFailureException(this);
+		}
+	},
+
 	/**
 	 * エラーコード：E-P-0003
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_FAIL_TO_DELETE_PHOTO}
 	 */
-	FAIL_TO_DELETE_PHOTO("E-P-0003", MessageConst.ERR_FAIL_TO_DELETE_PHOTO),
-	
+	FAIL_TO_DELETE_PHOTO("E-P-0003", MessageConst.ERR_FAIL_TO_DELETE_PHOTO) {
+		@Override
+		public GalleryException toException() {
+			return new UpdateFailureException(this);
+		}
+	},
+
 	/**
 	 * エラーコード：E-P-0004
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_FAIL_TO_REGIST_PHOTO_TAG}
 	 */
-	FAIL_TO_REGIST_PHOTO_TAG("E-P-0004", MessageConst.ERR_FAIL_TO_REGIST_PHOTO_TAG),
-	
+	FAIL_TO_REGIST_PHOTO_TAG("E-P-0004", MessageConst.ERR_FAIL_TO_REGIST_PHOTO_TAG) {
+		@Override
+		public GalleryException toException() {
+			return new RegistFailureException(this);
+		}
+	},
+
 	/**
 	 * エラーコード：E-P-0005
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_FAIL_TO_REGIST_FAVORITE}
 	 */
-	FAIL_TO_REGIST_FAVORITE("E-P-0005", MessageConst.ERR_FAIL_TO_REGIST_FAVORITE),
+	FAIL_TO_REGIST_FAVORITE("E-P-0005", MessageConst.ERR_FAIL_TO_REGIST_FAVORITE) {
+		@Override
+		public GalleryException toException() {
+			return new RegistFailureException(this);
+		}
+	},
 
 	/**
 	 * エラーコード：E-P-0006
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_FAIL_TO_CANCEL_FAVORITE}
 	 */
-	FAIL_TO_CANCEL_FAVORITE("E-P-0006", MessageConst.ERR_FAIL_TO_CANCEL_FAVORITE),
-	
+	FAIL_TO_CANCEL_FAVORITE("E-P-0006", MessageConst.ERR_FAIL_TO_CANCEL_FAVORITE) {
+		@Override
+		public GalleryException toException() {
+			return new UpdateFailureException(this);
+		}
+	},
+
 	/**
 	 * エラーコード：E-P-0007
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_DUPLICATE_PHOTO_FILE}
 	 */
-	DUPLICATE_PHOTO_FILE("E-P-0007", MessageConst.ERR_DUPLICATE_PHOTO_FILE),
-	
+	DUPLICATE_PHOTO_FILE("E-P-0007", MessageConst.ERR_DUPLICATE_PHOTO_FILE) {
+		@Override
+		public GalleryException toException() {
+			return new FileDuplicateException(this);
+		}
+	},
+
 	/**
 	 * エラーコード：E-P-0008
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_NOT_AUTHORIZED_TO_EDIT_PHOTO}
 	 */
-	NOT_AUTHORIZED_TO_EDIT_PHOTO("E-P-0008", MessageConst.ERR_NOT_AUTHORIZED_TO_EDIT_PHOTO),
+	NOT_AUTHORIZED_TO_EDIT_PHOTO("E-P-0008", MessageConst.ERR_NOT_AUTHORIZED_TO_EDIT_PHOTO) {
+		@Override
+		public GalleryException toException() {
+			return new ForbiddenAccountException(this);
+		}
+	},
 
 	/**
 	 * エラーコード：E-P-0009
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_PHOTO_NOT_FOUND}
 	 */
-	PHOTO_NOT_FOUND("E-P-0009", MessageConst.ERR_PHOTO_NOT_FOUND),
-	
+	PHOTO_NOT_FOUND("E-P-0009", MessageConst.ERR_PHOTO_NOT_FOUND) {
+		@Override
+		public GalleryException toException() {
+			return new PhotoNotFoundException(this);
+		}
+	},
+
 	/**
 	 * エラーコード：E-P-0010
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_REACHED_REGISTRATION_LIMIT}
 	 */
-	REACHED_REGISTRATION_LIMIT("E-P-0010", MessageConst.ERR_REACHED_REGISTRATION_LIMIT),
+	REACHED_REGISTRATION_LIMIT("E-P-0010", MessageConst.ERR_REACHED_REGISTRATION_LIMIT) {
+		@Override
+		public GalleryException toException() {
+			return new PhotoNotAdditableException(this);
+		}
+	},
 
 	/**
 	 * エラーコード：E-A-0001
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_NOT_AUTHORIZED_TO_ADMIN}
 	 */
-	NOT_AUTHORIZED_TO_ADMIN("E-A-0001", MessageConst.ERR_NOT_AUTHORIZED_TO_ADMIN),
+	NOT_AUTHORIZED_TO_ADMIN("E-A-0001", MessageConst.ERR_NOT_AUTHORIZED_TO_ADMIN) {
+		@Override
+		public GalleryException toException() {
+			return new ForbiddenAccountException(this);
+		}
+	},
 
 	/**
 	 * エラーコード：E-C-0004
 	 * <p>
 	 * エラーメッセージ：{@value MessageConst#ERR_FAIL_TO_DELETE_ACCOUNT}
 	 */
-	FAIL_TO_DELETE_ACCOUNT("E-C-0004", MessageConst.ERR_FAIL_TO_DELETE_ACCOUNT);
-	
+	FAIL_TO_DELETE_ACCOUNT("E-C-0004", MessageConst.ERR_FAIL_TO_DELETE_ACCOUNT) {
+		@Override
+		public GalleryException toException() {
+			return new UpdateFailureException(this);
+		}
+	};
+
 	/** エラーコード */
 	private final String errorCode;
-	
+
 	/** エラーメッセージ */
 	private final String errorMessage;
+
+	ErrorEnum(String errorCode, String errorMessage) {
+		this.errorCode = errorCode;
+		this.errorMessage = errorMessage;
+	}
+
+	/**
+	 * このエラーに対応する例外を生成する
+	 *
+	 * @return 生成された例外
+	 */
+	public abstract GalleryException toException();
 }

--- a/backend/src/main/java/com/web/gallery/exception/BadRequestException.java
+++ b/backend/src/main/java/com/web/gallery/exception/BadRequestException.java
@@ -5,19 +5,12 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.web.gallery.enumeration.ErrorEnum;
 
-import lombok.Getter;
-
 /**
  * リクエストパラメータ不正のExceptionクラス
  */
 @ResponseStatus(HttpStatus.BAD_REQUEST)
-@Getter
-public class BadRequestException extends Exception {
-	/** エラーコード */
-	private final String errorCode;
-	
+public class BadRequestException extends GalleryException {
 	public BadRequestException(ErrorEnum error) {
-		super(error.getErrorMessage());
-		this.errorCode = error.getErrorCode();
+		super(error);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/exception/FileDuplicateException.java
+++ b/backend/src/main/java/com/web/gallery/exception/FileDuplicateException.java
@@ -5,19 +5,12 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.web.gallery.enumeration.ErrorEnum;
 
-import lombok.Getter;
-
 /**
  * 保存するファイルが重複した時のExceptionクラス
  */
 @ResponseStatus(HttpStatus.CONFLICT)
-@Getter
-public class FileDuplicateException extends Exception {
-	/** エラーコード */
-	private final String errorCode;
-	
+public class FileDuplicateException extends GalleryException {
 	public FileDuplicateException(ErrorEnum error) {
-		super(error.getErrorMessage());
-		this.errorCode = error.getErrorCode();
+		super(error);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/exception/ForbiddenAccountException.java
+++ b/backend/src/main/java/com/web/gallery/exception/ForbiddenAccountException.java
@@ -5,19 +5,12 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.web.gallery.enumeration.ErrorEnum;
 
-import lombok.Getter;
-
 /**
  * 権限のないアカウントからの不正アクセスの時のExceptionクラス
  */
 @ResponseStatus(HttpStatus.FORBIDDEN)
-@Getter
-public class ForbiddenAccountException extends Exception {
-	/** エラーコード */
-	private final String errorCode;
-	
+public class ForbiddenAccountException extends GalleryException {
 	public ForbiddenAccountException(ErrorEnum error) {
-		super(error.getErrorMessage());
-		this.errorCode = error.getErrorCode();
+		super(error);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/exception/GalleryException.java
+++ b/backend/src/main/java/com/web/gallery/exception/GalleryException.java
@@ -1,0 +1,19 @@
+package com.web.gallery.exception;
+
+import com.web.gallery.enumeration.ErrorEnum;
+
+import lombok.Getter;
+
+/**
+ * アプリケーション固有のビジネスエラーを表す例外の基底クラス
+ */
+@Getter
+public abstract class GalleryException extends Exception {
+	/** エラーコード */
+	private final String errorCode;
+
+	protected GalleryException(ErrorEnum error) {
+		super(error.getErrorMessage());
+		this.errorCode = error.getErrorCode();
+	}
+}

--- a/backend/src/main/java/com/web/gallery/exception/PhotoNotAdditableException.java
+++ b/backend/src/main/java/com/web/gallery/exception/PhotoNotAdditableException.java
@@ -5,19 +5,12 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.web.gallery.enumeration.ErrorEnum;
 
-import lombok.Getter;
-
 /**
  * 登録枚数の上限に達して写真が追加できない時のExceptionクラス
  */
 @ResponseStatus(HttpStatus.BAD_REQUEST)
-@Getter
-public class PhotoNotAdditableException extends Exception {
-	/** エラーコード */
-	private final String errorCode;
-	
+public class PhotoNotAdditableException extends GalleryException {
 	public PhotoNotAdditableException(ErrorEnum error) {
-		super(error.getErrorMessage());
-		this.errorCode = error.getErrorCode();
+		super(error);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/exception/PhotoNotFoundException.java
+++ b/backend/src/main/java/com/web/gallery/exception/PhotoNotFoundException.java
@@ -5,19 +5,12 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.web.gallery.enumeration.ErrorEnum;
 
-import lombok.Getter;
-
 /**
  * 写真が存在しない時のExceptionクラス
  */
 @ResponseStatus(HttpStatus.BAD_REQUEST)
-@Getter
-public class PhotoNotFoundException extends Exception {
-	/** エラーコード */
-	private final String errorCode;
-	
+public class PhotoNotFoundException extends GalleryException {
 	public PhotoNotFoundException(ErrorEnum error) {
-		super(error.getErrorMessage());
-		this.errorCode = error.getErrorCode();
+		super(error);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/exception/RegistFailureException.java
+++ b/backend/src/main/java/com/web/gallery/exception/RegistFailureException.java
@@ -5,19 +5,12 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.web.gallery.enumeration.ErrorEnum;
 
-import lombok.Getter;
-
 /**
  * 登録失敗時のExceptionクラス
  */
 @ResponseStatus(HttpStatus.CONFLICT)
-@Getter
-public class RegistFailureException extends Exception {
-	/** エラーコード */
-	private final String errorCode;
-		
+public class RegistFailureException extends GalleryException {
 	public RegistFailureException(ErrorEnum error) {
-		super(error.getErrorMessage());
-		this.errorCode = error.getErrorCode();
+		super(error);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/exception/UpdateFailureException.java
+++ b/backend/src/main/java/com/web/gallery/exception/UpdateFailureException.java
@@ -5,19 +5,12 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.web.gallery.enumeration.ErrorEnum;
 
-import lombok.Getter;
-
 /**
  * 更新失敗時のExceptionクラス
  */
 @ResponseStatus(HttpStatus.CONFLICT)
-@Getter
-public class UpdateFailureException extends Exception {
-	/** エラーコード */
-	private final String errorCode;
-	
+public class UpdateFailureException extends GalleryException {
 	public UpdateFailureException(ErrorEnum error) {
-		super(error.getErrorMessage());
-		this.errorCode = error.getErrorCode();
+		super(error);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/repository/AccountRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/AccountRepository.java
@@ -2,8 +2,7 @@ package com.web.gallery.repository;
 
 import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountNo;
-import com.web.gallery.exception.RegistFailureException;
-import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.model.AccountModelList;
 
@@ -32,26 +31,26 @@ public interface AccountRepository {
 	/**
 	 * Accountテーブルへ登録する
 	 *
-	 * @param	accountModel			{@link AccountModel}
-	 * @throws	RegistFailureException	登録に失敗した場合
+	 * @param	accountModel		{@link AccountModel}
+	 * @throws	GalleryException	登録に失敗した場合
 	 */
-	void regist(AccountModel accountModel) throws RegistFailureException;
+	void regist(AccountModel accountModel) throws GalleryException;
 
 	/**
 	 * Accountテーブルで該当するレコードを更新する
 	 *
-	 * @param	accountModel			{@link AccountModel}
-	 * @throws	UpdateFailureException	更新に失敗した場合
+	 * @param	accountModel		{@link AccountModel}
+	 * @throws	GalleryException	更新に失敗した場合
 	 */
-	void update(AccountModel accountModel) throws UpdateFailureException;
+	void update(AccountModel accountModel) throws GalleryException;
 
 	/**
 	 * Accountテーブルのログイン失敗回数を更新する
 	 *
-	 * @param	accountModel			{@link AccountModel}
-	 * @throws	UpdateFailureException	更新に失敗した場合
+	 * @param	accountModel		{@link AccountModel}
+	 * @throws	GalleryException	更新に失敗した場合
 	 */
-	void updateLoginFailureCount(AccountModel accountModel) throws UpdateFailureException;
+	void updateLoginFailureCount(AccountModel accountModel) throws GalleryException;
 
 	/**
 	 * アカウントIDに該当するアカウントの存在有無をチェックする（新規登録用、除外なし）

--- a/backend/src/main/java/com/web/gallery/repository/PhotoDetailRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/PhotoDetailRepository.java
@@ -1,6 +1,6 @@
 package com.web.gallery.repository;
 
-import com.web.gallery.exception.PhotoNotFoundException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
 import com.web.gallery.model.PhotoGetModel;
@@ -23,7 +23,7 @@ public interface PhotoDetailRepository {
 	 * 
 	 * @param	photoDetailGetModel		{@link PhotoDetailGetModel}
 	 * @return							{@link PhotoDetailModel}
-	 * @throws	PhotoNotFoundException	写真が存在しなかった場合
+	 * @throws	GalleryException		写真が存在しなかった場合
 	 */
-	PhotoDetailModel getPhotoDetail(PhotoDetailGetModel photoDetailGetModel) throws PhotoNotFoundException;
+	PhotoDetailModel getPhotoDetail(PhotoDetailGetModel photoDetailGetModel) throws GalleryException;
 }

--- a/backend/src/main/java/com/web/gallery/repository/PhotoFavoriteRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/PhotoFavoriteRepository.java
@@ -1,8 +1,7 @@
 package com.web.gallery.repository;
 
 import com.web.gallery.domain.account.AccountNo;
-import com.web.gallery.exception.RegistFailureException;
-import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.PhotoFavoriteDeleteModel;
 import com.web.gallery.model.PhotoFavoriteModel;
 
@@ -13,18 +12,18 @@ public interface PhotoFavoriteRepository {
 	/**
 	 * 写真お気に入りを登録する
 	 * 
-	 * @param	favoriteModel			{@link PhotoFavoriteModel}
-	 * @throws	RegistFailureException	登録に失敗した場合
+	 * @param	favoriteModel		{@link PhotoFavoriteModel}
+	 * @throws	GalleryException	登録に失敗した場合
 	 */
-	void regist(PhotoFavoriteModel favoriteModel) throws RegistFailureException;
-	
+	void regist(PhotoFavoriteModel favoriteModel) throws GalleryException;
+
 	/**
 	 * 写真お気に入りを削除する
-	 * 
-	 * @param	favoriteDeleteModel		{@link PhotoFavoriteDeleteModel}
-	 * @throws	UpdateFailureException	更新に失敗した場合
+	 *
+	 * @param	favoriteDeleteModel	{@link PhotoFavoriteDeleteModel}
+	 * @throws	GalleryException	更新に失敗した場合
 	 */
-	void delete(PhotoFavoriteDeleteModel favoriteDeleteModel) throws UpdateFailureException;
+	void delete(PhotoFavoriteDeleteModel favoriteDeleteModel) throws GalleryException;
 	
 	/**
 	 * 該当写真の写真お気に入りを全件削除する

--- a/backend/src/main/java/com/web/gallery/repository/PhotoMstRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/PhotoMstRepository.java
@@ -3,8 +3,7 @@ package com.web.gallery.repository;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.ImageFilePath;
 import com.web.gallery.domain.photo.PhotoNo;
-import com.web.gallery.exception.RegistFailureException;
-import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.PhotoDeleteModel;
 import com.web.gallery.model.PhotoDetailModel;
 
@@ -17,26 +16,26 @@ public interface PhotoMstRepository {
 	 * 
 	 * @param	photoDetailModel		{@link PhotoDetailModel}
 	 * @param	filePath				写真の保存ファイルパス
-	 * @param	newPhotoNo				新規採番した写真番号
-	 * @throws	RegistFailureException	登録に失敗した場合
+	 * @param	newPhotoNo			新規採番した写真番号
+	 * @throws	GalleryException	登録に失敗した場合
 	 */
-	void regist(PhotoDetailModel photoDetailModel, ImageFilePath filePath, PhotoNo newPhotoNo) throws RegistFailureException;
-	
+	void regist(PhotoDetailModel photoDetailModel, ImageFilePath filePath, PhotoNo newPhotoNo) throws GalleryException;
+
 	/**
 	 * 写真マスタを更新する
-	 * 
-	 * @param	photoDetailModel		{@link PhotoDetailModel}
-	 * @throws	UpdateFailureException	更新に失敗した場合
+	 *
+	 * @param	photoDetailModel	{@link PhotoDetailModel}
+	 * @throws	GalleryException	更新に失敗した場合
 	 */
-	void update(PhotoDetailModel photoDetailModel) throws UpdateFailureException;
-	
+	void update(PhotoDetailModel photoDetailModel) throws GalleryException;
+
 	/**
 	 * 写真マスタを削除する
-	 * 
-	 * @param	photoDeleteModel		{@link PhotoDeleteModel}
-	 * @throws	UpdateFailureException	削除に失敗した場合
+	 *
+	 * @param	photoDeleteModel	{@link PhotoDeleteModel}
+	 * @throws	GalleryException	削除に失敗した場合
 	 */
-	void delete(PhotoDeleteModel photoDeleteModel) throws UpdateFailureException;
+	void delete(PhotoDeleteModel photoDeleteModel) throws GalleryException;
 	
 	/**
 	 * アカウント番号から新しい写真番号を発番する

--- a/backend/src/main/java/com/web/gallery/repository/PhotoTagMstRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/PhotoTagMstRepository.java
@@ -1,7 +1,7 @@
 package com.web.gallery.repository;
 
 import com.web.gallery.domain.account.AccountNo;
-import com.web.gallery.exception.RegistFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.PhotoTagDeleteModel;
 import com.web.gallery.model.PhotoTagModel;
 
@@ -12,10 +12,10 @@ public interface PhotoTagMstRepository {
 	/**
 	 * 写真タグマスタを登録する
 	 * 
-	 * @param	photoTagModel			{@link PhotoTagModel}
-	 * @throws	RegistFailureException	登録に失敗した場合
+	 * @param	photoTagModel		{@link PhotoTagModel}
+	 * @throws	GalleryException	登録に失敗した場合
 	 */
-	void regist(PhotoTagModel photoTagModel) throws RegistFailureException;
+	void regist(PhotoTagModel photoTagModel) throws GalleryException;
 	
 	/**
 	 * 該当写真の写真タグを全件削除する

--- a/backend/src/main/java/com/web/gallery/repository/impl/AccountRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/AccountRepositoryImpl.java
@@ -12,8 +12,7 @@ import com.web.gallery.entity.Account;
 import com.web.gallery.entity.AccountCondition;
 import com.web.gallery.entity.AccountUpdateTarget;
 import com.web.gallery.enumeration.ErrorEnum;
-import com.web.gallery.exception.RegistFailureException;
-import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.mapper.AccountMapper;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.model.AccountModelList;
@@ -62,11 +61,11 @@ public class AccountRepositoryImpl implements AccountRepository {
 	/**
 	 * Accountテーブルへ登録する
 	 *
-	 * @param	accountModel			{@link AccountModel}
-	 * @throws	RegistFailureException	登録に失敗した場合
+	 * @param	accountModel		{@link AccountModel}
+	 * @throws	GalleryException	登録に失敗した場合
 	 */
 	@Override
-	public void regist(AccountModel accountModel) throws RegistFailureException {
+	public void regist(AccountModel accountModel) throws GalleryException {
 		Account account = Account.from(accountModel, passwordEncoder);
 
 		try {
@@ -74,41 +73,41 @@ public class AccountRepositoryImpl implements AccountRepository {
 		}
 		catch (DuplicateKeyException e) {
 			log.warn("Account: Duplicate Key (AccountId: {})", accountModel.getAccountId().value(), e);
-			throw new RegistFailureException(ErrorEnum.FAIL_TO_REGIST_ACCOUNT);
+			throw ErrorEnum.FAIL_TO_REGIST_ACCOUNT.toException();
 		}
 	}
 
 	/**
 	 * Accountテーブルで該当するレコードを更新する
 	 *
-	 * @param	accountModel			{@link AccountModel}
-	 * @throws	UpdateFailureException	更新に失敗した場合
+	 * @param	accountModel		{@link AccountModel}
+	 * @throws	GalleryException	更新に失敗した場合
 	 */
 	@Override
-	public void update(AccountModel accountModel) throws UpdateFailureException {
+	public void update(AccountModel accountModel) throws GalleryException {
 		AccountCondition condition = AccountCondition.byAccountNo(accountModel.getAccountNo().value());
 		AccountUpdateTarget target = AccountUpdateTarget.fromForUpdate(accountModel, passwordEncoder);
 
 		if (accountMapper.update(condition, target) < 1) {
 			log.warn("Account: Update Failed (AccountNo: {})", accountModel.getAccountNo().value());
-			throw new UpdateFailureException(ErrorEnum.FAIL_TO_UPDATE_ACCOUNT);
+			throw ErrorEnum.FAIL_TO_UPDATE_ACCOUNT.toException();
 		}
 	}
 
 	/**
 	 * Accountテーブルのログイン失敗回数を更新する
 	 *
-	 * @param	accountModel			{@link AccountModel}
-	 * @throws	UpdateFailureException	更新に失敗した場合
+	 * @param	accountModel		{@link AccountModel}
+	 * @throws	GalleryException	更新に失敗した場合
 	 */
 	@Override
-	public void updateLoginFailureCount(AccountModel accountModel) throws UpdateFailureException {
+	public void updateLoginFailureCount(AccountModel accountModel) throws GalleryException {
 		AccountCondition condition = AccountCondition.byAccountNo(accountModel.getAccountNo().value());
 		AccountUpdateTarget target = AccountUpdateTarget.fromForUpdateLoginFailure(accountModel);
 
 		if (accountMapper.update(condition, target) < 1) {
 			log.warn("Account: Update Failed (AccountNo: {})", accountModel.getAccountNo().value());
-			throw new UpdateFailureException(ErrorEnum.FAIL_TO_UPDATE_ACCOUNT);
+			throw ErrorEnum.FAIL_TO_UPDATE_ACCOUNT.toException();
 		}
 	}
 

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImpl.java
@@ -13,7 +13,7 @@ import com.web.gallery.dto.PhotoListGetDto;
 import com.web.gallery.entity.PhotoTagMst;
 import com.web.gallery.entity.PhotoTagMstCondition;
 import com.web.gallery.enumeration.ErrorEnum;
-import com.web.gallery.exception.PhotoNotFoundException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.mapper.PhotoDetailMapper;
 import com.web.gallery.mapper.PhotoTagMstMapper;
 import com.web.gallery.model.PhotoDetailGetModel;
@@ -57,18 +57,18 @@ public class PhotoDetailRepositoryImpl implements PhotoDetailRepository {
 	 * 写真のメタデータを含めた詳細情報を取得する
 	 *
 	 * @param	photoDetailGetModel		{@link PhotoDetailGetModel}
-	 * @return							{@link PhotoDetailModel}
-	 * @throws	PhotoNotFoundException	写真が存在しなかった場合
+	 * @return						{@link PhotoDetailModel}
+	 * @throws	GalleryException	写真が存在しなかった場合
 	 */
 	@Override
-	public PhotoDetailModel getPhotoDetail(PhotoDetailGetModel photoDetailGetModel) throws PhotoNotFoundException {
+	public PhotoDetailModel getPhotoDetail(PhotoDetailGetModel photoDetailGetModel) throws GalleryException {
 		PhotoDetailGetDto photoGetDto = PhotoDetailGetDto.from(photoDetailGetModel);
 		PhotoDetailDto photoDetailDto = photoDetailMapper.getPhotoDetail(photoGetDto);
 
 		if(Objects.isNull(photoDetailDto)) {
 			log.warn("Photo not found. (AccountNo: {}, PhotoAccountNo: {}, PhotoNo: {})"
 					, photoGetDto.getAccountNo(), photoGetDto.getPhotoAccountNo(), photoGetDto.getPhotoNo());
-			throw new PhotoNotFoundException(ErrorEnum.PHOTO_NOT_FOUND);
+			throw ErrorEnum.PHOTO_NOT_FOUND.toException();
 		}
 
 		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoFavoriteRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoFavoriteRepositoryImpl.java
@@ -7,8 +7,7 @@ import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.entity.PhotoFavorite;
 import com.web.gallery.entity.PhotoFavoriteCondition;
 import com.web.gallery.enumeration.ErrorEnum;
-import com.web.gallery.exception.RegistFailureException;
-import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.mapper.PhotoFavoriteMapper;
 import com.web.gallery.model.PhotoFavoriteDeleteModel;
 import com.web.gallery.model.PhotoFavoriteModel;
@@ -30,11 +29,11 @@ public class PhotoFavoriteRepositoryImpl implements PhotoFavoriteRepository{
 	/**
 	 * 写真お気に入りを登録する
 	 *
-	 * @param	favoriteModel			{@link PhotoFavoriteModel}
-	 * @throws	RegistFailureException	登録に失敗した場合
+	 * @param	favoriteModel		{@link PhotoFavoriteModel}
+	 * @throws	GalleryException	登録に失敗した場合
 	 */
 	@Override
-	public void regist(PhotoFavoriteModel favoriteModel) throws RegistFailureException {
+	public void regist(PhotoFavoriteModel favoriteModel) throws GalleryException {
 		PhotoFavorite photoFavorite = PhotoFavorite.from(favoriteModel);
 
 		try {
@@ -43,25 +42,25 @@ public class PhotoFavoriteRepositoryImpl implements PhotoFavoriteRepository{
 		catch (DuplicateKeyException e) {
 			log.warn("PhotoFavorite: Duplicate Key (AccountNo: {}, FavoritePhotoAccountNo: {}, FavoritePhotoNo: {})",
 					favoriteModel.getAccountNo().value(), favoriteModel.getFavoritePhotoAccountNo().value(), favoriteModel.getFavoritePhotoNo().value(), e);
-			throw new RegistFailureException(ErrorEnum.FAIL_TO_REGIST_FAVORITE);
+			throw ErrorEnum.FAIL_TO_REGIST_FAVORITE.toException();
 		}
 	}
 
 	/**
 	 * 写真お気に入りを削除する
 	 *
-	 * @param	favoriteDeleteModel		{@link PhotoFavoriteDeleteModel}
-	 * @throws	UpdateFailureException	更新に失敗した場合
+	 * @param	favoriteDeleteModel	{@link PhotoFavoriteDeleteModel}
+	 * @throws	GalleryException	更新に失敗した場合
 	 */
 	@Override
-	public void delete(PhotoFavoriteDeleteModel favoriteDeleteModel) throws UpdateFailureException {
+	public void delete(PhotoFavoriteDeleteModel favoriteDeleteModel) throws GalleryException {
 		PhotoFavoriteCondition condition = PhotoFavoriteCondition.from(favoriteDeleteModel);
 
 		if (photoFavoriteMapper.delete(condition) < 1) {
 			log.warn("PhotoFavorite: Delete Failed (AccountNo: {}, FavoritePhotoAccountNo: {}, FavoritePhotoNo: {})",
 					favoriteDeleteModel.getAccountNo() != null ? favoriteDeleteModel.getAccountNo().value() : null,
 					favoriteDeleteModel.getFavoritePhotoAccountNo().value(), favoriteDeleteModel.getFavoritePhotoNo().value());
-			throw new UpdateFailureException(ErrorEnum.FAIL_TO_CANCEL_FAVORITE);
+			throw ErrorEnum.FAIL_TO_CANCEL_FAVORITE.toException();
 		}
 	}
 

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
@@ -10,8 +10,7 @@ import com.web.gallery.entity.PhotoMst;
 import com.web.gallery.entity.PhotoMstCondition;
 import com.web.gallery.entity.PhotoMstUpdateTarget;
 import com.web.gallery.enumeration.ErrorEnum;
-import com.web.gallery.exception.RegistFailureException;
-import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.mapper.PhotoMstMapper;
 import com.web.gallery.model.PhotoDeleteModel;
 import com.web.gallery.model.PhotoDetailModel;
@@ -35,11 +34,11 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 *
 	 * @param	photoDetailModel		{@link PhotoDetailModel}
 	 * @param	filePath				写真の保存ファイルパス
-	 * @param	newPhotoNo				新規採番した写真番号
-	 * @throws	RegistFailureException	登録に失敗した場合
+	 * @param	newPhotoNo			新規採番した写真番号
+	 * @throws	GalleryException	登録に失敗した場合
 	 */
 	@Override
-	public void regist(PhotoDetailModel photoDetailModel, ImageFilePath filePath, PhotoNo newPhotoNo) throws RegistFailureException {
+	public void regist(PhotoDetailModel photoDetailModel, ImageFilePath filePath, PhotoNo newPhotoNo) throws GalleryException {
 		PhotoMst photoMst = PhotoMst.fromForRegist(photoDetailModel, filePath.value(), newPhotoNo.value());
 
 		try {
@@ -47,41 +46,41 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 		}
 		catch (DuplicateKeyException e) {
 			log.warn("PhotoMst: Duplicate Key (AccountNo: {}, PhotoNo: {})", photoDetailModel.getAccountNo().value(), newPhotoNo.value(), e);
-			throw new RegistFailureException(ErrorEnum.FAIL_TO_REGIST_PHOTO);
+			throw ErrorEnum.FAIL_TO_REGIST_PHOTO.toException();
 		}
 	}
 
 	/**
 	 * 写真マスタを更新する
 	 *
-	 * @param	photoDetailModel		{@link PhotoDetailModel}
-	 * @throws	UpdateFailureException	更新に失敗した場合
+	 * @param	photoDetailModel	{@link PhotoDetailModel}
+	 * @throws	GalleryException	更新に失敗した場合
 	 */
 	@Override
-	public void update(PhotoDetailModel photoDetailModel) throws UpdateFailureException {
+	public void update(PhotoDetailModel photoDetailModel) throws GalleryException {
 		PhotoMstCondition condition = PhotoMstCondition.byAccountAndPhoto(photoDetailModel.getAccountNo().value(), photoDetailModel.getPhotoNo().value());
 		PhotoMstUpdateTarget target = PhotoMstUpdateTarget.fromForUpdate(photoDetailModel);
 
 		if (photoMstMapper.update(condition, target) < 1) {
 			log.warn("PhotoMst: Update Failed (AccountNo: {}, PhotoNo: {})", photoDetailModel.getAccountNo().value(), photoDetailModel.getPhotoNo().value());
-			throw new UpdateFailureException(ErrorEnum.FAIL_TO_UPDATE_PHOTO);
+			throw ErrorEnum.FAIL_TO_UPDATE_PHOTO.toException();
 		}
 	}
 
 	/**
 	 * 写真マスタを削除する
 	 *
-	 * @param	photoDeleteModel		{@link PhotoDeleteModel}
-	 * @throws	UpdateFailureException	削除に失敗した場合
+	 * @param	photoDeleteModel	{@link PhotoDeleteModel}
+	 * @throws	GalleryException	削除に失敗した場合
 	 */
 	@Override
-	public void delete(PhotoDeleteModel photoDeleteModel) throws UpdateFailureException {
+	public void delete(PhotoDeleteModel photoDeleteModel) throws GalleryException {
 		PhotoMstCondition condition = PhotoMstCondition.byAccountAndPhoto(photoDeleteModel.getAccountNo().value(), photoDeleteModel.getPhotoNo().value());
 		PhotoMstUpdateTarget target = PhotoMstUpdateTarget.forDelete(photoDeleteModel);
 
 		if (photoMstMapper.update(condition, target) < 1) {
 			log.warn("PhotoMst: Delete Failed (AccountNo: {}, PhotoNo: {})", photoDeleteModel.getAccountNo().value(), photoDeleteModel.getPhotoNo().value());
-			throw new UpdateFailureException(ErrorEnum.FAIL_TO_DELETE_PHOTO);
+			throw ErrorEnum.FAIL_TO_DELETE_PHOTO.toException();
 		}
 	}
 

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoTagMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoTagMstRepositoryImpl.java
@@ -7,7 +7,7 @@ import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.entity.PhotoTagMst;
 import com.web.gallery.entity.PhotoTagMstCondition;
 import com.web.gallery.enumeration.ErrorEnum;
-import com.web.gallery.exception.RegistFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.mapper.PhotoTagMstMapper;
 import com.web.gallery.model.PhotoTagDeleteModel;
 import com.web.gallery.model.PhotoTagModel;
@@ -29,11 +29,11 @@ public class PhotoTagMstRepositoryImpl implements PhotoTagMstRepository {
 	/**
 	 * 写真タグマスタを登録する
 	 *
-	 * @param	photoTagModel			{@link PhotoTagModel}
-	 * @throws	RegistFailureException	登録に失敗した場合
+	 * @param	photoTagModel		{@link PhotoTagModel}
+	 * @throws	GalleryException	登録に失敗した場合
 	 */
 	@Override
-	public void regist(PhotoTagModel photoTagModel) throws RegistFailureException {
+	public void regist(PhotoTagModel photoTagModel) throws GalleryException {
 		PhotoTagMst photoTagMst = PhotoTagMst.from(photoTagModel);
 
 		try {
@@ -42,7 +42,7 @@ public class PhotoTagMstRepositoryImpl implements PhotoTagMstRepository {
 		catch (DuplicateKeyException e) {
 			log.warn("PhotoTagMst: Duplicate Key (AccountNo: {}, PhototNo: {}, TagNo: {})",
 					photoTagModel.getAccountNo().value(), photoTagModel.getPhotoNo().value(), photoTagModel.getTagNo().value(), e);
-			throw new RegistFailureException(ErrorEnum.FAIL_TO_REGIST_PHOTO_TAG);
+			throw ErrorEnum.FAIL_TO_REGIST_PHOTO_TAG.toException();
 		}
 	}
 

--- a/backend/src/main/java/com/web/gallery/service/PhotoFavoriteService.java
+++ b/backend/src/main/java/com/web/gallery/service/PhotoFavoriteService.java
@@ -1,7 +1,6 @@
 package com.web.gallery.service;
 
-import com.web.gallery.exception.RegistFailureException;
-import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.PhotoFavoriteModel;
 
 /**
@@ -10,17 +9,17 @@ import com.web.gallery.model.PhotoFavoriteModel;
 public interface PhotoFavoriteService {
 	/**
 	 * お気に入りを追加する
-	 * 
-	 * @param	photoFavoriteModel		{@link PhotoFavoriteModel}
-	 * @throws	RegistFailureException	登録に失敗した場合
+	 *
+	 * @param	photoFavoriteModel	{@link PhotoFavoriteModel}
+	 * @throws	GalleryException	登録に失敗した場合
 	 */
-	void addFavorite(PhotoFavoriteModel photoFavoriteModel) throws RegistFailureException;
-	
+	void addFavorite(PhotoFavoriteModel photoFavoriteModel) throws GalleryException;
+
 	/**
 	 * お気に入りを解除する
-	 * 
-	 * @param	photoFavoriteModel		{@link PhotoFavoriteModel}
-	 * @throws	UpdateFailureException	解除に失敗した場合
+	 *
+	 * @param	photoFavoriteModel	{@link PhotoFavoriteModel}
+	 * @throws	GalleryException	解除に失敗した場合
 	 */
-	void deleteFavorite(PhotoFavoriteModel photoFavoriteModel) throws UpdateFailureException;
+	void deleteFavorite(PhotoFavoriteModel photoFavoriteModel) throws GalleryException;
 }

--- a/backend/src/main/java/com/web/gallery/service/PhotoService.java
+++ b/backend/src/main/java/com/web/gallery/service/PhotoService.java
@@ -3,10 +3,7 @@ package com.web.gallery.service;
 import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.PhotoNo;
-import com.web.gallery.exception.FileDuplicateException;
-import com.web.gallery.exception.PhotoNotFoundException;
-import com.web.gallery.exception.RegistFailureException;
-import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.PhotoDeleteModelList;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
@@ -29,32 +26,33 @@ public interface PhotoService {
 	/**
 	 * 写真のメタデータを含めた詳細情報を取得する
 	 * 
-	 * @param	photoDetailGetModel		{@link PhotoDetailGetModel}
-	 * @return							{@link PhotoDetailModel}
-	 * @throws	PhotoNotFoundException	写真が存在しなかった場合
+	 * @param	photoDetailGetModel	{@link PhotoDetailGetModel}
+	 * @return						{@link PhotoDetailModel}
+	 * @throws	GalleryException	写真が存在しなかった場合
 	 */
-	PhotoDetailModel getPhotoDetail(PhotoDetailGetModel photoDetailGetModel) throws PhotoNotFoundException;
-	
+	PhotoDetailModel getPhotoDetail(PhotoDetailGetModel photoDetailGetModel) throws GalleryException;
+
 	/**
 	 * 写真を登録・更新する
-	 * 
+	 *
 	 * @param	accountId				アカウントID
 	 * @param	photoDetailModelList	{@link PhotoDetailModelList}
-	 * @throws	FileDuplicateException 	同じファイル名のファイルが既に保存済みの場合
-	 * @throws	RegistFailureException	登録に失敗した場合
-	 * @throws	UpdateFailureException	更新に失敗した場合
+	 * @throws	GalleryException		以下のいずれかに該当する場合
+	 *                              	・同じファイル名のファイルが既に保存済みの場合
+	 *                              	・登録に失敗した場合
+	 *                              	・更新に失敗した場合
 	 * @return							登録・更新した写真番号
 	 */
-	PhotoNo savePhotos(AccountId accountId, PhotoDetailModelList photoDetailModelList) throws FileDuplicateException, RegistFailureException, UpdateFailureException;
+	PhotoNo savePhotos(AccountId accountId, PhotoDetailModelList photoDetailModelList) throws GalleryException;
 
 	/**
 	 * 写真を削除する
 	 *
 	 * @param	accountId				アカウントID
 	 * @param	photoDeleteModelList	{@link PhotoDeleteModelList}
-	 * @throws	UpdateFailureException	削除に失敗した場合
+	 * @throws	GalleryException		削除に失敗した場合
 	 */
-	void deletePhotos(AccountId accountId, PhotoDeleteModelList photoDeleteModelList) throws UpdateFailureException;
+	void deletePhotos(AccountId accountId, PhotoDeleteModelList photoDeleteModelList) throws GalleryException;
 	
 	/**
 	 * 該当アカウントが写真の登録枚数の上限に達しているかチェックする

--- a/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
@@ -19,8 +19,7 @@ import com.web.gallery.constant.MessageConst;
 import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.ImageFilePath;
-import com.web.gallery.exception.RegistFailureException;
-import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.model.AccountModelList;
 import com.web.gallery.repository.AccountRepository;
@@ -71,12 +70,12 @@ public class AccountServiceImpl implements UserDetailsService {
 	/**
 	 * アカウントを新規登録する
 	 *
-	 * @param	accountModel			{@link AccountModel}
-	 * @return							登録に成功した場合、true
-	 * @throws	RegistFailureException	登録に失敗した場合
+	 * @param	accountModel		{@link AccountModel}
+	 * @return						登録に成功した場合、true
+	 * @throws	GalleryException	登録に失敗した場合
 	 */
 	@Transactional
-	public Boolean registAccount(AccountModel accountModel) throws RegistFailureException {
+	public Boolean registAccount(AccountModel accountModel) throws GalleryException {
 		Boolean isExist = accountRepository.isExistAccount(accountModel.getAccountId());
 		if(!isExist) accountRepository.regist(accountModel);
 		return !isExist;
@@ -85,12 +84,12 @@ public class AccountServiceImpl implements UserDetailsService {
 	/**
 	 * アカウントを更新する
 	 *
-	 * @param	accountModel			{@link AccountModel}
-	 * @return							更新に成功した場合、true
-	 * @throws UpdateFailureException	更新に失敗した場合
+	 * @param	accountModel		{@link AccountModel}
+	 * @return						更新に成功した場合、true
+	 * @throws GalleryException	更新に失敗した場合
 	 */
 	@Transactional
-	public Boolean updateAccount(AccountModel accountModel) throws UpdateFailureException {
+	public Boolean updateAccount(AccountModel accountModel) throws GalleryException {
 		Boolean isExist = accountRepository.isExistAccount(accountModel.getAccountNo(), accountModel.getAccountId());
 		if(!isExist) accountRepository.update(accountModel);
 		return isExist;
@@ -130,22 +129,22 @@ public class AccountServiceImpl implements UserDetailsService {
 	/**
 	 * 管理者用：アカウントのロックを解除する（ログイン失敗回数を0にリセット）
 	 *
-	 * @param	accountNo				アカウント番号
-	 * @throws	UpdateFailureException	更新に失敗した場合
+	 * @param	accountNo			アカウント番号
+	 * @throws	GalleryException	更新に失敗した場合
 	 */
 	@Transactional
-	public void unlockAccount(AccountNo accountNo) throws UpdateFailureException {
+	public void unlockAccount(AccountNo accountNo) throws GalleryException {
 		accountRepository.updateLoginFailureCount(AccountModel.forUnlock(accountNo.value()));
 	}
 
 	/**
 	 * 管理者用：アカウントを強制ロックする（ログイン失敗回数を上限超過に設定）
 	 *
-	 * @param	accountNo				アカウント番号
-	 * @throws	UpdateFailureException	更新に失敗した場合
+	 * @param	accountNo			アカウント番号
+	 * @throws	GalleryException	更新に失敗した場合
 	 */
 	@Transactional
-	public void lockAccount(AccountNo accountNo) throws UpdateFailureException {
+	public void lockAccount(AccountNo accountNo) throws GalleryException {
 		accountRepository.updateLoginFailureCount(AccountModel.forLock(accountNo.value(), loginConfig.getFailCount()));
 	}
 
@@ -179,12 +178,12 @@ public class AccountServiceImpl implements UserDetailsService {
 	/**
 	 * 認証成功
 	 *
-	 * @param	event					{@link AuthenticationSuccessEvent}
-	 * @throws	UpdateFailureException	更新に失敗した場合
+	 * @param	event				{@link AuthenticationSuccessEvent}
+	 * @throws	GalleryException	更新に失敗した場合
 	 */
 	@EventListener
 	@Transactional
-	public void handle(AuthenticationSuccessEvent event) throws UpdateFailureException {
+	public void handle(AuthenticationSuccessEvent event) throws GalleryException {
 		AccountModel accountModel = accountRepository.getByAccountId(new AccountId(event.getAuthentication().getName()));
 
 		accountRepository.updateLoginFailureCount(AccountModel.forLoginSuccess(accountModel.getAccountNo(), clock));
@@ -193,12 +192,12 @@ public class AccountServiceImpl implements UserDetailsService {
 	/**
 	 * 認証失敗
 	 *
-	 * @param	event					{@link AuthenticationFailureBadCredentialsEvent}
-	 * @throws	UpdateFailureException	更新に失敗した場合
+	 * @param	event				{@link AuthenticationFailureBadCredentialsEvent}
+	 * @throws	GalleryException	更新に失敗した場合
 	 */
 	@EventListener
 	@Transactional
-	public void handle(AuthenticationFailureBadCredentialsEvent event) throws UpdateFailureException {
+	public void handle(AuthenticationFailureBadCredentialsEvent event) throws GalleryException {
 		AccountModel accountModel = accountRepository.getByAccountId(new AccountId(event.getAuthentication().getName()));
 
 		if(!Objects.isNull(accountModel)) {

--- a/backend/src/main/java/com/web/gallery/service/impl/PhotoFavoriteServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/PhotoFavoriteServiceImpl.java
@@ -3,8 +3,7 @@ package com.web.gallery.service.impl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.web.gallery.exception.RegistFailureException;
-import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.PhotoFavoriteDeleteModel;
 import com.web.gallery.model.PhotoFavoriteModel;
 import com.web.gallery.repository.PhotoFavoriteRepository;
@@ -24,24 +23,24 @@ public class PhotoFavoriteServiceImpl implements PhotoFavoriteService {
 	/**
 	 * お気に入りを追加する
 	 * 
-	 * @param	photoFavoriteModel		{@link PhotoFavoriteModel}
-	 * @throws	RegistFailureException	登録に失敗した場合
+	 * @param	photoFavoriteModel	{@link PhotoFavoriteModel}
+	 * @throws	GalleryException	登録に失敗した場合
 	 */
 	@Override
 	@Transactional
-	public void addFavorite(PhotoFavoriteModel photoFavoriteModel) throws RegistFailureException {
+	public void addFavorite(PhotoFavoriteModel photoFavoriteModel) throws GalleryException {
 		photoFavoriteRepository.regist(photoFavoriteModel);
 	}
-	
+
 	/**
 	 * お気に入りを解除する
-	 * 
-	 * @param	photoFavoriteModel		{@link PhotoFavoriteModel}
-	 * @throws	UpdateFailureException	解除に失敗した場合
+	 *
+	 * @param	photoFavoriteModel	{@link PhotoFavoriteModel}
+	 * @throws	GalleryException	解除に失敗した場合
 	 */
 	@Override
 	@Transactional
-	public void deleteFavorite(PhotoFavoriteModel photoFavoriteModel) throws UpdateFailureException {
+	public void deleteFavorite(PhotoFavoriteModel photoFavoriteModel) throws GalleryException {
 		photoFavoriteRepository.delete(PhotoFavoriteDeleteModel.from(photoFavoriteModel));
 	}
 }

--- a/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
@@ -21,10 +21,7 @@ import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.domain.photo.TagNo;
 import com.web.gallery.enumeration.ErrorEnum;
 import com.web.gallery.enumeration.SortPhotoEnum;
-import com.web.gallery.exception.FileDuplicateException;
-import com.web.gallery.exception.PhotoNotFoundException;
-import com.web.gallery.exception.RegistFailureException;
-import com.web.gallery.exception.UpdateFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.FileModel;
 import com.web.gallery.model.PhotoDeleteModel;
 import com.web.gallery.model.PhotoDeleteModelList;
@@ -91,13 +88,13 @@ public class PhotoServiceImpl implements PhotoService {
 	/**
 	 * 写真のメタデータを含めた詳細情報を取得する
 	 *
-	 * @param	photoDetailGetModel		{@link PhotoDetailGetModel}
-	 * @return							{@link PhotoDetailModel}
-	 * @throws	PhotoNotFoundException	写真が存在しなかった場合
+	 * @param	photoDetailGetModel	{@link PhotoDetailGetModel}
+	 * @return						{@link PhotoDetailModel}
+	 * @throws	GalleryException	写真が存在しなかった場合
 	 */
 	@Override
 	@Transactional(readOnly = true)
-	public PhotoDetailModel getPhotoDetail(PhotoDetailGetModel photoDetailGetModel) throws PhotoNotFoundException {
+	public PhotoDetailModel getPhotoDetail(PhotoDetailGetModel photoDetailGetModel) throws GalleryException {
 		return photoDetailRepository.getPhotoDetail(photoDetailGetModel);
 	}
 
@@ -105,13 +102,14 @@ public class PhotoServiceImpl implements PhotoService {
 	 * 写真を登録・更新する
 	 *
 	 * @param	photoDetailModelList	{@link PhotoDetailModelList}
-	 * @throws	FileDuplicateException 	同じファイル名のファイルが既に保存済みの場合
-	 * @throws	RegistFailureException	登録に失敗した場合
-	 * @throws	UpdateFailureException	更新に失敗した場合
+	 * @throws	GalleryException		以下のいずれかに該当する場合
+	 *                              	・同じファイル名のファイルが既に保存済みの場合
+	 *                              	・登録に失敗した場合
+	 *                              	・更新に失敗した場合
 	 */
 	@Override
 	@Transactional
-	public PhotoNo savePhotos(AccountId accountId, PhotoDetailModelList photoDetailModelList) throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+	public PhotoNo savePhotos(AccountId accountId, PhotoDetailModelList photoDetailModelList) throws GalleryException {
 		if(Objects.isNull(photoDetailModelList)) return null;
 		if(photoDetailModelList.isEmpty()) return null;
 
@@ -124,7 +122,7 @@ public class PhotoServiceImpl implements PhotoService {
 				String filename = photoDetailModel.getImageFile().value().getOriginalFilename();
 				if(photoMstRepository.isExistPhoto(photoDetailModel)) {
 					log.warn("Duplicate image file (filename: {}}", filename);
-					throw new FileDuplicateException(ErrorEnum.DUPLICATE_PHOTO_FILE);
+					throw ErrorEnum.DUPLICATE_PHOTO_FILE.toException();
 				}
 
 				photoMstRepository.regist(photoDetailModel, new ImageFilePath(filePath + filename), new PhotoNo(photoNo));
@@ -145,11 +143,11 @@ public class PhotoServiceImpl implements PhotoService {
 	 *
 	 * @param	accountId				アカウントID
 	 * @param	photoDeleteModelList	{@link PhotoDeleteModelList}
-	 * @throws	UpdateFailureException	削除に失敗した場合
+	 * @throws	GalleryException		削除に失敗した場合
 	 */
 	@Override
 	@Transactional
-	public void deletePhotos(AccountId accountId, PhotoDeleteModelList photoDeleteModelList) throws UpdateFailureException {
+	public void deletePhotos(AccountId accountId, PhotoDeleteModelList photoDeleteModelList) throws GalleryException {
 		String filePath = photoConfig.getOutputPath() + accountId.value() + "/";
 
 		for(PhotoDeleteModel photoDeleteModel : photoDeleteModelList) {
@@ -212,11 +210,11 @@ public class PhotoServiceImpl implements PhotoService {
 	/**
 	 * 写真タグを登録する
 	 *
-	 * @param	photoTagModelList		{@link PhotoTagModelList}
-	 * @param	newPhotoNo				新規採番された写真番号
-	 * @throws	RegistFailureException	登録に失敗した場合
+	 * @param	photoTagModelList	{@link PhotoTagModelList}
+	 * @param	newPhotoNo			新規採番された写真番号
+	 * @throws	GalleryException	登録に失敗した場合
 	 */
-	private void registPhotoTags(PhotoTagModelList photoTagModelList, Long newPhotoNo) throws RegistFailureException {
+	private void registPhotoTags(PhotoTagModelList photoTagModelList, Long newPhotoNo) throws GalleryException {
 		if(Objects.isNull(photoTagModelList)) return;
 
 		int tagNo = 1;

--- a/backend/src/test/java/com/web/gallery/repository/impl/AccountRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/AccountRepositoryImplTest.java
@@ -46,6 +46,7 @@ import com.web.gallery.entity.AccountCondition;
 import com.web.gallery.entity.AccountUpdateTarget;
 import com.web.gallery.enumeration.AuthorityEnum;
 import com.web.gallery.enumeration.SexEnum;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.mapper.AccountMapper;
@@ -215,7 +216,7 @@ public class AccountRepositoryImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：Nullのパラメータを含むAccountModelの登録")
-		void regist_contain_null_parameter() throws RegistFailureException {
+		void regist_contain_null_parameter() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountId(new AccountId("aaaaaaaa"))
 					.accountName(new AccountName("AAAAAAAA"))
@@ -252,7 +253,7 @@ public class AccountRepositoryImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：Nullのパラメータを含まないAccountModelの登録")
-		void regist_not_contain_null_parameter() throws RegistFailureException {
+		void regist_not_contain_null_parameter() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountId(new AccountId("aaaaaaaa"))
 					.accountName(new AccountName("AAAAAAAA"))
@@ -294,7 +295,7 @@ public class AccountRepositoryImplTest {
 		@Test
 		@Order(3)
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
-		void regist_RegistFailureException() throws RegistFailureException {
+		void regist_RegistFailureException() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountId(new AccountId("aaaaaaaa"))
 					.accountName(new AccountName("AAAAAAAA"))
@@ -336,7 +337,7 @@ public class AccountRepositoryImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：Nullのパラメータを含むAccountModelでの更新")
-		void update_contain_null_parameter() throws UpdateFailureException {
+		void update_contain_null_parameter() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountNo(new AccountNo(1L))
 					.accountId(new AccountId("aaaaaaaa"))
@@ -371,7 +372,7 @@ public class AccountRepositoryImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：Nullのパラメータを含まないAccountModelでの更新")
-		void update_not_contain_null_parameter() throws UpdateFailureException {
+		void update_not_contain_null_parameter() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountNo(new AccountNo(1L))
 					.accountId(new AccountId("aaaaaaaa"))
@@ -455,7 +456,7 @@ public class AccountRepositoryImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：Nullのパラメータを含むAccountModelでの更新")
-		void updateLoginFailureCount_contain_null_parameter() throws UpdateFailureException {
+		void updateLoginFailureCount_contain_null_parameter() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountNo(new AccountNo(1L))
 					.build();
@@ -488,7 +489,7 @@ public class AccountRepositoryImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：Nullのパラメータを含まないAccountModelでの更新")
-		void updateLoginFailureCount_not_contain_null_parameter() throws UpdateFailureException {
+		void updateLoginFailureCount_not_contain_null_parameter() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountNo(new AccountNo(1L))
 					.lastLoginDatetime(new LastLoginDatetime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9))))

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImplTest.java
@@ -54,6 +54,7 @@ import com.web.gallery.entity.PhotoTagMst;
 import com.web.gallery.entity.PhotoTagMstCondition;
 import com.web.gallery.enumeration.DirectionEnum;
 import com.web.gallery.enumeration.SortPhotoEnum;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.PhotoNotFoundException;
 import com.web.gallery.mapper.PhotoDetailMapper;
 import com.web.gallery.mapper.PhotoTagMstMapper;
@@ -299,7 +300,7 @@ public class PhotoDetailRepositoryImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：写真のメタデータがデフォルト値、写真タグが0件の場合")
-		void getPhotoDetail_photoTag_default_value_not_found() throws PhotoNotFoundException {
+		void getPhotoDetail_photoTag_default_value_not_found() throws GalleryException {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
 					.accountNo(new AccountNo(1L))
 					.photoAccountNo(new AccountNo(1L))
@@ -372,7 +373,7 @@ public class PhotoDetailRepositoryImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：写真のメタデータがデフォルト値でない場、写真タグが1件以上の場合")
-		void getPhotoDetail_not_default_value_photoTag_found() throws PhotoNotFoundException {
+		void getPhotoDetail_not_default_value_photoTag_found() throws GalleryException {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
 					.accountNo(new AccountNo(1L))
 					.photoAccountNo(new AccountNo(1L))

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoFavoriteRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoFavoriteRepositoryImplTest.java
@@ -23,6 +23,7 @@ import com.web.gallery.domain.common.CreatedBy;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.entity.PhotoFavorite;
 import com.web.gallery.entity.PhotoFavoriteCondition;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.mapper.PhotoFavoriteMapper;
@@ -45,7 +46,7 @@ public class PhotoFavoriteRepositoryImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void regist_contain_null_parameter() throws RegistFailureException {
+		void regist_contain_null_parameter() throws GalleryException {
 			PhotoFavoriteModel favoriteModel = PhotoFavoriteModel.builder()
 					.accountNo(new AccountNo(1L))
 					.favoritePhotoAccountNo(new AccountNo(1L))
@@ -98,7 +99,7 @@ public class PhotoFavoriteRepositoryImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void delete_contain_null_parameter() throws UpdateFailureException {
+		void delete_contain_null_parameter() throws GalleryException {
 			PhotoFavoriteDeleteModel favoriteDeleteModel = PhotoFavoriteDeleteModel.builder()
 					.accountNo(new AccountNo(1L))
 					.favoritePhotoAccountNo(new AccountNo(1L))
@@ -120,7 +121,7 @@ public class PhotoFavoriteRepositoryImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
-		void delete_UpdateFailureException() throws UpdateFailureException {
+		void delete_UpdateFailureException() throws GalleryException {
 			PhotoFavoriteDeleteModel favoriteDeleteModel = PhotoFavoriteDeleteModel.builder()
 					.accountNo(new AccountNo(1L))
 					.favoritePhotoAccountNo(new AccountNo(1L))

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoMstRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoMstRepositoryImplTest.java
@@ -44,6 +44,7 @@ import com.web.gallery.entity.PhotoMst;
 import com.web.gallery.entity.PhotoMstCondition;
 import com.web.gallery.entity.PhotoMstUpdateTarget;
 import com.web.gallery.enumeration.DirectionEnum;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.mapper.PhotoMstMapper;
@@ -66,7 +67,7 @@ public class PhotoMstRepositoryImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：Nullのパラメータを含むPhotoDetailModelの登録")
-		void regist_contain_null_parameter() throws RegistFailureException {
+		void regist_contain_null_parameter() throws GalleryException {
 			String imageFilePath = "https://localhost:8080/image/aaaaaaaa/DSC111.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
@@ -105,7 +106,7 @@ public class PhotoMstRepositoryImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：Nullのパラメータを含まないPhotoDetailModelの登録")
-		void regist_not_contain_null_parameter() throws RegistFailureException {
+		void regist_not_contain_null_parameter() throws GalleryException {
 			String imageFilePath = "https://localhost:8080/image/aaaaaaaa/DSC111.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
@@ -198,7 +199,7 @@ public class PhotoMstRepositoryImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：Nullのパラメータを含むPhotoDetailModelでの更新")
-		void update_contain_null_parameter() throws UpdateFailureException {
+		void update_contain_null_parameter() throws GalleryException {
 			String imageFilePath = "https://localhost:8080/image/aaaaaaaa/DSC111.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
@@ -250,7 +251,7 @@ public class PhotoMstRepositoryImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：Nullのパラメータを含まないPhotoDetailModelでの更新")
-		void update_not_contain_null_parameter() throws UpdateFailureException {
+		void update_not_contain_null_parameter() throws GalleryException {
 			String imageFilePath = "https://localhost:8080/image/aaaaaaaa/DSC111.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
@@ -369,7 +370,7 @@ public class PhotoMstRepositoryImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void delete_success() throws UpdateFailureException {
+		void delete_success() throws GalleryException {
 			String imageFilePath = "https://localhost:8080/image/aaaaaaaa/DSC111.jpg";
 			
 			PhotoDeleteModel photoDeleteModel = PhotoDeleteModel.builder()

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoTagMstRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoTagMstRepositoryImplTest.java
@@ -26,6 +26,7 @@ import com.web.gallery.domain.photo.TagJapaneseName;
 import com.web.gallery.domain.photo.TagEnglishName;
 import com.web.gallery.entity.PhotoTagMst;
 import com.web.gallery.entity.PhotoTagMstCondition;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.mapper.PhotoTagMstMapper;
 import com.web.gallery.model.PhotoTagDeleteModel;
@@ -47,7 +48,7 @@ public class PhotoTagMstRepositoryImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void regist_contain_null_parameter() throws RegistFailureException {
+		void regist_contain_null_parameter() throws GalleryException {
 			PhotoTagModel photoTagModel = PhotoTagModel.builder()
 					.accountNo(new AccountNo(1L))
 					.photoNo(new PhotoNo(1L))

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/AccountRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/AccountRepositoryImplIntegrationTest.java
@@ -39,6 +39,7 @@ import com.web.gallery.domain.account.LoginFailureCount;
 import com.web.gallery.entity.Account;
 import com.web.gallery.enumeration.AuthorityEnum;
 import com.web.gallery.enumeration.SexEnum;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.AccountModel;
@@ -136,7 +137,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@DisplayName("正常系：Nullのパラメータを含むAccountModelの登録")
 		@Sql("/sql/common/cleanup.sql")
 		@Sql("/sql/common/ResetAccountNoSeq.sql")
-		void regist_contain_null_parameter() throws RegistFailureException {
+		void regist_contain_null_parameter() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountId(new AccountId("zzzzzzzz"))
 					.accountName(new AccountName("ZZZZZZZZ"))
@@ -192,7 +193,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@DisplayName("正常系：Nullのパラメータを含まないAccountModelの登録")
 		@Sql("/sql/common/cleanup.sql")
 		@Sql("/sql/common/ResetAccountNoSeq.sql")
-		void regist_not_contain_null_parameter() throws RegistFailureException {
+		void regist_not_contain_null_parameter() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountId(new AccountId("zzzzzzzz"))
 					.accountName(new AccountName("ZZZZZZZZ"))
@@ -253,7 +254,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
 		@Sql("/sql/common/cleanup.sql")
 		@Sql("/sql/repository/AccountRepositoryImplIntegrationTest.sql")
-		void regist_RegistFailureException() throws RegistFailureException {
+		void regist_RegistFailureException() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountId(new AccountId("aaaaaaaa"))
 					.accountName(new AccountName("AAAAAAAA"))
@@ -273,7 +274,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：Nullのパラメータを含むAccountModelでの更新")
-		void update_contain_null_parameter() throws UpdateFailureException {
+		void update_contain_null_parameter() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountNo(new AccountNo(1L))
 					.accountId(new AccountId("aaaaaaaa"))
@@ -328,7 +329,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：Nullのパラメータを含まないAccountModelでの更新")
-		void update_not_contain_null_parameter() throws UpdateFailureException {
+		void update_not_contain_null_parameter() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountNo(new AccountNo(1L))
 					.accountId(new AccountId("aaaaaaaa"))
@@ -411,7 +412,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：Nullのパラメータを含むAccountModelでの更新")
-		void updateLoginFailureCount_contain_null_parameter() throws UpdateFailureException {
+		void updateLoginFailureCount_contain_null_parameter() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountNo(new AccountNo(8L))
 					.build();
@@ -464,7 +465,7 @@ public class AccountRepositoryImplIntegrationTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：Nullのパラメータを含まないAccountModelでの更新")
-		void updateLoginFailureCount_not_contain_null_parameter() throws UpdateFailureException {
+		void updateLoginFailureCount_not_contain_null_parameter() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountNo(new AccountNo(1L))
 					.lastLoginDatetime(new LastLoginDatetime(OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(9))))

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoDetailRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoDetailRepositoryImplIntegrationTest.java
@@ -44,6 +44,7 @@ import com.web.gallery.domain.photo.TagEnglishName;
 import com.web.gallery.domain.photo.IsFavoriteOnly;
 import com.web.gallery.enumeration.DirectionEnum;
 import com.web.gallery.enumeration.SortPhotoEnum;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.PhotoNotFoundException;
 import com.web.gallery.model.PhotoDetailGetModel;
 import com.web.gallery.model.PhotoDetailModel;
@@ -268,7 +269,7 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：写真のメタデータがデフォルト値、写真タグが0件の場合")
-		void getPhotoDetail_photoTag_default_value_not_found() throws PhotoNotFoundException {
+		void getPhotoDetail_photoTag_default_value_not_found() throws GalleryException {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
 					.accountNo(new AccountNo(1L))
 					.photoAccountNo(new AccountNo(2L))
@@ -301,7 +302,7 @@ public class PhotoDetailRepositoryImplIntegrationTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：写真のメタデータがデフォルト値でない場、写真タグが1件以上の場合")
-		void getPhotoDetail_not_default_value_photoTag_found() throws PhotoNotFoundException {
+		void getPhotoDetail_not_default_value_photoTag_found() throws GalleryException {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
 					.accountNo(new AccountNo(1L))
 					.photoAccountNo(new AccountNo(1L))

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoFavoriteRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoFavoriteRepositoryImplIntegrationTest.java
@@ -24,6 +24,7 @@ import com.web.gallery.domain.common.CreatedAt;
 import com.web.gallery.domain.common.CreatedBy;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.entity.PhotoFavorite;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.PhotoFavoriteDeleteModel;
@@ -49,7 +50,7 @@ public class PhotoFavoriteRepositoryImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void regist_contain_null_parameter() throws RegistFailureException {
+		void regist_contain_null_parameter() throws GalleryException {
 			PhotoFavoriteModel favoriteModel = PhotoFavoriteModel.builder()
 					.accountNo(new AccountNo(1L))
 					.favoritePhotoAccountNo(new AccountNo(2L))
@@ -99,7 +100,7 @@ public class PhotoFavoriteRepositoryImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void delete_contain_null_parameter() throws UpdateFailureException {
+		void delete_contain_null_parameter() throws GalleryException {
 			PhotoFavoriteDeleteModel favoriteDeleteModel = PhotoFavoriteDeleteModel.builder()
 					.accountNo(new AccountNo(1L))
 					.favoritePhotoAccountNo(new AccountNo(1L))
@@ -134,7 +135,7 @@ public class PhotoFavoriteRepositoryImplIntegrationTest {
 		@Test
 		@Order(2)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
-		void delete_UpdateFailureException() throws UpdateFailureException {
+		void delete_UpdateFailureException() throws GalleryException {
 			PhotoFavoriteDeleteModel favoriteDeleteModel = PhotoFavoriteDeleteModel.builder()
 					.accountNo(new AccountNo(1L))
 					.favoritePhotoAccountNo(new AccountNo(3L))

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoMstRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoMstRepositoryImplIntegrationTest.java
@@ -43,6 +43,7 @@ import com.web.gallery.domain.photo.ShutterSpeed;
 import com.web.gallery.domain.photo.Iso;
 import com.web.gallery.entity.PhotoMst;
 import com.web.gallery.enumeration.DirectionEnum;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.PhotoDeleteModel;
@@ -68,7 +69,7 @@ public class PhotoMstRepositoryImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：Nullのパラメータを含むPhotoDetailModelの登録")
-		void regist_contain_null_parameter() throws RegistFailureException {
+		void regist_contain_null_parameter() throws GalleryException {
 			String imageFilePath = "https://www.xxx.com/DSC14.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
@@ -127,7 +128,7 @@ public class PhotoMstRepositoryImplIntegrationTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：Nullのパラメータを含まないPhotoDetailModelの登録")
-		void regist_not_contain_null_parameter() throws RegistFailureException {
+		void regist_not_contain_null_parameter() throws GalleryException {
 			String imageFilePath = "https://www.xxx.com/DSC14.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
@@ -218,7 +219,7 @@ public class PhotoMstRepositoryImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：Nullのパラメータを含むPhotoDetailModelでの更新")
-		void update_contain_null_parameter() throws UpdateFailureException {
+		void update_contain_null_parameter() throws GalleryException {
 			String imageFilePath = "https://www.xxx.com/DSC111.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
@@ -277,7 +278,7 @@ public class PhotoMstRepositoryImplIntegrationTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：Nullのパラメータを含まないPhotoDetailModelでの更新")
-		void update_not_contain_null_parameter() throws UpdateFailureException {
+		void update_not_contain_null_parameter() throws GalleryException {
 			String imageFilePath = "https://www.xxx.com/DSC111.jpg";
 			
 			PhotoDetailModel photoDetailModel = PhotoDetailModel.builder()
@@ -368,7 +369,7 @@ public class PhotoMstRepositoryImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void delete_success() throws UpdateFailureException {
+		void delete_success() throws GalleryException {
 			String imageFilePath = "https://www.xxx.com/DSC11.jpg";
 			
 			PhotoDeleteModel photoDeleteModel = PhotoDeleteModel.builder()

--- a/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoTagMstRepositoryImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/integration/PhotoTagMstRepositoryImplIntegrationTest.java
@@ -27,6 +27,7 @@ import com.web.gallery.domain.photo.TagNo;
 import com.web.gallery.domain.photo.TagJapaneseName;
 import com.web.gallery.domain.photo.TagEnglishName;
 import com.web.gallery.entity.PhotoTagMst;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.model.PhotoTagDeleteModel;
 import com.web.gallery.model.PhotoTagModel;
@@ -51,7 +52,7 @@ public class PhotoTagMstRepositoryImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void regist_contain_null_parameter() throws RegistFailureException {
+		void regist_contain_null_parameter() throws GalleryException {
 			PhotoTagModel photoTagModel = PhotoTagModel.builder()
 					.accountNo(new AccountNo(1L))
 					.photoNo(new PhotoNo(1L))

--- a/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
@@ -47,6 +47,7 @@ import com.web.gallery.domain.account.Password;
 import com.web.gallery.domain.account.ResidentPrefectureKbnCode;
 import com.web.gallery.domain.common.IsDeleted;
 import com.web.gallery.domain.photo.ImageFilePath;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.AccountModel;
@@ -137,7 +138,7 @@ public class AccountServiceImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：アカウントを新規登録")
-		void registAccount_success() throws RegistFailureException {
+		void registAccount_success() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder().accountId(new AccountId("aaaaaaaa")).build();
 			doReturn(false).when(accountRepositoryImpl).isExistAccount(new AccountId("aaaaaaaa"));
 			doNothing().when(accountRepositoryImpl).regist(accountModel);
@@ -147,7 +148,7 @@ public class AccountServiceImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：アカウントが既に存在する")
-		void registAccount_account_already_exist() throws RegistFailureException {
+		void registAccount_account_already_exist() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder().accountId(new AccountId("aaaaaaaa")).build();
 			doReturn(true).when(accountRepositoryImpl).isExistAccount(new AccountId("aaaaaaaa"));
 			verify(accountRepositoryImpl,times(0)).regist(accountModel);
@@ -157,7 +158,7 @@ public class AccountServiceImplTest {
 		@Test
 		@Order(3)
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
-		void registAccount_RegistFailureException() throws RegistFailureException {
+		void registAccount_RegistFailureException() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder().accountId(new AccountId("aaaaaaaa")).build();
 			doReturn(false).when(accountRepositoryImpl).isExistAccount(new AccountId("aaaaaaaa"));
 			doThrow(RegistFailureException.class).when(accountRepositoryImpl).regist(accountModel);
@@ -172,7 +173,7 @@ public class AccountServiceImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：アカウントを更新")
-		void updateAccount_success() throws UpdateFailureException {
+		void updateAccount_success() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder().accountNo(new AccountNo(1L)).accountId(new AccountId("aaaaaaaa")).build();
 			doReturn(false).when(accountRepositoryImpl).isExistAccount(new AccountNo(1L), new AccountId("aaaaaaaa"));
 			doNothing().when(accountRepositoryImpl).update(accountModel);
@@ -182,7 +183,7 @@ public class AccountServiceImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：アカウントが既に存在する")
-		void updateAccount_account_already_exist() throws UpdateFailureException {
+		void updateAccount_account_already_exist() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder().accountNo(new AccountNo(1L)).accountId(new AccountId("aaaaaaaa")).build();
 			doReturn(true).when(accountRepositoryImpl).isExistAccount(new AccountNo(1L), new AccountId("aaaaaaaa"));
 			verify(accountRepositoryImpl,times(0)).update(accountModel);
@@ -192,7 +193,7 @@ public class AccountServiceImplTest {
 		@Test
 		@Order(3)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
-		void updateAccount_UpdateFailureException() throws UpdateFailureException {
+		void updateAccount_UpdateFailureException() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder().accountNo(new AccountNo(1L)).accountId(new AccountId("aaaaaaaa")).build();
 			doReturn(false).when(accountRepositoryImpl).isExistAccount(new AccountNo(1L), new AccountId("aaaaaaaa"));
 			doThrow(UpdateFailureException.class).when(accountRepositoryImpl).update(accountModel);
@@ -320,7 +321,7 @@ public class AccountServiceImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：ログイン失敗回数が0にリセットされること")
-		void unlockAccount_success() throws UpdateFailureException {
+		void unlockAccount_success() throws GalleryException {
 			ArgumentCaptor<AccountModel> captor = ArgumentCaptor.forClass(AccountModel.class);
 			doNothing().when(accountRepositoryImpl).updateLoginFailureCount(captor.capture());
 
@@ -335,7 +336,7 @@ public class AccountServiceImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
-		void unlockAccount_UpdateFailureException() throws UpdateFailureException {
+		void unlockAccount_UpdateFailureException() throws GalleryException {
 			doThrow(UpdateFailureException.class).when(accountRepositoryImpl).updateLoginFailureCount(any(AccountModel.class));
 			assertThrows(UpdateFailureException.class, () -> accountServiceImpl.unlockAccount(new AccountNo(999L)));
 		}
@@ -348,7 +349,7 @@ public class AccountServiceImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：ログイン失敗回数が上限値に設定されること")
-		void lockAccount_success() throws UpdateFailureException {
+		void lockAccount_success() throws GalleryException {
 			doReturn(10).when(loginConfig).getFailCount();
 
 			ArgumentCaptor<AccountModel> captor = ArgumentCaptor.forClass(AccountModel.class);
@@ -364,7 +365,7 @@ public class AccountServiceImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
-		void lockAccount_UpdateFailureException() throws UpdateFailureException {
+		void lockAccount_UpdateFailureException() throws GalleryException {
 			doReturn(10).when(loginConfig).getFailCount();
 			doThrow(UpdateFailureException.class).when(accountRepositoryImpl).updateLoginFailureCount(any(AccountModel.class));
 			assertThrows(UpdateFailureException.class, () -> accountServiceImpl.lockAccount(new AccountNo(999L)));
@@ -414,7 +415,7 @@ public class AccountServiceImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void handle_success() throws UpdateFailureException {
+		void handle_success() throws GalleryException {
 			String username = "aaaaaaaa";
 			String password = "AAAAAAAA";
 			
@@ -450,7 +451,7 @@ public class AccountServiceImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
-		void handle_UpdateFailureException() throws UpdateFailureException {
+		void handle_UpdateFailureException() throws GalleryException {
 			String username = "aaaaaaaa";
 			String password = "AAAAAAAA";
 			
@@ -491,7 +492,7 @@ public class AccountServiceImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：アカウントが存在する場合")
-		void handle_account_found() throws UpdateFailureException {
+		void handle_account_found() throws GalleryException {
 			String username = "aaaaaaaa";
 			String password = "AAAAAAAA";
 			
@@ -530,7 +531,7 @@ public class AccountServiceImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：アカウントが存在しない場合")
-		void handle_account_not_found() throws UpdateFailureException {
+		void handle_account_not_found() throws GalleryException {
 			String username = "aaaaaaaa";
 			String password = "AAAAAAAA";
 			
@@ -552,7 +553,7 @@ public class AccountServiceImplTest {
 		@Test
 		@Order(3)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
-		void handle_UpdateFailureException() throws UpdateFailureException {
+		void handle_UpdateFailureException() throws GalleryException {
 			String username = "aaaaaaaa";
 			String password = "AAAAAAAA";
 			

--- a/backend/src/test/java/com/web/gallery/service/impl/PhotoFavoriteServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/PhotoFavoriteServiceImplTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.PhotoNo;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.PhotoFavoriteDeleteModel;
@@ -40,7 +41,7 @@ public class PhotoFavoriteServiceImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void addFavorite_success() throws RegistFailureException {
+		void addFavorite_success() throws GalleryException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
 					.accountNo(new AccountNo(1L))
 					.favoritePhotoAccountNo(new AccountNo(1L))
@@ -53,7 +54,7 @@ public class PhotoFavoriteServiceImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
-		void addFavorite_RegistFailureException() throws RegistFailureException {
+		void addFavorite_RegistFailureException() throws GalleryException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
 					.accountNo(new AccountNo(1L))
 					.favoritePhotoAccountNo(new AccountNo(1L))
@@ -71,7 +72,7 @@ public class PhotoFavoriteServiceImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void deleteFavorite_success() throws UpdateFailureException {
+		void deleteFavorite_success() throws GalleryException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
 					.accountNo(new AccountNo(1L))
 					.favoritePhotoAccountNo(new AccountNo(1L))
@@ -91,7 +92,7 @@ public class PhotoFavoriteServiceImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
-		void deleteFavorite_UpdateFailureException() throws UpdateFailureException {
+		void deleteFavorite_UpdateFailureException() throws GalleryException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
 					.accountNo(new AccountNo(1L))
 					.favoritePhotoAccountNo(new AccountNo(1L))

--- a/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
@@ -56,6 +56,7 @@ import com.web.gallery.enumeration.DirectionEnum;
 import com.web.gallery.enumeration.ErrorEnum;
 import com.web.gallery.enumeration.SortPhotoEnum;
 import com.web.gallery.exception.FileDuplicateException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.PhotoNotFoundException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
@@ -411,7 +412,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void getPhotoDetail_success() throws PhotoNotFoundException {
+		void getPhotoDetail_success() throws GalleryException {
 			PhotoDetailModel actual = PhotoDetailModel.builder()
 					.accountNo(new AccountNo(1L))
 					.imageFilePath(new ImageFilePath("https://www.xxx.com/DSC111.jpg"))
@@ -429,7 +430,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("異常系：PhotoNotFoundExceptionをthrowする")
-		void getPhotoDetail_PhotoNotFoundException() throws PhotoNotFoundException {
+		void getPhotoDetail_PhotoNotFoundException() throws GalleryException {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
 					.accountNo(new AccountNo(1L))
 					.photoAccountNo(new AccountNo(1L))
@@ -563,7 +564,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：photoDetailModelListがnullの場合、終了")
-		void savePhotos_photoDetailModelList_is_null() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+		void savePhotos_photoDetailModelList_is_null() throws GalleryException {
 			PhotoNo actual = photoServiceImpl.savePhotos(new AccountId("aaaaaaaa"), null);
 			assertNull(actual);
 			verify(photoMstRepositoryImpl, times(0)).getNewPhotoNo(any(AccountNo.class));
@@ -575,7 +576,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：photoDetailModelListがemptyの場合、終了")
-		void savePhotos_photoDetailModelList_is_empty() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+		void savePhotos_photoDetailModelList_is_empty() throws GalleryException {
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			PhotoNo actual = photoServiceImpl.savePhotos(new AccountId("aaaaaaaa"), PhotoDetailModelList.of(photoDetailModelList));
 			assertNull(actual);
@@ -588,7 +589,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(3)
 		@DisplayName("正常系：新規登録のみ")
-		void savePhotos_newPhoto() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+		void savePhotos_newPhoto() throws GalleryException {
 			String accountId = "aaaaaaaa";
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
@@ -646,7 +647,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(4)
 		@DisplayName("正常系：更新のみ")
-		void savePhotos_updatePhoto() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+		void savePhotos_updatePhoto() throws GalleryException {
 			String accountId = "aaaaaaaa";
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
@@ -696,7 +697,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(5)
 		@DisplayName("正常系：新規登録＋更新")
-		void savePhotos_newPhoto_and_updatePhoto() throws FileDuplicateException, RegistFailureException, UpdateFailureException  {
+		void savePhotos_newPhoto_and_updatePhoto() throws GalleryException  {
 			String accountId = "aaaaaaaa";
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
@@ -750,7 +751,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(6)
 		@DisplayName("異常系：FileDuplicateExceptionをthrowする（写真は複数枚）")
-		void savePhotos_FileDuplicateException() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+		void savePhotos_FileDuplicateException() throws GalleryException {
 			String accountId = "aaaaaaaa";
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
@@ -780,7 +781,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(7)
 		@DisplayName("異常系：写真登録でRegistFailureExceptionをthrowする（写真は複数枚）")
-		void savePhotos_registPhoto_RegistFailureException() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+		void savePhotos_registPhoto_RegistFailureException() throws GalleryException {
 			String accountId = "aaaaaaaa";
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
@@ -811,7 +812,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(8)
 		@DisplayName("異常系：新規登録時、写真タグ登録でRegistFailureExceptionをthrowする（写真は複数枚）")
-		void savePhotos_newPhoto_registPhotoTag_RegistFailureException() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+		void savePhotos_newPhoto_registPhotoTag_RegistFailureException() throws GalleryException {
 			String accountId = "aaaaaaaa";
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
@@ -852,7 +853,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(9)
 		@DisplayName("異常系：更新時、写真タグ登録でRegistFailureExceptionをthrowする（写真は複数枚）")
-		void savePhotos_updatePhoto_registPhotoTag_RegistFailureException() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+		void savePhotos_updatePhoto_registPhotoTag_RegistFailureException() throws GalleryException {
 			String accountId = "aaaaaaaa";
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
@@ -895,7 +896,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(10)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする（写真は複数枚）")
-		void savePhotos_UpdateFailureException() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+		void savePhotos_UpdateFailureException() throws GalleryException {
 			String accountId = "aaaaaaaa";
 			String filePath = "https://localhost:8080/image/";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
@@ -930,7 +931,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：photoDeleteModelListが0件の場合、終了")
-		void deletePhotos_photoDeleteModelList_empty() throws UpdateFailureException {
+		void deletePhotos_photoDeleteModelList_empty() throws GalleryException {
 			doReturn("https://localhost:8080/image/").when(photoConfig).getOutputPath();
 			
 			photoServiceImpl.deletePhotos(new AccountId("aaaaaaaa"), PhotoDeleteModelList.empty());
@@ -943,7 +944,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：photoDetailModelListが2件以上の場合")
-		void deletePhotos_success() throws UpdateFailureException {
+		void deletePhotos_success() throws GalleryException {
 			doReturn("https://localhost:8080/image/").when(photoConfig).getOutputPath();
 			
 			ArgumentCaptor<PhotoFavoriteDeleteModel> photoFavoriteDeleteModelCaptor = ArgumentCaptor.forClass(PhotoFavoriteDeleteModel.class);
@@ -1006,7 +1007,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(3)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
-		void deletePhotos_UpdateFailureException() throws UpdateFailureException {
+		void deletePhotos_UpdateFailureException() throws GalleryException {
 			doReturn("https://localhost:8080/image/").when(photoConfig).getOutputPath();
 			ArgumentCaptor<PhotoFavoriteDeleteModel> photoFavoriteDeleteModelCaptor = ArgumentCaptor.forClass(PhotoFavoriteDeleteModel.class);
 			doNothing().when(photoFavoriteRepositoryImpl).clear(photoFavoriteDeleteModelCaptor.capture());
@@ -1203,7 +1204,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：photoTagModelListがnullの場合")
-		void registPhotoTags_photoTagModelList_is_null() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, RegistFailureException {
+		void registPhotoTags_photoTagModelList_is_null() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, GalleryException {
 			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", PhotoTagModelList.class, Long.class);
 			registPhotoTags.setAccessible(true);
 
@@ -1215,7 +1216,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：photoTagModelListがemptyの場合")
-		void registPhotoTags_photoTagModelList_is_empty() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, RegistFailureException {
+		void registPhotoTags_photoTagModelList_is_empty() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, GalleryException {
 			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", PhotoTagModelList.class, Long.class);
 			registPhotoTags.setAccessible(true);
 
@@ -1227,7 +1228,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(3)
 		@DisplayName("正常系：newPhotoNoがnullの場合")
-		void registPhotoTags_newPhotoNo_is_null() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, RegistFailureException {
+		void registPhotoTags_newPhotoNo_is_null() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, GalleryException {
 			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", PhotoTagModelList.class, Long.class);
 			registPhotoTags.setAccessible(true);
 
@@ -1270,7 +1271,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(4)
 		@DisplayName("正常系：newPhotoNoがnullでない場合")
-		void registPhotoTags_newPhotoNo_is_not_null() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, RegistFailureException {
+		void registPhotoTags_newPhotoNo_is_not_null() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, GalleryException {
 			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", PhotoTagModelList.class, Long.class);
 			registPhotoTags.setAccessible(true);
 
@@ -1313,7 +1314,7 @@ public class PhotoServiceImplTest {
 		@Test
 		@Order(5)
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
-		void registPhotoTags_RegistFailureException() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, RegistFailureException {
+		void registPhotoTags_RegistFailureException() throws NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException, GalleryException {
 			Method registPhotoTags = PhotoServiceImpl.class.getDeclaredMethod("registPhotoTags", PhotoTagModelList.class, Long.class);
 			registPhotoTags.setAccessible(true);
 

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/AccountServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/AccountServiceImplIntegrationTest.java
@@ -49,7 +49,7 @@ import com.web.gallery.domain.common.UpdatedBy;
 import com.web.gallery.entity.Account;
 import com.web.gallery.enumeration.AuthorityEnum;
 import com.web.gallery.enumeration.SexEnum;
-import com.web.gallery.exception.RegistFailureException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.model.AccountModelList;
@@ -97,7 +97,7 @@ public class AccountServiceImplIntegrationTest {
 		@DisplayName("正常系：アカウントを新規登録")
 		@Sql("/sql/common/cleanup.sql")
 		@Sql("/sql/common/ResetAccountNoSeq.sql")
-		void registAccount_success() throws RegistFailureException {
+		void registAccount_success() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountId(new AccountId("mmmmmmmm"))
 					.accountName(new AccountName("MMMMMMMM"))
@@ -153,7 +153,7 @@ public class AccountServiceImplIntegrationTest {
 		@DisplayName("正常系：アカウントが既に存在する")
 		@Sql("/sql/common/cleanup.sql")
 		@Sql("/sql/service/AccountServiceImplIntegrationTest.sql")
-		void registAccount_account_already_exist() throws RegistFailureException {
+		void registAccount_account_already_exist() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder()
 					.accountId(new AccountId("aaaaaaaa"))
 					.accountName(new AccountName("AAAAAAAA"))
@@ -172,7 +172,7 @@ public class AccountServiceImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：アカウントを更新")
-		void updateAccount_success() throws UpdateFailureException {
+		void updateAccount_success() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder().accountNo(new AccountNo(1L)).accountId(new AccountId("zzzzzzzz")).build();
 
 			OffsetDateTime transactionNow = jdbcTemplate.queryForObject("SELECT NOW()", OffsetDateTime.class);
@@ -223,7 +223,7 @@ public class AccountServiceImplIntegrationTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：アカウントが既に存在する")
-		void updateAccount_account_already_exist() throws UpdateFailureException {
+		void updateAccount_account_already_exist() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder().accountNo(new AccountNo(1L)).accountId(new AccountId("bbbbbbbb")).build();
 			assertTrue(accountServiceImpl.updateAccount(accountModel));
 
@@ -272,7 +272,7 @@ public class AccountServiceImplIntegrationTest {
 		@Test
 		@Order(3)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
-		void updateAccount_UpdateFailureException() throws UpdateFailureException {
+		void updateAccount_UpdateFailureException() throws GalleryException {
 			AccountModel accountModel = AccountModel.builder().accountNo(new AccountNo(99L)).accountId(new AccountId("zzzzzzzz")).build();
 			assertThrows(UpdateFailureException.class, () -> accountServiceImpl.updateAccount(accountModel));
 		}
@@ -416,7 +416,7 @@ public class AccountServiceImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void handle_success() throws UpdateFailureException {
+		void handle_success() throws GalleryException {
 			String username = "kkkkkkkk";
 			String password = "KKKKKKKK";
 			
@@ -484,7 +484,7 @@ public class AccountServiceImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：アカウントが存在する場合")
-		void handle_account_found() throws UpdateFailureException {
+		void handle_account_found() throws GalleryException {
 			String username = "aaaaaaaa";
 			String password = "AAAAAAAA";
 			
@@ -545,7 +545,7 @@ public class AccountServiceImplIntegrationTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：アカウントが存在しない場合")
-		void handle_account_not_found() throws UpdateFailureException {
+		void handle_account_not_found() throws GalleryException {
 			String username = "zzzzzzzz";
 			String password = "ZZZZZZZZ";
 			

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoFavoriteServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoFavoriteServiceImplIntegrationTest.java
@@ -24,6 +24,7 @@ import com.web.gallery.domain.common.CreatedAt;
 import com.web.gallery.domain.common.CreatedBy;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.entity.PhotoFavorite;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.PhotoFavoriteModel;
@@ -48,7 +49,7 @@ public class PhotoFavoriteServiceImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void addFavorite_success() throws RegistFailureException {
+		void addFavorite_success() throws GalleryException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
 					.accountNo(new AccountNo(2L))
 					.favoritePhotoAccountNo(new AccountNo(1L))
@@ -78,7 +79,7 @@ public class PhotoFavoriteServiceImplIntegrationTest {
 		@Test
 		@Order(2)
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
-		void addFavorite_RegistFailureException() throws RegistFailureException {
+		void addFavorite_RegistFailureException() throws GalleryException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
 					.accountNo(new AccountNo(1L))
 					.favoritePhotoAccountNo(new AccountNo(1L))
@@ -98,7 +99,7 @@ public class PhotoFavoriteServiceImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void deleteFavorite_success() throws UpdateFailureException {
+		void deleteFavorite_success() throws GalleryException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
 					.accountNo(new AccountNo(1L))
 					.favoritePhotoAccountNo(new AccountNo(1L))
@@ -133,7 +134,7 @@ public class PhotoFavoriteServiceImplIntegrationTest {
 		@Test
 		@Order(2)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
-		void deleteFavorite_UpdateFailureException() throws UpdateFailureException {
+		void deleteFavorite_UpdateFailureException() throws GalleryException {
 			PhotoFavoriteModel photoFavoriteModel = PhotoFavoriteModel.builder()
 					.accountNo(new AccountNo(9L))
 					.favoritePhotoAccountNo(new AccountNo(1L))

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/PhotoServiceImplIntegrationTest.java
@@ -60,8 +60,8 @@ import com.web.gallery.entity.PhotoTagMst;
 import com.web.gallery.enumeration.DirectionEnum;
 import com.web.gallery.enumeration.SortPhotoEnum;
 import com.web.gallery.exception.FileDuplicateException;
+import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.PhotoNotFoundException;
-import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.PhotoDeleteModel;
 import com.web.gallery.model.PhotoDeleteModelList;
@@ -376,7 +376,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系")
-		void getPhotoDetail_success() throws PhotoNotFoundException {
+		void getPhotoDetail_success() throws GalleryException {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
 					.accountNo(new AccountNo(1L))
 					.photoAccountNo(new AccountNo(1L))
@@ -416,7 +416,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Test
 		@Order(2)
 		@DisplayName("異常系：PhotoNotFoundExceptionをthrowする")
-		void getPhotoDetail_PhotoNotFoundException() throws PhotoNotFoundException {
+		void getPhotoDetail_PhotoNotFoundException() throws GalleryException {
 			PhotoDetailGetModel photoDetailGetModel = PhotoDetailGetModel.builder()
 					.accountNo(new AccountNo(1L))
 					.photoAccountNo(new AccountNo(1L))
@@ -589,7 +589,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：photoDetailModelListがnullの場合、終了")
-		void savePhotos_photoDetailModelList_is_null() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+		void savePhotos_photoDetailModelList_is_null() throws GalleryException {
 			String accountId = "aaaaaaaa";
 			List<PhotoMst> beforeSaveData = getPhotoMstData(accountId);
 			PhotoNo actual = photoServiceImpl.savePhotos(new AccountId(accountId), null);
@@ -601,7 +601,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：photoDetailModelListがemptyの場合、終了")
-		void savePhotos_photoDetailModelList_is_empty() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+		void savePhotos_photoDetailModelList_is_empty() throws GalleryException {
 			String accountId = "aaaaaaaa";
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
 			List<PhotoMst> beforeSaveData = getPhotoMstData(accountId);
@@ -614,7 +614,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Test
 		@Order(3)
 		@DisplayName("正常系：新規登録のみ")
-		void savePhotos_newPhoto() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+		void savePhotos_newPhoto() throws GalleryException {
 			String accountId = "aaaaaaaa";
 			
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
@@ -684,7 +684,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Test
 		@Order(4)
 		@DisplayName("正常系：更新のみ")
-		void savePhotos_updatePhoto() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+		void savePhotos_updatePhoto() throws GalleryException {
 			String accountId = "aaaaaaaa";
 			
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
@@ -755,7 +755,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Test
 		@Order(5)
 		@DisplayName("正常系：新規登録＋更新")
-		void savePhotos_newPhoto_and_updatePhoto() throws FileDuplicateException, RegistFailureException, UpdateFailureException  {
+		void savePhotos_newPhoto_and_updatePhoto() throws GalleryException  {
 			String accountId = "aaaaaaaa";
 			
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
@@ -827,7 +827,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Test
 		@Order(6)
 		@DisplayName("異常系：FileDuplicateExceptionをthrowする（写真は複数枚）")
-		void savePhotos_FileDuplicateException() throws FileDuplicateException, RegistFailureException, UpdateFailureException {
+		void savePhotos_FileDuplicateException() throws GalleryException {
 			String accountId = "aaaaaaaa";
 			
 			List<PhotoDetailModel> photoDetailModelList = new ArrayList<PhotoDetailModel>();
@@ -869,7 +869,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Test
 		@Order(1)
 		@DisplayName("正常系：photoDeleteModelListが0件の場合、終了")
-		void deletePhotos_photoDeleteModelList_empty() throws UpdateFailureException {
+		void deletePhotos_photoDeleteModelList_empty() throws GalleryException {
 			photoServiceImpl.deletePhotos(new AccountId("aaaaaaaa"), PhotoDeleteModelList.empty());
 			
 			List<PhotoMst> actualData = jdbcTemplate.query(
@@ -901,7 +901,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Test
 		@Order(2)
 		@DisplayName("正常系：photoDetailModelListが2件以上の場合")
-		void deletePhotos_success() throws UpdateFailureException {
+		void deletePhotos_success() throws GalleryException {
 			List<PhotoDeleteModel> photoDeleteModelList = new ArrayList<PhotoDeleteModel>();
 			photoDeleteModelList.add(PhotoDeleteModel.builder()
 					.accountNo(new AccountNo(1L))
@@ -1023,7 +1023,7 @@ public class PhotoServiceImplIntegrationTest {
 		@Test
 		@Order(3)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
-		void deletePhotos_UpdateFailureException() throws UpdateFailureException {
+		void deletePhotos_UpdateFailureException() throws GalleryException {
 			List<PhotoDeleteModel> photoDeleteModelList = new ArrayList<PhotoDeleteModel>();
 			photoDeleteModelList.add(PhotoDeleteModel.builder()
 					.accountNo(new AccountNo(1L))


### PR DESCRIPTION
# 概要

## 背景

`~/Desktop/backend-code-review.md` の「3-3. 振る舞いのないEnumの活用不足」で指摘された、`ErrorEnum`がコードとメッセージを保持するだけで振る舞いを持たない点への対応。

## 変更内容

- 共通基底例外クラス`GalleryException`を新設し、既存7例外クラス（`BadRequestException`、`FileDuplicateException`、`ForbiddenAccountException`、`PhotoNotAdditableException`、`PhotoNotFoundException`、`RegistFailureException`、`UpdateFailureException`）をそれに統合（コンストラクタの重複コードも削減）
- `ErrorEnum`に`toException()`を抽象メソッドとして追加し、各定数を匿名クラスでオーバーライドすることで、対応する具象例外を生成するファクトリメソッドとして実装
- 呼び出し箇所（Controller/Aspect/Repository/Service、約25箇所）を`throw new XxxException(ErrorEnum.YYY)`から`throw ErrorEnum.YYY.toException()`に統一し、例外生成ロジックを`ErrorEnum`に集約
- Repository/Serviceインターフェース・実装クラス・Controller・Aspectの`throws`節、およびJavaDocの`@throws`タグを`GalleryException`に統一

`CommonRestControllerAdvice`の`@ExceptionHandler`群は具象例外の実行時型でディスパッチされるため、変更していない。

# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `./backend/gradlew -p backend bootRun` で backend の起動が成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認

# 懸念事項

- 各メソッドの`throws`節を`GalleryException`に統一したため、呼び出し元がコンパイル時にどの具体的な例外（ForbiddenAccountExceptionなのかBadRequestExceptionなのか等）が飛びうるかを型シグネチャからは判別できなくなった。JavaDocの`@throws`には具体的な発生条件を箇条書きで残しているが、型情報としては失われている点はレビュー時にご確認いただきたい。
- 本PRはbackendのみの変更のため、frontend起動確認・E2Eテストは未実施。
