### PR TITLE
fix: 写真一覧取得時のタグ取得をaccountNoからphotoNoで絞り込むよう修正

### DIFF
--- a/backend/src/main/java/com/web/gallery/entity/PhotoTagMstCondition.java
+++ b/backend/src/main/java/com/web/gallery/entity/PhotoTagMstCondition.java
@@ -1,5 +1,7 @@
 package com.web.gallery.entity;
 
+import java.util.List;
+
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.domain.photo.TagEnglishName;
@@ -23,6 +25,9 @@ public class PhotoTagMstCondition {
 
 	/** 写真番号 */
 	private PhotoNo photoNo;
+
+	/** 写真番号リスト */
+	private List<PhotoNo> photoNoList;
 
 	/** タグ番号 */
 	private TagNo tagNo;
@@ -61,13 +66,17 @@ public class PhotoTagMstCondition {
 
 	/**
 	 * PhotoGetModelから抽出条件を生成する
+	 * <p>
+	 * 取得対象の写真番号リストで絞り込むことで、アカウント全体のタグではなく該当写真のタグのみを取得する
 	 *
-	 * @param	model	{@link PhotoGetModel}
-	 * @return			{@link PhotoTagMstCondition}
+	 * @param	model			{@link PhotoGetModel}
+	 * @param	photoNoList		抽出対象の写真番号リスト
+	 * @return					{@link PhotoTagMstCondition}
 	 */
-	public static PhotoTagMstCondition from(PhotoGetModel model) {
+	public static PhotoTagMstCondition from(PhotoGetModel model, List<PhotoNo> photoNoList) {
 		return PhotoTagMstCondition.builder()
 				.accountNo(model.getPhotoAccountNo())
+				.photoNoList(photoNoList)
 				.build();
 	}
 

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImpl.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Repository;
 
+import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.dto.PhotoDetailDto;
 import com.web.gallery.dto.PhotoDetailGetDto;
 import com.web.gallery.dto.PhotoDto;
@@ -47,8 +48,16 @@ public class PhotoDetailRepositoryImpl implements PhotoDetailRepository {
 	public PhotoModelList getPhotoList(PhotoGetModel photoGetModel) {
 		List<PhotoDto> photoDtoList = photoDetailMapper.getPhotoList(PhotoListGetDto.from(photoGetModel));
 
+		if (photoDtoList.isEmpty()) {
+			return PhotoModelList.empty();
+		}
+
+		List<PhotoNo> photoNoList = photoDtoList.stream()
+				.map(photoDto -> new PhotoNo(photoDto.getPhotoNo()))
+				.toList();
+
 		List<PhotoTagMst> photoTagMstList = photoTagMstMapper.select(
-				PhotoTagMstCondition.from(photoGetModel));
+				PhotoTagMstCondition.from(photoGetModel, photoNoList));
 
 		return PhotoModelList.from(photoDtoList, photoTagMstList);
 	}

--- a/backend/src/main/resources/com/web/gallery/mapper/PhotoTagMstMapper.xml
+++ b/backend/src/main/resources/com/web/gallery/mapper/PhotoTagMstMapper.xml
@@ -27,6 +27,12 @@
 		<where>
 			<if test="accountNo != null"> AND account_no = #{accountNo, typeHandler=com.web.gallery.type_handler.AccountNoTypeHandler}</if>
 			<if test="photoNo != null"> AND photo_no = #{photoNo, typeHandler=com.web.gallery.type_handler.PhotoNoTypeHandler}</if>
+			<if test="photoNoList != null and !photoNoList.isEmpty()">
+				AND photo_no IN
+				<foreach item="photoNo" collection="photoNoList" open="(" separator="," close=")">
+					#{photoNo, typeHandler=com.web.gallery.type_handler.PhotoNoTypeHandler}
+				</foreach>
+			</if>
 			<if test="tagNo != null"> AND tag_no = #{tagNo, typeHandler=com.web.gallery.type_handler.TagNoTypeHandler}</if>
 			<if test="tagJapaneseName != null"> AND tag_japanese_name = #{tagJapaneseName, typeHandler=com.web.gallery.type_handler.TagJapaneseNameTypeHandler}</if>
 			<if test="tagEnglishName != null"> AND tag_english_name = #{tagEnglishName, typeHandler=com.web.gallery.type_handler.TagEnglishNameTypeHandler}</if>

--- a/backend/src/test/java/com/web/gallery/mapper/PhotoTagMstMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/PhotoTagMstMapperTest.java
@@ -467,4 +467,92 @@ public class PhotoTagMstMapperTest {
 			assertEquals(4, actualRestData.size());
 		}
 	}
+
+	@Nested
+	@Order(4)
+	@Sql("/sql/common/cleanup.sql")
+	@Sql("/sql/mapper/PhotoTagMstMapperTest.sql")
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class selectByPhotoNoList {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：写真番号リストでのselectで複数件の場合")
+		void select_by_photoNoList() {
+			PhotoTagMstCondition photoTagMst = PhotoTagMstCondition.builder()
+					.accountNo(new AccountNo(1L))
+					.photoNoList(List.of(new PhotoNo(1L), new PhotoNo(2L)))
+					.build();
+			List<PhotoTagMst> actual = photoTagMstMapper.select(photoTagMst);
+			actual.forEach(e -> e.setId(null));
+
+			PhotoTagMst expectedPhotoTagMst1 = PhotoTagMst.builder()
+					.accountNo(new AccountNo(1L))
+					.photoNo(new PhotoNo(1L))
+					.tagNo(new TagNo(1L))
+					.createdBy(new CreatedBy(1L))
+					.createdAt(new CreatedAt(OffsetDateTime.of(2000, 1, 1, 1, 0, 0, 0, ZoneOffset.ofHours(0))))
+					.tagJapaneseName(new TagJapaneseName("太陽"))
+					.tagEnglishName(new TagEnglishName("sun"))
+					.build();
+			PhotoTagMst expectedPhotoTagMst2 = PhotoTagMst.builder()
+					.accountNo(new AccountNo(1L))
+					.photoNo(new PhotoNo(1L))
+					.tagNo(new TagNo(2L))
+					.createdBy(new CreatedBy(1L))
+					.createdAt(new CreatedAt(OffsetDateTime.of(2000, 1, 1, 2, 0, 0, 0, ZoneOffset.ofHours(0))))
+					.tagJapaneseName(new TagJapaneseName("青空"))
+					.tagEnglishName(new TagEnglishName("bluesky"))
+					.build();
+			PhotoTagMst expectedPhotoTagMst3 = PhotoTagMst.builder()
+					.accountNo(new AccountNo(1L))
+					.photoNo(new PhotoNo(2L))
+					.tagNo(new TagNo(1L))
+					.createdBy(new CreatedBy(1L))
+					.createdAt(new CreatedAt(OffsetDateTime.of(2000, 2, 1, 1, 0, 0, 0, ZoneOffset.ofHours(0))))
+					.tagJapaneseName(new TagJapaneseName("太陽"))
+					.tagEnglishName(new TagEnglishName("sun"))
+					.build();
+			PhotoTagMst expectedPhotoTagMst4 = PhotoTagMst.builder()
+					.accountNo(new AccountNo(1L))
+					.photoNo(new PhotoNo(2L))
+					.tagNo(new TagNo(2L))
+					.createdBy(new CreatedBy(1L))
+					.createdAt(new CreatedAt(OffsetDateTime.of(2000, 2, 1, 2, 0, 0, 0, ZoneOffset.ofHours(0))))
+					.tagJapaneseName(new TagJapaneseName("曇天"))
+					.tagEnglishName(new TagEnglishName("cloudy"))
+					.build();
+			PhotoTagMst expectedPhotoTagMst5 = PhotoTagMst.builder()
+					.accountNo(new AccountNo(1L))
+					.photoNo(new PhotoNo(2L))
+					.tagNo(new TagNo(3L))
+					.createdBy(new CreatedBy(1L))
+					.createdAt(new CreatedAt(OffsetDateTime.of(2000, 2, 1, 3, 0, 0, 0, ZoneOffset.ofHours(0))))
+					.tagJapaneseName(new TagJapaneseName("花"))
+					.tagEnglishName(new TagEnglishName("flower"))
+					.build();
+			List<PhotoTagMst> expected = new ArrayList<PhotoTagMst>();
+			expected.add(expectedPhotoTagMst1);
+			expected.add(expectedPhotoTagMst2);
+			expected.add(expectedPhotoTagMst3);
+			expected.add(expectedPhotoTagMst4);
+			expected.add(expectedPhotoTagMst5);
+
+			assertEquals(5, actual.size());
+			assertEquals(expected.stream().sorted(Comparator.comparing(p -> p.getCreatedAt().value())).toList(),
+					actual.stream().sorted(Comparator.comparing(p -> p.getCreatedAt().value())).toList());
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("正常系：写真番号リストが空の場合は絞り込まれない")
+		void select_by_photoNoList_empty() {
+			PhotoTagMstCondition photoTagMst = PhotoTagMstCondition.builder()
+					.accountNo(new AccountNo(1L))
+					.photoNoList(List.of())
+					.build();
+			List<PhotoTagMst> actual = photoTagMstMapper.select(photoTagMst);
+
+			assertEquals(5, actual.size());
+		}
+	}
 }

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoDetailRepositoryImplTest.java
@@ -97,11 +97,6 @@ public class PhotoDetailRepositoryImplTest {
 			ArgumentCaptor<PhotoListGetDto> photoListGetDtoCaptor = ArgumentCaptor.forClass(PhotoListGetDto.class);
 			doReturn(photoDtoList).when(photoDetailMapper).getPhotoList(photoListGetDtoCaptor.capture());
 
-			List<PhotoTagMst> photoTagMstList = new ArrayList<PhotoTagMst>();
-
-			ArgumentCaptor<PhotoTagMstCondition> photoTagMstCaptor = ArgumentCaptor.forClass(PhotoTagMstCondition.class);
-			doReturn(photoTagMstList).when(photoTagMstMapper).select(photoTagMstCaptor.capture());
-
 			PhotoModelList actual = photoDetailRepositoryImpl.getPhotoList(photoSelectModel);
 
 			assertTrue(actual.isEmpty());
@@ -114,8 +109,7 @@ public class PhotoDetailRepositoryImplTest {
 			assertEquals(List.of(), photoListGetDtoCapture.getTagList());
 			assertEquals("PHOTO_AT", photoListGetDtoCapture.getSortBy());
 
-			PhotoTagMstCondition photoTagMstCapture = photoTagMstCaptor.getValue();
-			assertEquals(new AccountNo(1L), photoTagMstCapture.getAccountNo());
+			verify(photoTagMstMapper, times(0)).select(any(PhotoTagMstCondition.class));
 		}
 
 		@Test
@@ -192,8 +186,9 @@ public class PhotoDetailRepositoryImplTest {
 
 			PhotoTagMstCondition photoTagMstCapture = photoTagMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoTagMstCapture.getAccountNo());
+			assertEquals(List.of(new PhotoNo(1L), new PhotoNo(2L)), photoTagMstCapture.getPhotoNoList());
 		}
-		
+
 		@Test
 		@Order(3)
 		@DisplayName("正常系：写真が1件以上、写真タグが1件以上の場合")
@@ -290,9 +285,10 @@ public class PhotoDetailRepositoryImplTest {
 
 			PhotoTagMstCondition photoTagMstCapture = photoTagMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoTagMstCapture.getAccountNo());
+			assertEquals(List.of(new PhotoNo(1L), new PhotoNo(2L)), photoTagMstCapture.getPhotoNoList());
 		}
 	}
-	
+
 	@Nested
 	@Order(2)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)


### PR DESCRIPTION
# 概要

## 背景

バックエンドのコードレビューで、`PhotoDetailRepositoryImpl.getPhotoList()`が「アカウント全体のタグを取得後、写真ごとにメモリ上でフィルタリングしている（N+1問題の変形。写真数×タグ数の計算量になる）」と指摘された。

原因は`PhotoTagMstCondition.from(PhotoGetModel)`が`accountNo`のみで絞り込み、`photoNo`を条件に含めていなかったこと（対比として`getPhotoDetail`側は`photoNo`も条件に含めており問題なし）。

## 変更内容

- `PhotoTagMstCondition`に`photoNoList`（`List<PhotoNo>`）を追加し、`from(PhotoGetModel, List<PhotoNo>)`で取得済み写真のphotoNoのみに絞り込むよう変更
- `PhotoTagMstMapper.xml`の`select`に`photo_no IN (...)`（`<foreach>`）を追加
- `PhotoDetailRepositoryImpl.getPhotoList()`で、取得した`photoDtoList`からphotoNoリストを生成して渡すよう変更。写真が0件の場合はタグ取得自体をスキップ（`PhotoModelList.empty()`）
- `PhotoDetailRepositoryImplTest`・`PhotoTagMstMapperTest`に関連するテストケースを追加・修正

MyBatisのネストした結果マッピング（`<collection>`）の導入も検討したが、`PhotoDto`/`resultMap`/`PhotoModel`層に及ぶ大きな変更になり本プロジェクトに前例もないため、既存の抽出条件クラス（Condition）+IN句という規約に沿った軽量な修正を採用した。

# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `./backend/gradlew -p backend bootRun --args='--spring.profiles.active=local'` で backend の起動が成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認

# 懸念事項

- 挙動は変わらず（返却されるタグは従来通り写真ごとに正しくフィルタリングされたもの）、SQLで取得するタグの範囲を「アカウント全体」から「今回取得した写真分」に絞り込んだのみ。互換性への影響はない想定。
- frontendには変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
