### PR TITLE
refactor: null/デフォルト値変換ロジックを値オブジェクトに集約する

### DIFF
--- a/backend/src/main/java/com/web/gallery/domain/account/BirthDate.java
+++ b/backend/src/main/java/com/web/gallery/domain/account/BirthDate.java
@@ -3,6 +3,8 @@ package com.web.gallery.domain.account;
 import java.io.Serializable;
 import java.time.LocalDate;
 
+import com.web.gallery.constant.Consts;
+
 /**
  * 生年月日の値オブジェクト
  *
@@ -19,5 +21,15 @@ public record BirthDate(LocalDate value) implements Serializable {
 		if (value == null) {
 			throw new IllegalArgumentException("生年月日はnullにできません");
 		}
+	}
+
+	/**
+	 * 未設定の場合にDB保存用のデフォルト値を返す
+	 *
+	 * @param	nullable	{@link BirthDate}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればデフォルト値を持つ{@link BirthDate}
+	 */
+	public static BirthDate getOrDefault(BirthDate nullable) {
+		return nullable != null ? nullable : new BirthDate(Consts.MIN_LOCAL_DATE);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/domain/account/BirthplacePrefectureKbnCode.java
+++ b/backend/src/main/java/com/web/gallery/domain/account/BirthplacePrefectureKbnCode.java
@@ -2,6 +2,8 @@ package com.web.gallery.domain.account;
 
 import java.io.Serializable;
 
+import com.web.gallery.constant.Consts;
+
 /**
  * 出身都道府県区分コードの値オブジェクト
  *
@@ -18,5 +20,15 @@ public record BirthplacePrefectureKbnCode(String value) implements Serializable 
 		if (value == null) {
 			throw new IllegalArgumentException("出身都道府県区分コードはnullにできません");
 		}
+	}
+
+	/**
+	 * 未設定の場合にDB保存用のデフォルト値を返す
+	 *
+	 * @param	nullable	{@link BirthplacePrefectureKbnCode}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればデフォルト値を持つ{@link BirthplacePrefectureKbnCode}
+	 */
+	public static BirthplacePrefectureKbnCode getOrDefault(BirthplacePrefectureKbnCode nullable) {
+		return nullable != null ? nullable : new BirthplacePrefectureKbnCode(Consts.STRING_NONE);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/domain/account/FreeMemo.java
+++ b/backend/src/main/java/com/web/gallery/domain/account/FreeMemo.java
@@ -2,6 +2,8 @@ package com.web.gallery.domain.account;
 
 import java.io.Serializable;
 
+import com.web.gallery.constant.Consts;
+
 /**
  * フリーメモの値オブジェクト
  * <p>
@@ -13,5 +15,15 @@ public record FreeMemo(String value) implements Serializable {
 	@Override
 	public String toString() {
 		return value == null ? "" : value;
+	}
+
+	/**
+	 * 未設定の場合にDB保存用のデフォルト値を返す
+	 *
+	 * @param	nullable	{@link FreeMemo}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればデフォルト値を持つ{@link FreeMemo}
+	 */
+	public static FreeMemo getOrDefault(FreeMemo nullable) {
+		return nullable != null ? nullable : new FreeMemo(Consts.STRING_EMPTY);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/domain/account/LastLoginDatetime.java
+++ b/backend/src/main/java/com/web/gallery/domain/account/LastLoginDatetime.java
@@ -3,6 +3,8 @@ package com.web.gallery.domain.account;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 
+import com.web.gallery.constant.Consts;
+
 /**
  * 最終ログイン日時の値オブジェクト
  *
@@ -19,5 +21,15 @@ public record LastLoginDatetime(OffsetDateTime value) implements Serializable {
 		if (value == null) {
 			throw new IllegalArgumentException("最終ログイン日時はnullにできません");
 		}
+	}
+
+	/**
+	 * 未設定の場合にDB保存用のデフォルト値を返す
+	 *
+	 * @param	nullable	{@link LastLoginDatetime}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればデフォルト値を持つ{@link LastLoginDatetime}
+	 */
+	public static LastLoginDatetime getOrDefault(LastLoginDatetime nullable) {
+		return nullable != null ? nullable : new LastLoginDatetime(Consts.MIN_OFFSET_DATE_TIME);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/domain/account/LoginFailureCount.java
+++ b/backend/src/main/java/com/web/gallery/domain/account/LoginFailureCount.java
@@ -22,4 +22,14 @@ public record LoginFailureCount(Integer value) implements Serializable {
 			throw new IllegalArgumentException("ログイン失敗回数は0以上である必要があります");
 		}
 	}
+
+	/**
+	 * 未設定の場合にDB保存用のデフォルト値を返す
+	 *
+	 * @param	nullable	{@link LoginFailureCount}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればデフォルト値を持つ{@link LoginFailureCount}
+	 */
+	public static LoginFailureCount getOrDefault(LoginFailureCount nullable) {
+		return nullable != null ? nullable : new LoginFailureCount(0);
+	}
 }

--- a/backend/src/main/java/com/web/gallery/domain/account/ResidentPrefectureKbnCode.java
+++ b/backend/src/main/java/com/web/gallery/domain/account/ResidentPrefectureKbnCode.java
@@ -2,6 +2,8 @@ package com.web.gallery.domain.account;
 
 import java.io.Serializable;
 
+import com.web.gallery.constant.Consts;
+
 /**
  * 在住都道府県区分コードの値オブジェクト
  *
@@ -18,5 +20,15 @@ public record ResidentPrefectureKbnCode(String value) implements Serializable {
 		if (value == null) {
 			throw new IllegalArgumentException("在住都道府県区分コードはnullにできません");
 		}
+	}
+
+	/**
+	 * 未設定の場合にDB保存用のデフォルト値を返す
+	 *
+	 * @param	nullable	{@link ResidentPrefectureKbnCode}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればデフォルト値を持つ{@link ResidentPrefectureKbnCode}
+	 */
+	public static ResidentPrefectureKbnCode getOrDefault(ResidentPrefectureKbnCode nullable) {
+		return nullable != null ? nullable : new ResidentPrefectureKbnCode(Consts.STRING_NONE);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/domain/photo/Caption.java
+++ b/backend/src/main/java/com/web/gallery/domain/photo/Caption.java
@@ -2,6 +2,8 @@ package com.web.gallery.domain.photo;
 
 import java.io.Serializable;
 
+import com.web.gallery.constant.Consts;
+
 /**
  * キャプションの値オブジェクト
  *
@@ -18,5 +20,15 @@ public record Caption(String value) implements Serializable {
 		if (value == null) {
 			throw new IllegalArgumentException("キャプションはnullにできません");
 		}
+	}
+
+	/**
+	 * 未設定の場合にDB保存用のデフォルト値を返す
+	 *
+	 * @param	nullable	{@link Caption}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればデフォルト値を持つ{@link Caption}
+	 */
+	public static Caption getOrDefault(Caption nullable) {
+		return nullable != null ? nullable : new Caption(Consts.STRING_EMPTY);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/domain/photo/FValue.java
+++ b/backend/src/main/java/com/web/gallery/domain/photo/FValue.java
@@ -23,4 +23,14 @@ public record FValue(BigDecimal value) implements Serializable {
 			throw new IllegalArgumentException("F値は0以上である必要があります");
 		}
 	}
+
+	/**
+	 * 未設定の場合にDB保存用のデフォルト値を返す
+	 *
+	 * @param	nullable	{@link FValue}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればデフォルト値を持つ{@link FValue}
+	 */
+	public static FValue getOrDefault(FValue nullable) {
+		return nullable != null ? nullable : new FValue(BigDecimal.ZERO);
+	}
 }

--- a/backend/src/main/java/com/web/gallery/domain/photo/FocalLength.java
+++ b/backend/src/main/java/com/web/gallery/domain/photo/FocalLength.java
@@ -22,4 +22,14 @@ public record FocalLength(Integer value) implements Serializable {
 			throw new IllegalArgumentException("焦点距離は0以上である必要があります");
 		}
 	}
+
+	/**
+	 * 未設定の場合にDB保存用のデフォルト値を返す
+	 *
+	 * @param	nullable	{@link FocalLength}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればデフォルト値を持つ{@link FocalLength}
+	 */
+	public static FocalLength getOrDefault(FocalLength nullable) {
+		return nullable != null ? nullable : new FocalLength(0);
+	}
 }

--- a/backend/src/main/java/com/web/gallery/domain/photo/Iso.java
+++ b/backend/src/main/java/com/web/gallery/domain/photo/Iso.java
@@ -22,4 +22,14 @@ public record Iso(Integer value) implements Serializable {
 			throw new IllegalArgumentException("ISOは0以上である必要があります");
 		}
 	}
+
+	/**
+	 * 未設定の場合にDB保存用のデフォルト値を返す
+	 *
+	 * @param	nullable	{@link Iso}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればデフォルト値を持つ{@link Iso}
+	 */
+	public static Iso getOrDefault(Iso nullable) {
+		return nullable != null ? nullable : new Iso(0);
+	}
 }

--- a/backend/src/main/java/com/web/gallery/domain/photo/LocationNo.java
+++ b/backend/src/main/java/com/web/gallery/domain/photo/LocationNo.java
@@ -22,4 +22,14 @@ public record LocationNo(Long value) implements Serializable {
 			throw new IllegalArgumentException("ロケーション番号は0以上である必要があります");
 		}
 	}
+
+	/**
+	 * 未設定の場合にDB保存用のデフォルト値を返す
+	 *
+	 * @param	nullable	{@link LocationNo}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればデフォルト値を持つ{@link LocationNo}
+	 */
+	public static LocationNo getOrDefault(LocationNo nullable) {
+		return nullable != null ? nullable : new LocationNo(0L);
+	}
 }

--- a/backend/src/main/java/com/web/gallery/domain/photo/PhotoAt.java
+++ b/backend/src/main/java/com/web/gallery/domain/photo/PhotoAt.java
@@ -3,6 +3,8 @@ package com.web.gallery.domain.photo;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 
+import com.web.gallery.constant.Consts;
+
 /**
  * 撮影日時の値オブジェクト
  *
@@ -19,5 +21,15 @@ public record PhotoAt(OffsetDateTime value) implements Serializable {
 		if (value == null) {
 			throw new IllegalArgumentException("撮影日時はnullにできません");
 		}
+	}
+
+	/**
+	 * 未設定の場合にDB保存用のデフォルト値を返す
+	 *
+	 * @param	nullable	{@link PhotoAt}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればデフォルト値を持つ{@link PhotoAt}
+	 */
+	public static PhotoAt getOrDefault(PhotoAt nullable) {
+		return nullable != null ? nullable : new PhotoAt(Consts.MIN_OFFSET_DATE_TIME);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/domain/photo/PhotoEnglishTitle.java
+++ b/backend/src/main/java/com/web/gallery/domain/photo/PhotoEnglishTitle.java
@@ -2,6 +2,8 @@ package com.web.gallery.domain.photo;
 
 import java.io.Serializable;
 
+import com.web.gallery.constant.Consts;
+
 /**
  * 写真タイトル英語名の値オブジェクト
  *
@@ -18,5 +20,15 @@ public record PhotoEnglishTitle(String value) implements Serializable {
 		if (value == null) {
 			throw new IllegalArgumentException("写真タイトル英語名はnullにできません");
 		}
+	}
+
+	/**
+	 * 未設定の場合にDB保存用のデフォルト値を返す
+	 *
+	 * @param	nullable	{@link PhotoEnglishTitle}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればデフォルト値を持つ{@link PhotoEnglishTitle}
+	 */
+	public static PhotoEnglishTitle getOrDefault(PhotoEnglishTitle nullable) {
+		return nullable != null ? nullable : new PhotoEnglishTitle(Consts.STRING_EMPTY);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/domain/photo/PhotoJapaneseTitle.java
+++ b/backend/src/main/java/com/web/gallery/domain/photo/PhotoJapaneseTitle.java
@@ -2,6 +2,8 @@ package com.web.gallery.domain.photo;
 
 import java.io.Serializable;
 
+import com.web.gallery.constant.Consts;
+
 /**
  * 写真タイトル日本語名の値オブジェクト
  *
@@ -18,5 +20,15 @@ public record PhotoJapaneseTitle(String value) implements Serializable {
 		if (value == null) {
 			throw new IllegalArgumentException("写真タイトル日本語名はnullにできません");
 		}
+	}
+
+	/**
+	 * 未設定の場合にDB保存用のデフォルト値を返す
+	 *
+	 * @param	nullable	{@link PhotoJapaneseTitle}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればデフォルト値を持つ{@link PhotoJapaneseTitle}
+	 */
+	public static PhotoJapaneseTitle getOrDefault(PhotoJapaneseTitle nullable) {
+		return nullable != null ? nullable : new PhotoJapaneseTitle(Consts.STRING_EMPTY);
 	}
 }

--- a/backend/src/main/java/com/web/gallery/domain/photo/ShutterSpeed.java
+++ b/backend/src/main/java/com/web/gallery/domain/photo/ShutterSpeed.java
@@ -23,4 +23,14 @@ public record ShutterSpeed(BigDecimal value) implements Serializable {
 			throw new IllegalArgumentException("シャッタースピードは0以上である必要があります");
 		}
 	}
+
+	/**
+	 * 未設定の場合にDB保存用のデフォルト値を返す
+	 *
+	 * @param	nullable	{@link ShutterSpeed}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればデフォルト値を持つ{@link ShutterSpeed}
+	 */
+	public static ShutterSpeed getOrDefault(ShutterSpeed nullable) {
+		return nullable != null ? nullable : new ShutterSpeed(BigDecimal.ZERO);
+	}
 }

--- a/backend/src/main/java/com/web/gallery/entity/Account.java
+++ b/backend/src/main/java/com/web/gallery/entity/Account.java
@@ -1,7 +1,5 @@
 package com.web.gallery.entity;
 
-import java.util.Optional;
-
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.web.gallery.constant.Consts;
@@ -106,20 +104,11 @@ public class Account {
 				.accountId(model.getAccountId())
 				.accountName(model.getAccountName())
 				.password(new Password(passwordEncoder.encode(model.getPassword().value())))
-				.birthdate(
-					Optional.ofNullable(model.getBirthdate())
-						.orElse(new BirthDate(Consts.MIN_LOCAL_DATE)))
-				.sexKbn(
-					Optional.ofNullable(model.getSexKbn()).orElse(SexEnum.NONE))
-				.birthplacePrefectureKbnCode(
-					Optional.ofNullable(model.getBirthplacePrefectureKbnCode())
-						.orElse(new BirthplacePrefectureKbnCode(Consts.STRING_NONE)))
-				.residentPrefectureKbnCode(
-					Optional.ofNullable(model.getResidentPrefectureKbnCode())
-						.orElse(new ResidentPrefectureKbnCode(Consts.STRING_NONE)))
-				.freeMemo(
-					Optional.ofNullable(model.getFreeMemo())
-						.orElse(new FreeMemo(Consts.STRING_EMPTY)))
+				.birthdate(BirthDate.getOrDefault(model.getBirthdate()))
+				.sexKbn(SexEnum.getOrDefault(model.getSexKbn()))
+				.birthplacePrefectureKbnCode(BirthplacePrefectureKbnCode.getOrDefault(model.getBirthplacePrefectureKbnCode()))
+				.residentPrefectureKbnCode(ResidentPrefectureKbnCode.getOrDefault(model.getResidentPrefectureKbnCode()))
+				.freeMemo(FreeMemo.getOrDefault(model.getFreeMemo()))
 				.authorityKbn(AuthorityEnum.MINI)
 				.lastLoginDatetime(new LastLoginDatetime(Consts.MIN_OFFSET_DATE_TIME))
 				.loginFailureCount(new LoginFailureCount(0))

--- a/backend/src/main/java/com/web/gallery/entity/AccountUpdateTarget.java
+++ b/backend/src/main/java/com/web/gallery/entity/AccountUpdateTarget.java
@@ -1,10 +1,7 @@
 package com.web.gallery.entity;
 
-import java.util.Optional;
-
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import com.web.gallery.constant.Consts;
 import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountName;
 import com.web.gallery.domain.account.BirthDate;
@@ -87,26 +84,13 @@ public class AccountUpdateTarget {
 		AccountUpdateTarget target = AccountUpdateTarget.builder()
 				.accountId(model.getAccountId())
 				.accountName(model.getAccountName())
-				.birthdate(
-					Optional.ofNullable(model.getBirthdate())
-						.orElse(new BirthDate(Consts.MIN_LOCAL_DATE)))
-				.sexKbn(
-					Optional.ofNullable(model.getSexKbn()).orElse(SexEnum.NONE))
-				.birthplacePrefectureKbnCode(
-					Optional.ofNullable(model.getBirthplacePrefectureKbnCode())
-						.orElse(new BirthplacePrefectureKbnCode(Consts.STRING_NONE)))
-				.residentPrefectureKbnCode(
-					Optional.ofNullable(model.getResidentPrefectureKbnCode())
-						.orElse(new ResidentPrefectureKbnCode(Consts.STRING_NONE)))
-				.freeMemo(
-					Optional.ofNullable(model.getFreeMemo())
-						.orElse(new FreeMemo(Consts.STRING_EMPTY)))
-				.lastLoginDatetime(
-					Optional.ofNullable(model.getLastLoginDatetime())
-						.orElse(new LastLoginDatetime(Consts.MIN_OFFSET_DATE_TIME)))
-				.loginFailureCount(
-					Optional.ofNullable(model.getLoginFailureCount())
-						.orElse(new LoginFailureCount(0)))
+				.birthdate(BirthDate.getOrDefault(model.getBirthdate()))
+				.sexKbn(SexEnum.getOrDefault(model.getSexKbn()))
+				.birthplacePrefectureKbnCode(BirthplacePrefectureKbnCode.getOrDefault(model.getBirthplacePrefectureKbnCode()))
+				.residentPrefectureKbnCode(ResidentPrefectureKbnCode.getOrDefault(model.getResidentPrefectureKbnCode()))
+				.freeMemo(FreeMemo.getOrDefault(model.getFreeMemo()))
+				.lastLoginDatetime(LastLoginDatetime.getOrDefault(model.getLastLoginDatetime()))
+				.loginFailureCount(LoginFailureCount.getOrDefault(model.getLoginFailureCount()))
 				.build();
 
 		if (model.getPassword() != null) {
@@ -125,9 +109,7 @@ public class AccountUpdateTarget {
 	public static AccountUpdateTarget fromForUpdateLoginFailure(AccountModel model) {
 		return AccountUpdateTarget.builder()
 				.lastLoginDatetime(model.getLastLoginDatetime())
-				.loginFailureCount(
-					Optional.ofNullable(model.getLoginFailureCount())
-						.orElse(new LoginFailureCount(0)))
+				.loginFailureCount(LoginFailureCount.getOrDefault(model.getLoginFailureCount()))
 				.build();
 	}
 }

--- a/backend/src/main/java/com/web/gallery/entity/PhotoMst.java
+++ b/backend/src/main/java/com/web/gallery/entity/PhotoMst.java
@@ -1,9 +1,5 @@
 package com.web.gallery.entity;
 
-import java.math.BigDecimal;
-import java.util.Optional;
-
-import com.web.gallery.constant.Consts;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.common.CreatedBy;
 import com.web.gallery.domain.common.CreatedAt;
@@ -110,27 +106,17 @@ public class PhotoMst {
 				.photoNo(new PhotoNo(newPhotoNo))
 				.createdBy(new CreatedBy(model.getAccountNo().value()))
 				.updatedBy(new UpdatedBy(model.getAccountNo().value()))
-				.photoAt(new PhotoAt(
-					Optional.ofNullable(model.getPhotoAt()).map(PhotoAt::value).orElse(Consts.MIN_OFFSET_DATE_TIME)))
-				.locationNo(new LocationNo(
-					Optional.ofNullable(model.getLocationNo()).map(LocationNo::value).orElse(0L)))
+				.photoAt(PhotoAt.getOrDefault(model.getPhotoAt()))
+				.locationNo(LocationNo.getOrDefault(model.getLocationNo()))
 				.imageFilePath(new ImageFilePath(filePath))
-				.photoJapaneseTitle(new PhotoJapaneseTitle(
-					Optional.ofNullable(model.getPhotoJapaneseTitle()).map(PhotoJapaneseTitle::value).orElse(Consts.STRING_EMPTY)))
-				.photoEnglishTitle(new PhotoEnglishTitle(
-					Optional.ofNullable(model.getPhotoEnglishTitle()).map(PhotoEnglishTitle::value).orElse(Consts.STRING_EMPTY)))
-				.caption(new Caption(
-					Optional.ofNullable(model.getCaption()).map(Caption::value).orElse(Consts.STRING_EMPTY)))
-				.directionKbn(
-					Optional.ofNullable(model.getDirectionKbn()).orElse(DirectionEnum.NONE))
-				.focalLength(new FocalLength(
-					Optional.ofNullable(exifData.focalLength()).map(FocalLength::value).orElse(0)))
-				.fValue(new FValue(
-					Optional.ofNullable(exifData.fValue()).map(FValue::value).orElse(BigDecimal.ZERO)))
-				.shutterSpeed(new ShutterSpeed(
-					Optional.ofNullable(exifData.shutterSpeed()).map(ShutterSpeed::value).orElse(BigDecimal.ZERO)))
-				.iso(new Iso(
-					Optional.ofNullable(exifData.iso()).map(Iso::value).orElse(0)))
+				.photoJapaneseTitle(PhotoJapaneseTitle.getOrDefault(model.getPhotoJapaneseTitle()))
+				.photoEnglishTitle(PhotoEnglishTitle.getOrDefault(model.getPhotoEnglishTitle()))
+				.caption(Caption.getOrDefault(model.getCaption()))
+				.directionKbn(DirectionEnum.getOrDefault(model.getDirectionKbn()))
+				.focalLength(FocalLength.getOrDefault(exifData.focalLength()))
+				.fValue(FValue.getOrDefault(exifData.fValue()))
+				.shutterSpeed(ShutterSpeed.getOrDefault(exifData.shutterSpeed()))
+				.iso(Iso.getOrDefault(exifData.iso()))
 				.build();
 	}
 }

--- a/backend/src/main/java/com/web/gallery/entity/PhotoMstUpdateTarget.java
+++ b/backend/src/main/java/com/web/gallery/entity/PhotoMstUpdateTarget.java
@@ -1,9 +1,5 @@
 package com.web.gallery.entity;
 
-import java.math.BigDecimal;
-import java.util.Optional;
-
-import com.web.gallery.constant.Consts;
 import com.web.gallery.domain.common.IsDeleted;
 import com.web.gallery.domain.common.UpdatedBy;
 import com.web.gallery.domain.photo.Caption;
@@ -84,27 +80,17 @@ public class PhotoMstUpdateTarget {
 		return PhotoMstUpdateTarget.builder()
 				.updatedBy(new UpdatedBy(model.getAccountNo().value()))
 				.isDeleted(new IsDeleted(false))
-				.photoAt(new PhotoAt(
-					Optional.ofNullable(model.getPhotoAt()).map(PhotoAt::value).orElse(Consts.MIN_OFFSET_DATE_TIME)))
-				.locationNo(new LocationNo(
-					Optional.ofNullable(model.getLocationNo()).map(LocationNo::value).orElse(0L)))
+				.photoAt(PhotoAt.getOrDefault(model.getPhotoAt()))
+				.locationNo(LocationNo.getOrDefault(model.getLocationNo()))
 				.imageFilePath(model.getImageFilePath())
-				.photoJapaneseTitle(new PhotoJapaneseTitle(
-					Optional.ofNullable(model.getPhotoJapaneseTitle()).map(PhotoJapaneseTitle::value).orElse(Consts.STRING_EMPTY)))
-				.photoEnglishTitle(new PhotoEnglishTitle(
-					Optional.ofNullable(model.getPhotoEnglishTitle()).map(PhotoEnglishTitle::value).orElse(Consts.STRING_EMPTY)))
-				.caption(new Caption(
-					Optional.ofNullable(model.getCaption()).map(Caption::value).orElse(Consts.STRING_EMPTY)))
-				.directionKbn(
-					Optional.ofNullable(model.getDirectionKbn()).orElse(DirectionEnum.NONE))
-				.focalLength(new FocalLength(
-					Optional.ofNullable(exifData.focalLength()).map(FocalLength::value).orElse(0)))
-				.fValue(new FValue(
-					Optional.ofNullable(exifData.fValue()).map(FValue::value).orElse(BigDecimal.ZERO)))
-				.shutterSpeed(new ShutterSpeed(
-					Optional.ofNullable(exifData.shutterSpeed()).map(ShutterSpeed::value).orElse(BigDecimal.ZERO)))
-				.iso(new Iso(
-					Optional.ofNullable(exifData.iso()).map(Iso::value).orElse(0)))
+				.photoJapaneseTitle(PhotoJapaneseTitle.getOrDefault(model.getPhotoJapaneseTitle()))
+				.photoEnglishTitle(PhotoEnglishTitle.getOrDefault(model.getPhotoEnglishTitle()))
+				.caption(Caption.getOrDefault(model.getCaption()))
+				.directionKbn(DirectionEnum.getOrDefault(model.getDirectionKbn()))
+				.focalLength(FocalLength.getOrDefault(exifData.focalLength()))
+				.fValue(FValue.getOrDefault(exifData.fValue()))
+				.shutterSpeed(ShutterSpeed.getOrDefault(exifData.shutterSpeed()))
+				.iso(Iso.getOrDefault(exifData.iso()))
 				.build();
 	}
 

--- a/backend/src/main/java/com/web/gallery/enumeration/DirectionEnum.java
+++ b/backend/src/main/java/com/web/gallery/enumeration/DirectionEnum.java
@@ -46,4 +46,14 @@ public enum DirectionEnum {
 				.findFirst()
 				.orElse(DirectionEnum.NONE);
     }
+
+	/**
+	 * 未設定の場合にデフォルトでNONEを返す
+	 *
+	 * @param	nullable	{@link DirectionEnum}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればNONE
+	 */
+	public static DirectionEnum getOrDefault(DirectionEnum nullable) {
+		return nullable != null ? nullable : DirectionEnum.NONE;
+	}
 }

--- a/backend/src/main/java/com/web/gallery/enumeration/SexEnum.java
+++ b/backend/src/main/java/com/web/gallery/enumeration/SexEnum.java
@@ -42,7 +42,7 @@ public enum SexEnum {
 		if(Objects.isNull(value)) {
 			return SexEnum.NONE;
 		}
-		
+
 		try {
 			String upperValue = value.toUpperCase();
 			return SexEnum.valueOf(upperValue);
@@ -50,5 +50,15 @@ public enum SexEnum {
 			log.info("SexEnum: Invalid value. (value: {})", value);
 			return SexEnum.NONE;
 		}
+	}
+
+	/**
+	 * 未設定の場合にデフォルトでNONEを返す
+	 *
+	 * @param	nullable	{@link SexEnum}（null許容）
+	 * @return				nullableがnullでなければそのまま、nullであればNONE
+	 */
+	public static SexEnum getOrDefault(SexEnum nullable) {
+		return nullable != null ? nullable : SexEnum.NONE;
 	}
 }


### PR DESCRIPTION
# 概要

## 背景
バックエンドコードレビュー(2-2)にて、`Optional.ofNullable().orElse()`によるnull→デフォルト値変換ロジックがEntity層に散在・重複しており、どの層でnullが解決されるか追跡が困難、との指摘があった。
具体的には`PhotoMst.fromForRegist()` ⇔ `PhotoMstUpdateTarget.fromForUpdate()`、`Account.from()` ⇔ `AccountUpdateTarget.fromForUpdate()`間で、ほぼ同一のデフォルト値変換ロジックがコピペされていた。

## 変更内容
- domain層の値オブジェクト（15クラス）と`DirectionEnum`/`SexEnum`に`getOrDefault(Xxx nullable)`静的メソッドを追加し、null→デフォルト値変換の責任をドメインオブジェクト自身に一元化（既存の`DirectionEnum.getOrDefault(String)`/`SexEnum.getOrDefault(String)`の命名パターンに合わせた）
- `PhotoMst`/`PhotoMstUpdateTarget`、`Account`/`AccountUpdateTarget`のファクトリメソッドから重複した`Optional.ofNullable().orElse()`ロジックを排除し、`getOrDefault`呼び出しに統一

# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `./backend/gradlew -p backend bootRun --args='--spring.profiles.active=local'` で backend の起動が成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認

# 懸念事項

- `AccountUpdateTarget.fromForUpdateLoginFailure()`の`lastLoginDatetime`のみ`getOrDefault`を使わず`model.getLastLoginDatetime()`を直接セットしている。これは`UpdateTarget`がMyBatisの部分更新パターン（フィールドがnullならSET句から除外＝そのカラムは更新しない）を採用しているためで、意図的な設計。一貫性のために`getOrDefault`化を試みたが既存テストが失敗したため、元の実装に戻している。
- 本PRはEntity層の重複解消に対応範囲を絞っている。レビュー原文で指摘された「Model層・Response層」への分散は、性質の異なる処理（Modelの`@NonNull`制約充足、Responseでの保存先パス計算など）であり、無理に統合すると影響範囲が広がるため今回は対象外とした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)