### PR TITLE
refactor: PhotoServiceImpl.savePhotos()の新規登録・更新処理を分離する

### DIFF
--- a/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
@@ -119,23 +119,47 @@ public class PhotoServiceImpl implements PhotoService {
 
 		for(PhotoDetailModel photoDetailModel : photoDetailModelList){
 			if(Objects.isNull(photoDetailModel.getPhotoNo())) {
-				String filename = photoDetailModel.getImageFile().value().getOriginalFilename();
-				if(photoMstRepository.isExistPhoto(photoDetailModel)) {
-					log.warn("Duplicate image file (filename: {}}", filename);
-					throw ErrorEnum.DUPLICATE_PHOTO_FILE.toException();
-				}
-
-				photoMstRepository.regist(photoDetailModel, new ImageFilePath(filePath + filename), new PhotoNo(photoNo));
-				registPhotoTags(photoDetailModel.getPhotoTagModelList(), photoNo++);
-				uploadFile(new ImageFilePath(filePath + filename), photoDetailModel.getImageFile());
+				registPhoto(photoDetailModel, filePath, photoNo);
+				++photoNo;
 			} else {
 				savedPhotoNo = photoDetailModel.getPhotoNo();
-				photoMstRepository.update(photoDetailModel);
-				deletePhotoTags(photoDetailModel.getAccountNo(), photoDetailModel.getPhotoNo());
-				registPhotoTags(photoDetailModel.getPhotoTagModelList(), null);
+				updatePhoto(photoDetailModel);
 			}
 		}
 		return savedPhotoNo;
+	}
+
+	/**
+	 * 写真を新規登録する
+	 *
+	 * @param	photoDetailModel	{@link PhotoDetailModel}
+	 * @param	filePath			保存先のディレクトリパス
+	 * @param	newPhotoNo			新規採番された写真番号
+	 * @throws	GalleryException	同じファイル名のファイルが既に保存済みの場合
+	 */
+	private void registPhoto(PhotoDetailModel photoDetailModel, String filePath, Long newPhotoNo) throws GalleryException {
+		String filename = photoDetailModel.getImageFile().value().getOriginalFilename();
+		if(photoMstRepository.isExistPhoto(photoDetailModel)) {
+			log.warn("Duplicate image file (filename: {}}", filename);
+			throw ErrorEnum.DUPLICATE_PHOTO_FILE.toException();
+		}
+
+		ImageFilePath imageFilePath = new ImageFilePath(filePath + filename);
+		photoMstRepository.regist(photoDetailModel, imageFilePath, new PhotoNo(newPhotoNo));
+		registPhotoTags(photoDetailModel.getPhotoTagModelList(), newPhotoNo);
+		uploadFile(imageFilePath, photoDetailModel.getImageFile());
+	}
+
+	/**
+	 * 写真を更新する
+	 *
+	 * @param	photoDetailModel	{@link PhotoDetailModel}
+	 * @throws	GalleryException	更新に失敗した場合
+	 */
+	private void updatePhoto(PhotoDetailModel photoDetailModel) throws GalleryException {
+		photoMstRepository.update(photoDetailModel);
+		deletePhotoTags(photoDetailModel.getAccountNo(), photoDetailModel.getPhotoNo());
+		registPhotoTags(photoDetailModel.getPhotoTagModelList(), null);
 	}
 
 	/**


### PR DESCRIPTION
# 概要

## 背景

コードレビュー（backend-code-review.md 2-1）で、PhotoServiceImpl.savePhotos()が
以下の責務をひとつのforループ内に詰め込んでおり、可読性・保守性が低いと指摘された。
- ファイル重複チェック
- 写真登録/更新の分岐
- タグの削除と再登録
- ファイルのアップロード

## 変更内容

savePhotos()のforループ内に混在していた新規登録処理・更新処理を、
それぞれ registPhoto() / updatePhoto() のprivateメソッドに分割した。
savePhotos()本体は新規/更新の分岐とループ制御のみの責務とした。

# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `./backend/gradlew -p backend bootRun --args='--spring.profiles.active=local'` で backend の起動が成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認

# 懸念事項

ロジックの外部からの見え方（挙動）は変更していない。既存のユニットテスト・
結合テストがすべて成功することを確認済み。