### PR TITLE
refactor: 写真登録・削除時にドメインイベントを発行する

### DIFF
--- a/.claude/rules/event.md
+++ b/.claude/rules/event.md
@@ -1,0 +1,28 @@
+---
+paths:
+  - backend/**/event/**
+---
+
+# Eventクラスのアーキテクチャルール
+
+写真登録・削除などのドメインイベントと、それをハンドリングするリスナーを配置する。Service層のビジネスロジックから、通知やログ集計等の副次的な処理を疎結合にする。
+
+## 命名規則
+
+- イベントクラスサフィックス: `Event`
+- リスナークラスサフィックス: `Listener`
+
+## イベントクラス
+
+- `record Xxx(型 xxx, ...)`として実装する
+- プロパティは、ドメインクラス（値オブジェクト）のみとする
+
+## リスナークラス
+
+- `@Component`アノテーションを付与すること
+- ハンドリングするメソッドには`@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)`を付与し、トランザクションのコミット後にのみ実行されるようにすること
+
+## レイヤー間依存関係
+
+- **許可するimport**: `domain/`
+- **禁止するimport**: `controller/`、`repository/`、`mapper/`、`entity/`、`dto/`、`service/`への依存

--- a/.claude/rules/service.md
+++ b/.claude/rules/service.md
@@ -17,7 +17,7 @@ paths:
 
 ## レイヤー間依存関係
 
-- **許可するimport**: `repository/`のインターフェース、`model/`、`aggregate/`、`constant/`、`enumeration/`、`exception/`、`policy/`、`domain/`、`config/`
+- **許可するimport**: `repository/`のインターフェース、`model/`、`aggregate/`、`constant/`、`enumeration/`、`exception/`、`policy/`、`domain/`、`config/`、`event/`
 - **禁止するimport**: `controller/`、`mapper/`、`entity/`、`dto/`、`repository/impl/`への直接依存
 - **禁止するimport**: `controller/request/`や`controller/response/`のDTO
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ just e2e
 3. **Repository層** (`repository/` + `repository/impl/`) - データベースアクセス。`/model/`でService層と、`/entity/`や`/dto/`でMapper層と転送する
 4. **MyBatis Mapper層** (`mapper/`) - SQLは`resources/com/web/gallery/mapper/*.xml`のXMLファイルで定義
 
-上記に加え、`domain/`にはプロパティ単位の値オブジェクト（`record`）が定義されており、Model・Repository・Serviceのメソッド引数・返り値として利用される。単一のビジネスルールを判定するドメインサービスは`policy/`に配置し、Service層からのみ利用する。また、管理者権限チェックには`annotation/`のカスタムアノテーションと`aspect/`のAOPを使用する。
+上記に加え、`domain/`にはプロパティ単位の値オブジェクト（`record`）が定義されており、Model・Repository・Serviceのメソッド引数・返り値として利用される。単一のビジネスルールを判定するドメインサービスは`policy/`に配置し、Service層からのみ利用する。また、管理者権限チェックには`annotation/`のカスタムアノテーションと`aspect/`のAOPを使用する。写真登録・削除などのドメインイベントとそのリスナーは`event/`に配置し、通知やログ集計等の副次的な処理をService層のビジネスロジックから疎結合にする。
 
 書き込みユースケース（登録・更新・削除）で複数テーブルにまたがる整合性・ライフサイクルの管理が必要な場合、`aggregate/`に集約ルートクラスを定義し、Service層とRepository層の間に位置づける（例：`Photo`集約）。詳細は`.claude/rules/aggregate.md`を参照。
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ WebGallery/
 │       │   │   ├── dto/                # DBアクセス層の複合データ転送オブジェクト
 │       │   │   ├── entity/             # エンティティ
 │       │   │   ├── enumeration/        # 列挙型
+│       │   │   ├── event/              # ドメインイベント・リスナー
 │       │   │   ├── exception/          # カスタム例外
 │       │   │   ├── helper/             # ヘルパーユーティリティ
 │       │   │   ├── mapper/             # MyBatisマッパー

--- a/backend/src/main/java/com/web/gallery/event/AccountDeletedEvent.java
+++ b/backend/src/main/java/com/web/gallery/event/AccountDeletedEvent.java
@@ -1,0 +1,13 @@
+package com.web.gallery.event;
+
+import com.web.gallery.domain.account.AccountId;
+import com.web.gallery.domain.account.AccountNo;
+
+/**
+ * アカウントの削除時に発行されるドメインイベント
+ *
+ * @param	accountNo	アカウント番号
+ * @param	accountId	アカウントID
+ */
+public record AccountDeletedEvent(AccountNo accountNo, AccountId accountId) {
+}

--- a/backend/src/main/java/com/web/gallery/event/AccountEventListener.java
+++ b/backend/src/main/java/com/web/gallery/event/AccountEventListener.java
@@ -1,0 +1,36 @@
+package com.web.gallery.event;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * アカウントに関するドメインイベントをハンドリングするリスナークラス<p>
+ * アカウント登録・削除のログ集計を、Service層のビジネスロジックから疎結合に行う
+ */
+@Slf4j
+@Component
+public class AccountEventListener {
+
+	/**
+	 * アカウントの新規登録イベントをハンドリングする
+	 *
+	 * @param	event	{@link AccountRegisteredEvent}
+	 */
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(AccountRegisteredEvent event) {
+		log.info("Account registered (accountId: {})", event.accountId().value());
+	}
+
+	/**
+	 * アカウントの削除イベントをハンドリングする
+	 *
+	 * @param	event	{@link AccountDeletedEvent}
+	 */
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(AccountDeletedEvent event) {
+		log.info("Account deleted (accountNo: {}, accountId: {})", event.accountNo().value(), event.accountId().value());
+	}
+}

--- a/backend/src/main/java/com/web/gallery/event/AccountEventListener.java
+++ b/backend/src/main/java/com/web/gallery/event/AccountEventListener.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * アカウントに関するドメインイベントをハンドリングするリスナークラス<p>
- * アカウント登録・削除のログ集計を、Service層のビジネスロジックから疎結合に行う
+ * アカウント登録・更新・削除のログ集計を、Service層のビジネスロジックから疎結合に行う
  */
 @Slf4j
 @Component
@@ -22,6 +22,16 @@ public class AccountEventListener {
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(AccountRegisteredEvent event) {
 		log.info("Account registered (accountId: {})", event.accountId().value());
+	}
+
+	/**
+	 * アカウントの更新イベントをハンドリングする
+	 *
+	 * @param	event	{@link AccountUpdatedEvent}
+	 */
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(AccountUpdatedEvent event) {
+		log.info("Account updated (accountNo: {}, accountId: {})", event.accountNo().value(), event.accountId().value());
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/event/AccountRegisteredEvent.java
+++ b/backend/src/main/java/com/web/gallery/event/AccountRegisteredEvent.java
@@ -1,0 +1,11 @@
+package com.web.gallery.event;
+
+import com.web.gallery.domain.account.AccountId;
+
+/**
+ * アカウントの新規登録時に発行されるドメインイベント
+ *
+ * @param	accountId	アカウントID
+ */
+public record AccountRegisteredEvent(AccountId accountId) {
+}

--- a/backend/src/main/java/com/web/gallery/event/AccountUpdatedEvent.java
+++ b/backend/src/main/java/com/web/gallery/event/AccountUpdatedEvent.java
@@ -1,0 +1,13 @@
+package com.web.gallery.event;
+
+import com.web.gallery.domain.account.AccountId;
+import com.web.gallery.domain.account.AccountNo;
+
+/**
+ * アカウントの更新時に発行されるドメインイベント
+ *
+ * @param	accountNo	アカウント番号
+ * @param	accountId	アカウントID
+ */
+public record AccountUpdatedEvent(AccountNo accountNo, AccountId accountId) {
+}

--- a/backend/src/main/java/com/web/gallery/event/PhotoDeletedEvent.java
+++ b/backend/src/main/java/com/web/gallery/event/PhotoDeletedEvent.java
@@ -1,0 +1,13 @@
+package com.web.gallery.event;
+
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.photo.PhotoNo;
+
+/**
+ * 写真の削除時に発行されるドメインイベント
+ *
+ * @param	accountNo	アカウント番号
+ * @param	photoNo		写真番号
+ */
+public record PhotoDeletedEvent(AccountNo accountNo, PhotoNo photoNo) {
+}

--- a/backend/src/main/java/com/web/gallery/event/PhotoEventListener.java
+++ b/backend/src/main/java/com/web/gallery/event/PhotoEventListener.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * 写真に関するドメインイベントをハンドリングするリスナークラス<p>
- * 写真登録・削除のログ集計を、Service層のビジネスロジックから疎結合に行う
+ * 写真登録・更新・削除のログ集計を、Service層のビジネスロジックから疎結合に行う
  */
 @Slf4j
 @Component
@@ -22,6 +22,16 @@ public class PhotoEventListener {
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(PhotoRegisteredEvent event) {
 		log.info("Photo registered (accountNo: {}, photoNo: {})", event.accountNo().value(), event.photoNo().value());
+	}
+
+	/**
+	 * 写真の更新イベントをハンドリングする
+	 *
+	 * @param	event	{@link PhotoUpdatedEvent}
+	 */
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(PhotoUpdatedEvent event) {
+		log.info("Photo updated (accountNo: {}, photoNo: {})", event.accountNo().value(), event.photoNo().value());
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/event/PhotoEventListener.java
+++ b/backend/src/main/java/com/web/gallery/event/PhotoEventListener.java
@@ -1,0 +1,36 @@
+package com.web.gallery.event;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 写真に関するドメインイベントをハンドリングするリスナークラス<p>
+ * 写真登録・削除のログ集計を、Service層のビジネスロジックから疎結合に行う
+ */
+@Slf4j
+@Component
+public class PhotoEventListener {
+
+	/**
+	 * 写真の新規登録イベントをハンドリングする
+	 *
+	 * @param	event	{@link PhotoRegisteredEvent}
+	 */
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(PhotoRegisteredEvent event) {
+		log.info("Photo registered (accountNo: {}, photoNo: {})", event.accountNo().value(), event.photoNo().value());
+	}
+
+	/**
+	 * 写真の削除イベントをハンドリングする
+	 *
+	 * @param	event	{@link PhotoDeletedEvent}
+	 */
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(PhotoDeletedEvent event) {
+		log.info("Photo deleted (accountNo: {}, photoNo: {})", event.accountNo().value(), event.photoNo().value());
+	}
+}

--- a/backend/src/main/java/com/web/gallery/event/PhotoRegisteredEvent.java
+++ b/backend/src/main/java/com/web/gallery/event/PhotoRegisteredEvent.java
@@ -1,0 +1,13 @@
+package com.web.gallery.event;
+
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.photo.PhotoNo;
+
+/**
+ * 写真の新規登録時に発行されるドメインイベント
+ *
+ * @param	accountNo	アカウント番号
+ * @param	photoNo		写真番号
+ */
+public record PhotoRegisteredEvent(AccountNo accountNo, PhotoNo photoNo) {
+}

--- a/backend/src/main/java/com/web/gallery/event/PhotoUpdatedEvent.java
+++ b/backend/src/main/java/com/web/gallery/event/PhotoUpdatedEvent.java
@@ -1,0 +1,13 @@
+package com.web.gallery.event;
+
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.photo.PhotoNo;
+
+/**
+ * 写真の更新時に発行されるドメインイベント
+ *
+ * @param	accountNo	アカウント番号
+ * @param	photoNo		写真番号
+ */
+public record PhotoUpdatedEvent(AccountNo accountNo, PhotoNo photoNo) {
+}

--- a/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
@@ -22,6 +22,7 @@ import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.ImageFilePath;
 import com.web.gallery.event.AccountDeletedEvent;
 import com.web.gallery.event.AccountRegisteredEvent;
+import com.web.gallery.event.AccountUpdatedEvent;
 import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.model.AccountModelList;
@@ -98,7 +99,10 @@ public class AccountServiceImpl implements UserDetailsService {
 	@Transactional
 	public Boolean updateAccount(AccountModel accountModel) throws GalleryException {
 		Boolean isExist = accountRepository.isExistAccount(accountModel.getAccountNo(), accountModel.getAccountId());
-		if(!isExist) accountRepository.update(accountModel);
+		if(!isExist) {
+			accountRepository.update(accountModel);
+			applicationEventPublisher.publishEvent(new AccountUpdatedEvent(accountModel.getAccountNo(), accountModel.getAccountId()));
+		}
 		return isExist;
 	}
 

--- a/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
@@ -3,6 +3,7 @@ package com.web.gallery.service.impl;
 import java.time.Clock;
 import java.util.Objects;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
@@ -19,6 +20,8 @@ import com.web.gallery.constant.MessageConst;
 import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.ImageFilePath;
+import com.web.gallery.event.AccountDeletedEvent;
+import com.web.gallery.event.AccountRegisteredEvent;
 import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.model.AccountModelList;
@@ -47,6 +50,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	private final LoginConfig loginConfig;
 	private final PhotoConfig photoConfig;
 	private final Clock clock;
+	private final ApplicationEventPublisher applicationEventPublisher;
 
 	/**
 	 * アカウントIDからアカウント情報の存在を確認する
@@ -77,7 +81,10 @@ public class AccountServiceImpl implements UserDetailsService {
 	@Transactional
 	public Boolean registAccount(AccountModel accountModel) throws GalleryException {
 		Boolean isExist = accountRepository.isExistAccount(accountModel.getAccountId());
-		if(!isExist) accountRepository.regist(accountModel);
+		if(!isExist) {
+			accountRepository.regist(accountModel);
+			applicationEventPublisher.publishEvent(new AccountRegisteredEvent(accountModel.getAccountId()));
+		}
 		return !isExist;
 	}
 
@@ -173,6 +180,8 @@ public class AccountServiceImpl implements UserDetailsService {
 
 		// 写真ファイルのディレクトリを削除
 		fileRepository.delete(new ImageFilePath(photoConfig.getOutputPath() + accountId.value() + "/"));
+
+		applicationEventPublisher.publishEvent(new AccountDeletedEvent(accountNo, accountId));
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
@@ -7,6 +7,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.Objects;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,8 @@ import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.PhotoCount;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.enumeration.SortPhotoEnum;
+import com.web.gallery.event.PhotoDeletedEvent;
+import com.web.gallery.event.PhotoRegisteredEvent;
 import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.FileModel;
 import com.web.gallery.model.PhotoDeleteModel;
@@ -61,6 +64,7 @@ public class PhotoServiceImpl implements PhotoService {
 	private final FileRepository fileRepository;
 	private final PhotoConfig photoConfig;
 	private final PhotoQuotaPolicy photoQuotaPolicy;
+	private final ApplicationEventPublisher applicationEventPublisher;
 
 	/**
 	 * 写真一覧を取得する
@@ -121,6 +125,7 @@ public class PhotoServiceImpl implements PhotoService {
 				Photo photo = Photo.forRegist(photoDetailModel, new PhotoNo(photoNo), new ImageFilePath(filePath + filename));
 				photoAggregateRepository.regist(photo);
 				fileRepository.save(FileModel.of(photo.getImageFilePath(), photo.getImageFile()));
+				applicationEventPublisher.publishEvent(new PhotoRegisteredEvent(photo.getAccountNo(), photo.getPhotoNo()));
 				++photoNo;
 			} else {
 				savedPhotoNo = photoDetailModel.getPhotoNo();
@@ -149,6 +154,7 @@ public class PhotoServiceImpl implements PhotoService {
 			Photo photo = Photo.forDelete(photoDeleteModel.getAccountNo(), photoDeleteModel.getPhotoNo(), imageFilePathForDelete);
 			photoAggregateRepository.delete(photo);
 			fileRepository.delete(imageFilePathForDelete);
+			applicationEventPublisher.publishEvent(new PhotoDeletedEvent(photo.getAccountNo(), photo.getPhotoNo()));
 		}
 	}
 

--- a/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
@@ -23,6 +23,7 @@ import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.enumeration.SortPhotoEnum;
 import com.web.gallery.event.PhotoDeletedEvent;
 import com.web.gallery.event.PhotoRegisteredEvent;
+import com.web.gallery.event.PhotoUpdatedEvent;
 import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.FileModel;
 import com.web.gallery.model.PhotoDeleteModel;
@@ -131,6 +132,7 @@ public class PhotoServiceImpl implements PhotoService {
 				savedPhotoNo = photoDetailModel.getPhotoNo();
 				Photo photo = Photo.forUpdate(photoDetailModel);
 				photoAggregateRepository.update(photo);
+				applicationEventPublisher.publishEvent(new PhotoUpdatedEvent(photo.getAccountNo(), photo.getPhotoNo()));
 			}
 		}
 		return savedPhotoNo;

--- a/backend/src/test/java/com/web/gallery/event/AccountEventListenerTest.java
+++ b/backend/src/test/java/com/web/gallery/event/AccountEventListenerTest.java
@@ -1,0 +1,34 @@
+package com.web.gallery.event;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.web.gallery.domain.account.AccountId;
+import com.web.gallery.domain.account.AccountNo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class AccountEventListenerTest {
+	@InjectMocks
+	private AccountEventListener accountEventListener;
+
+	@Test
+	@DisplayName("正常系：AccountRegisteredEventを受け取っても例外が発生しないこと")
+	void handle_accountRegisteredEvent_success() {
+		AccountRegisteredEvent event = new AccountRegisteredEvent(new AccountId("aaaaaaaa"));
+		assertDoesNotThrow(() -> accountEventListener.handle(event));
+	}
+
+	@Test
+	@DisplayName("正常系：AccountDeletedEventを受け取っても例外が発生しないこと")
+	void handle_accountDeletedEvent_success() {
+		AccountDeletedEvent event = new AccountDeletedEvent(new AccountNo(1L), new AccountId("aaaaaaaa"));
+		assertDoesNotThrow(() -> accountEventListener.handle(event));
+	}
+}

--- a/backend/src/test/java/com/web/gallery/event/AccountEventListenerTest.java
+++ b/backend/src/test/java/com/web/gallery/event/AccountEventListenerTest.java
@@ -26,6 +26,13 @@ public class AccountEventListenerTest {
 	}
 
 	@Test
+	@DisplayName("正常系：AccountUpdatedEventを受け取っても例外が発生しないこと")
+	void handle_accountUpdatedEvent_success() {
+		AccountUpdatedEvent event = new AccountUpdatedEvent(new AccountNo(1L), new AccountId("aaaaaaaa"));
+		assertDoesNotThrow(() -> accountEventListener.handle(event));
+	}
+
+	@Test
 	@DisplayName("正常系：AccountDeletedEventを受け取っても例外が発生しないこと")
 	void handle_accountDeletedEvent_success() {
 		AccountDeletedEvent event = new AccountDeletedEvent(new AccountNo(1L), new AccountId("aaaaaaaa"));

--- a/backend/src/test/java/com/web/gallery/event/PhotoEventListenerTest.java
+++ b/backend/src/test/java/com/web/gallery/event/PhotoEventListenerTest.java
@@ -26,6 +26,13 @@ public class PhotoEventListenerTest {
 	}
 
 	@Test
+	@DisplayName("正常系：PhotoUpdatedEventを受け取っても例外が発生しないこと")
+	void handle_photoUpdatedEvent_success() {
+		PhotoUpdatedEvent event = new PhotoUpdatedEvent(new AccountNo(1L), new PhotoNo(1L));
+		assertDoesNotThrow(() -> photoEventListener.handle(event));
+	}
+
+	@Test
 	@DisplayName("正常系：PhotoDeletedEventを受け取っても例外が発生しないこと")
 	void handle_photoDeletedEvent_success() {
 		PhotoDeletedEvent event = new PhotoDeletedEvent(new AccountNo(1L), new PhotoNo(1L));

--- a/backend/src/test/java/com/web/gallery/event/PhotoEventListenerTest.java
+++ b/backend/src/test/java/com/web/gallery/event/PhotoEventListenerTest.java
@@ -1,0 +1,34 @@
+package com.web.gallery.event;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.domain.photo.PhotoNo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class PhotoEventListenerTest {
+	@InjectMocks
+	private PhotoEventListener photoEventListener;
+
+	@Test
+	@DisplayName("正常系：PhotoRegisteredEventを受け取っても例外が発生しないこと")
+	void handle_photoRegisteredEvent_success() {
+		PhotoRegisteredEvent event = new PhotoRegisteredEvent(new AccountNo(1L), new PhotoNo(1L));
+		assertDoesNotThrow(() -> photoEventListener.handle(event));
+	}
+
+	@Test
+	@DisplayName("正常系：PhotoDeletedEventを受け取っても例外が発生しないこと")
+	void handle_photoDeletedEvent_success() {
+		PhotoDeletedEvent event = new PhotoDeletedEvent(new AccountNo(1L), new PhotoNo(1L));
+		assertDoesNotThrow(() -> photoEventListener.handle(event));
+	}
+}

--- a/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
@@ -50,6 +50,7 @@ import com.web.gallery.domain.common.IsDeleted;
 import com.web.gallery.domain.photo.ImageFilePath;
 import com.web.gallery.event.AccountDeletedEvent;
 import com.web.gallery.event.AccountRegisteredEvent;
+import com.web.gallery.event.AccountUpdatedEvent;
 import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
@@ -190,8 +191,13 @@ public class AccountServiceImplTest {
 			doReturn(false).when(accountRepositoryImpl).isExistAccount(new AccountNo(1L), new AccountId("aaaaaaaa"));
 			doNothing().when(accountRepositoryImpl).update(accountModel);
 			assertFalse(accountServiceImpl.updateAccount(accountModel));
+
+			ArgumentCaptor<AccountUpdatedEvent> accountUpdatedEventCaptor = ArgumentCaptor.forClass(AccountUpdatedEvent.class);
+			verify(applicationEventPublisher, times(1)).publishEvent(accountUpdatedEventCaptor.capture());
+			assertEquals(new AccountNo(1L), accountUpdatedEventCaptor.getValue().accountNo());
+			assertEquals(new AccountId("aaaaaaaa"), accountUpdatedEventCaptor.getValue().accountId());
 		}
-		
+
 		@Test
 		@Order(2)
 		@DisplayName("正常系：アカウントが既に存在する")
@@ -200,8 +206,9 @@ public class AccountServiceImplTest {
 			doReturn(true).when(accountRepositoryImpl).isExistAccount(new AccountNo(1L), new AccountId("aaaaaaaa"));
 			verify(accountRepositoryImpl,times(0)).update(accountModel);
 			assertTrue(accountServiceImpl.updateAccount(accountModel));
+			verify(applicationEventPublisher, times(0)).publishEvent(any());
 		}
-		
+
 		@Test
 		@Order(3)
 		@DisplayName("異常系：UpdateFailureExceptionをthrowする")
@@ -210,6 +217,7 @@ public class AccountServiceImplTest {
 			doReturn(false).when(accountRepositoryImpl).isExistAccount(new AccountNo(1L), new AccountId("aaaaaaaa"));
 			doThrow(UpdateFailureException.class).when(accountRepositoryImpl).update(accountModel);
 			assertThrows(UpdateFailureException.class, () -> accountServiceImpl.updateAccount(accountModel));
+			verify(applicationEventPublisher, times(0)).publishEvent(any());
 		}
 	}
 	

--- a/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
@@ -22,6 +22,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
@@ -47,6 +48,8 @@ import com.web.gallery.domain.account.Password;
 import com.web.gallery.domain.account.ResidentPrefectureKbnCode;
 import com.web.gallery.domain.common.IsDeleted;
 import com.web.gallery.domain.photo.ImageFilePath;
+import com.web.gallery.event.AccountDeletedEvent;
+import com.web.gallery.event.AccountRegisteredEvent;
 import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
@@ -90,6 +93,9 @@ public class AccountServiceImplTest {
 
 	@Mock
 	private Clock clock;
+
+	@Mock
+	private ApplicationEventPublisher applicationEventPublisher;
 
 	@BeforeEach
 	void setUpClock() {
@@ -143,8 +149,12 @@ public class AccountServiceImplTest {
 			doReturn(false).when(accountRepositoryImpl).isExistAccount(new AccountId("aaaaaaaa"));
 			doNothing().when(accountRepositoryImpl).regist(accountModel);
 			assertTrue(accountServiceImpl.registAccount(accountModel));
+
+			ArgumentCaptor<AccountRegisteredEvent> accountRegisteredEventCaptor = ArgumentCaptor.forClass(AccountRegisteredEvent.class);
+			verify(applicationEventPublisher, times(1)).publishEvent(accountRegisteredEventCaptor.capture());
+			assertEquals(new AccountId("aaaaaaaa"), accountRegisteredEventCaptor.getValue().accountId());
 		}
-		
+
 		@Test
 		@Order(2)
 		@DisplayName("正常系：アカウントが既に存在する")
@@ -153,8 +163,9 @@ public class AccountServiceImplTest {
 			doReturn(true).when(accountRepositoryImpl).isExistAccount(new AccountId("aaaaaaaa"));
 			verify(accountRepositoryImpl,times(0)).regist(accountModel);
 			assertFalse(accountServiceImpl.registAccount(accountModel));
+			verify(applicationEventPublisher, times(0)).publishEvent(any());
 		}
-		
+
 		@Test
 		@Order(3)
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
@@ -163,6 +174,7 @@ public class AccountServiceImplTest {
 			doReturn(false).when(accountRepositoryImpl).isExistAccount(new AccountId("aaaaaaaa"));
 			doThrow(RegistFailureException.class).when(accountRepositoryImpl).regist(accountModel);
 			assertThrows(RegistFailureException.class, () -> accountServiceImpl.registAccount(accountModel));
+			verify(applicationEventPublisher, times(0)).publishEvent(any());
 		}
 	}
 	
@@ -405,6 +417,11 @@ public class AccountServiceImplTest {
 			verify(photoMstRepository, times(1)).deleteByAccountNo(new AccountNo(accountNo));
 			verify(accountRepositoryImpl, times(1)).delete(new AccountNo(accountNo));
 			verify(fileRepository, times(1)).delete(new ImageFilePath("/output/" + accountId + "/"));
+
+			ArgumentCaptor<AccountDeletedEvent> accountDeletedEventCaptor = ArgumentCaptor.forClass(AccountDeletedEvent.class);
+			verify(applicationEventPublisher, times(1)).publishEvent(accountDeletedEventCaptor.capture());
+			assertEquals(new AccountNo(accountNo), accountDeletedEventCaptor.getValue().accountNo());
+			assertEquals(new AccountId(accountId), accountDeletedEventCaptor.getValue().accountId());
 		}
 	}
 

--- a/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
@@ -25,6 +25,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
@@ -57,6 +58,8 @@ import com.web.gallery.model.AccountModel;
 import com.web.gallery.enumeration.AuthorityEnum;
 import com.web.gallery.enumeration.DirectionEnum;
 import com.web.gallery.enumeration.SortPhotoEnum;
+import com.web.gallery.event.PhotoDeletedEvent;
+import com.web.gallery.event.PhotoRegisteredEvent;
 import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.PhotoNotFoundException;
 import com.web.gallery.exception.RegistFailureException;
@@ -106,6 +109,9 @@ public class PhotoServiceImplTest {
 
 	@Mock
 	private PhotoQuotaPolicy photoQuotaPolicy;
+
+	@Mock
+	private ApplicationEventPublisher applicationEventPublisher;
 
 	@Nested
 	@Order(1)
@@ -560,6 +566,7 @@ public class PhotoServiceImplTest {
 			verify(photoMstRepositoryImpl, times(0)).getNewPhotoNo(any(AccountNo.class));
 			verify(photoAggregateRepositoryImpl, times(0)).regist(any(Photo.class));
 			verify(photoAggregateRepositoryImpl, times(0)).update(any(Photo.class));
+			verify(applicationEventPublisher, times(0)).publishEvent(any());
 		}
 
 		@Test
@@ -572,6 +579,7 @@ public class PhotoServiceImplTest {
 			verify(photoMstRepositoryImpl, times(0)).getNewPhotoNo(any(AccountNo.class));
 			verify(photoAggregateRepositoryImpl, times(0)).regist(any(Photo.class));
 			verify(photoAggregateRepositoryImpl, times(0)).update(any(Photo.class));
+			verify(applicationEventPublisher, times(0)).publishEvent(any());
 		}
 
 		@Test
@@ -630,6 +638,14 @@ public class PhotoServiceImplTest {
 			assertEquals(new AccountNo(1L), photoCaptureList.get(1).getAccountNo());
 			assertEquals(new PhotoNo(6L), photoCaptureList.get(1).getPhotoNo());
 			assertEquals(new ImageFilePath(filePath + accountId + "/DSC222.jpg"), photoCaptureList.get(1).getImageFilePath());
+
+			ArgumentCaptor<PhotoRegisteredEvent> photoRegisteredEventCaptor = ArgumentCaptor.forClass(PhotoRegisteredEvent.class);
+			verify(applicationEventPublisher, times(2)).publishEvent(photoRegisteredEventCaptor.capture());
+			List<PhotoRegisteredEvent> photoRegisteredEventCaptureList = photoRegisteredEventCaptor.getAllValues();
+			assertEquals(new AccountNo(1L), photoRegisteredEventCaptureList.get(0).accountNo());
+			assertEquals(new PhotoNo(5L), photoRegisteredEventCaptureList.get(0).photoNo());
+			assertEquals(new AccountNo(1L), photoRegisteredEventCaptureList.get(1).accountNo());
+			assertEquals(new PhotoNo(6L), photoRegisteredEventCaptureList.get(1).photoNo());
 		}
 
 		@Test
@@ -660,6 +676,7 @@ public class PhotoServiceImplTest {
 			verify(photoAggregateRepositoryImpl, times(0)).regist(any(Photo.class));
 			verify(photoAggregateRepositoryImpl, times(2)).update(any(Photo.class));
 			verify(fileRepositoryImpl, times(0)).save(any(FileModel.class));
+			verify(applicationEventPublisher, times(0)).publishEvent(any());
 
 			List<Photo> photoCaptureList = photoCaptor.getAllValues();
 			assertEquals(new PhotoNo(2L), photoCaptureList.get(0).getPhotoNo());
@@ -718,6 +735,11 @@ public class PhotoServiceImplTest {
 
 			Photo updatedPhoto = photoUpdateCaptor.getValue();
 			assertEquals(new PhotoNo(3L), updatedPhoto.getPhotoNo());
+
+			ArgumentCaptor<PhotoRegisteredEvent> photoRegisteredEventCaptor = ArgumentCaptor.forClass(PhotoRegisteredEvent.class);
+			verify(applicationEventPublisher, times(1)).publishEvent(photoRegisteredEventCaptor.capture());
+			assertEquals(new AccountNo(1L), photoRegisteredEventCaptor.getValue().accountNo());
+			assertEquals(new PhotoNo(5L), photoRegisteredEventCaptor.getValue().photoNo());
 		}
 
 		@Test
@@ -745,6 +767,7 @@ public class PhotoServiceImplTest {
 			verify(photoAggregateRepositoryImpl, times(1)).regist(any(Photo.class));
 			verify(photoAggregateRepositoryImpl, times(0)).update(any(Photo.class));
 			verify(fileRepositoryImpl, times(0)).save(any(FileModel.class));
+			verify(applicationEventPublisher, times(0)).publishEvent(any());
 		}
 
 		@Test
@@ -771,6 +794,7 @@ public class PhotoServiceImplTest {
 
 			verify(photoAggregateRepositoryImpl, times(0)).regist(any(Photo.class));
 			verify(photoAggregateRepositoryImpl, times(1)).update(any(Photo.class));
+			verify(applicationEventPublisher, times(0)).publishEvent(any());
 		}
 	}
 	
@@ -786,6 +810,7 @@ public class PhotoServiceImplTest {
 
 			photoServiceImpl.deletePhotos(new AccountId("aaaaaaaa"), PhotoDeleteModelList.empty());
 			verify(photoAggregateRepositoryImpl, times(0)).delete(any(Photo.class));
+			verify(applicationEventPublisher, times(0)).publishEvent(any());
 		}
 
 		@Test
@@ -828,6 +853,14 @@ public class PhotoServiceImplTest {
 			assertEquals(new AccountNo(1L), photoCaptureList.get(1).getAccountNo());
 			assertEquals(2L, photoCaptureList.get(1).getPhotoNo().value());
 			assertEquals(new ImageFilePath("https://localhost:8080/image/aaaaaaaa/DSC222.jpg"), photoCaptureList.get(1).getImageFilePathForDelete());
+
+			ArgumentCaptor<PhotoDeletedEvent> photoDeletedEventCaptor = ArgumentCaptor.forClass(PhotoDeletedEvent.class);
+			verify(applicationEventPublisher, times(2)).publishEvent(photoDeletedEventCaptor.capture());
+			List<PhotoDeletedEvent> photoDeletedEventCaptureList = photoDeletedEventCaptor.getAllValues();
+			assertEquals(new AccountNo(1L), photoDeletedEventCaptureList.get(0).accountNo());
+			assertEquals(1L, photoDeletedEventCaptureList.get(0).photoNo().value());
+			assertEquals(new AccountNo(1L), photoDeletedEventCaptureList.get(1).accountNo());
+			assertEquals(2L, photoDeletedEventCaptureList.get(1).photoNo().value());
 		}
 
 		@Test
@@ -848,6 +881,7 @@ public class PhotoServiceImplTest {
 
 			verify(photoAggregateRepositoryImpl, times(1)).delete(any(Photo.class));
 			verify(fileRepositoryImpl, times(0)).delete(any(ImageFilePath.class));
+			verify(applicationEventPublisher, times(0)).publishEvent(any());
 		}
 	}
 	

--- a/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/PhotoServiceImplTest.java
@@ -60,6 +60,7 @@ import com.web.gallery.enumeration.DirectionEnum;
 import com.web.gallery.enumeration.SortPhotoEnum;
 import com.web.gallery.event.PhotoDeletedEvent;
 import com.web.gallery.event.PhotoRegisteredEvent;
+import com.web.gallery.event.PhotoUpdatedEvent;
 import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.PhotoNotFoundException;
 import com.web.gallery.exception.RegistFailureException;
@@ -676,7 +677,6 @@ public class PhotoServiceImplTest {
 			verify(photoAggregateRepositoryImpl, times(0)).regist(any(Photo.class));
 			verify(photoAggregateRepositoryImpl, times(2)).update(any(Photo.class));
 			verify(fileRepositoryImpl, times(0)).save(any(FileModel.class));
-			verify(applicationEventPublisher, times(0)).publishEvent(any());
 
 			List<Photo> photoCaptureList = photoCaptor.getAllValues();
 			assertEquals(new PhotoNo(2L), photoCaptureList.get(0).getPhotoNo());
@@ -687,6 +687,14 @@ public class PhotoServiceImplTest {
 			assertEquals("海", photoCaptureList.get(0).getPhotoTagModelList().get(1).getTagJapaneseName().value());
 
 			assertEquals(new PhotoNo(3L), photoCaptureList.get(1).getPhotoNo());
+
+			ArgumentCaptor<PhotoUpdatedEvent> photoUpdatedEventCaptor = ArgumentCaptor.forClass(PhotoUpdatedEvent.class);
+			verify(applicationEventPublisher, times(2)).publishEvent(photoUpdatedEventCaptor.capture());
+			List<PhotoUpdatedEvent> photoUpdatedEventCaptureList = photoUpdatedEventCaptor.getAllValues();
+			assertEquals(new AccountNo(1L), photoUpdatedEventCaptureList.get(0).accountNo());
+			assertEquals(new PhotoNo(2L), photoUpdatedEventCaptureList.get(0).photoNo());
+			assertEquals(new AccountNo(1L), photoUpdatedEventCaptureList.get(1).accountNo());
+			assertEquals(new PhotoNo(3L), photoUpdatedEventCaptureList.get(1).photoNo());
 		}
 
 		@Test
@@ -740,6 +748,11 @@ public class PhotoServiceImplTest {
 			verify(applicationEventPublisher, times(1)).publishEvent(photoRegisteredEventCaptor.capture());
 			assertEquals(new AccountNo(1L), photoRegisteredEventCaptor.getValue().accountNo());
 			assertEquals(new PhotoNo(5L), photoRegisteredEventCaptor.getValue().photoNo());
+
+			ArgumentCaptor<PhotoUpdatedEvent> photoUpdatedEventCaptor = ArgumentCaptor.forClass(PhotoUpdatedEvent.class);
+			verify(applicationEventPublisher, times(1)).publishEvent(photoUpdatedEventCaptor.capture());
+			assertEquals(new AccountNo(1L), photoUpdatedEventCaptor.getValue().accountNo());
+			assertEquals(new PhotoNo(3L), photoUpdatedEventCaptor.getValue().photoNo());
 		}
 
 		@Test


### PR DESCRIPTION
# 概要

## 背景

バックエンドコードレビューの指摘事項（4-3. ドメインイベントの活用）に基づく対応。
現状、`AuthenticationSuccessEvent`（Spring Security標準）のみSpring Eventを利用しており、
写真・アカウントの登録・更新・削除処理はログ出力等の副次処理がService層のビジネスロジックに直接埋め込まれていた。

## 変更内容

- `event/`パッケージを新設し、以下のドメインイベントを追加
  - `PhotoRegisteredEvent`・`PhotoUpdatedEvent`・`PhotoDeletedEvent`（写真登録・更新・削除時）
  - `AccountRegisteredEvent`・`AccountUpdatedEvent`・`AccountDeletedEvent`（アカウント登録・更新・削除時）
- `PhotoEventListener`・`AccountEventListener`を追加し、`@TransactionalEventListener(phase = AFTER_COMMIT)`でイベントをハンドリング（トランザクションコミット後にログ出力）
- `PhotoServiceImpl`・`AccountServiceImpl`に`ApplicationEventPublisher`を注入し、各登録・更新・削除処理の成功時にそれぞれイベントをpublishするよう変更
- `.claude/rules/event.md`を新設し、`.claude/rules/service.md`のimport許可リストを更新
- `README.md`・`CLAUDE.md`のパッケージ構成説明に`event/`を追記


# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `./backend/gradlew -p backend bootRun --args='--spring.profiles.active=local'` で backend の起動が成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認


# 懸念事項

DBスキーマ・API仕様（request/response）への変更を伴わないため、結合テスト・E2Eテストは未実施です。
写真・アカウントの登録・更新・削除の既存の振る舞い（トランザクション境界含む）に変更はありません。