### PR TITLE
fix: チェック例外時にトランザクションがロールバックされない不具合を修正

### DIFF
--- a/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
@@ -79,7 +79,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @return						登録に成功した場合、true
 	 * @throws	GalleryException	登録に失敗した場合
 	 */
-	@Transactional
+	@Transactional(rollbackFor = GalleryException.class)
 	public Boolean registAccount(AccountModel accountModel) throws GalleryException {
 		Boolean isExist = accountRepository.isExistAccount(accountModel.getAccountId());
 		if(!isExist) {
@@ -96,7 +96,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @return						更新に成功した場合、true
 	 * @throws GalleryException	更新に失敗した場合
 	 */
-	@Transactional
+	@Transactional(rollbackFor = GalleryException.class)
 	public Boolean updateAccount(AccountModel accountModel) throws GalleryException {
 		Boolean isExist = accountRepository.isExistAccount(accountModel.getAccountNo(), accountModel.getAccountId());
 		if(!isExist) {
@@ -143,7 +143,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @param	accountNo			アカウント番号
 	 * @throws	GalleryException	更新に失敗した場合
 	 */
-	@Transactional
+	@Transactional(rollbackFor = GalleryException.class)
 	public void unlockAccount(AccountNo accountNo) throws GalleryException {
 		accountRepository.updateLoginFailureCount(AccountModel.forUnlock(accountNo.value()));
 	}
@@ -154,7 +154,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @param	accountNo			アカウント番号
 	 * @throws	GalleryException	更新に失敗した場合
 	 */
-	@Transactional
+	@Transactional(rollbackFor = GalleryException.class)
 	public void lockAccount(AccountNo accountNo) throws GalleryException {
 		accountRepository.updateLoginFailureCount(AccountModel.forLock(accountNo.value(), loginConfig.getFailCount()));
 	}
@@ -195,7 +195,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @throws	GalleryException	更新に失敗した場合
 	 */
 	@EventListener
-	@Transactional
+	@Transactional(rollbackFor = GalleryException.class)
 	public void handle(AuthenticationSuccessEvent event) throws GalleryException {
 		AccountModel accountModel = accountRepository.getByAccountId(new AccountId(event.getAuthentication().getName()));
 
@@ -209,7 +209,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @throws	GalleryException	更新に失敗した場合
 	 */
 	@EventListener
-	@Transactional
+	@Transactional(rollbackFor = GalleryException.class)
 	public void handle(AuthenticationFailureBadCredentialsEvent event) throws GalleryException {
 		AccountModel accountModel = accountRepository.getByAccountId(new AccountId(event.getAuthentication().getName()));
 

--- a/backend/src/main/java/com/web/gallery/service/impl/PhotoFavoriteServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/PhotoFavoriteServiceImpl.java
@@ -27,7 +27,7 @@ public class PhotoFavoriteServiceImpl implements PhotoFavoriteService {
 	 * @throws	GalleryException	登録に失敗した場合
 	 */
 	@Override
-	@Transactional
+	@Transactional(rollbackFor = GalleryException.class)
 	public void addFavorite(PhotoFavoriteModel photoFavoriteModel) throws GalleryException {
 		photoFavoriteRepository.regist(photoFavoriteModel);
 	}
@@ -39,7 +39,7 @@ public class PhotoFavoriteServiceImpl implements PhotoFavoriteService {
 	 * @throws	GalleryException	解除に失敗した場合
 	 */
 	@Override
-	@Transactional
+	@Transactional(rollbackFor = GalleryException.class)
 	public void deleteFavorite(PhotoFavoriteModel photoFavoriteModel) throws GalleryException {
 		photoFavoriteRepository.delete(PhotoFavoriteDeleteModel.from(photoFavoriteModel));
 	}

--- a/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
@@ -111,7 +111,7 @@ public class PhotoServiceImpl implements PhotoService {
 	 *                              	・更新に失敗した場合
 	 */
 	@Override
-	@Transactional
+	@Transactional(rollbackFor = GalleryException.class)
 	public PhotoNo savePhotos(AccountId accountId, PhotoDetailModelList photoDetailModelList) throws GalleryException {
 		if(Objects.isNull(photoDetailModelList)) return null;
 		if(photoDetailModelList.isEmpty()) return null;
@@ -146,7 +146,7 @@ public class PhotoServiceImpl implements PhotoService {
 	 * @throws	GalleryException		削除に失敗した場合
 	 */
 	@Override
-	@Transactional
+	@Transactional(rollbackFor = GalleryException.class)
 	public void deletePhotos(AccountId accountId, PhotoDeleteModelList photoDeleteModelList) throws GalleryException {
 		String filePath = photoConfig.getOutputPath() + accountId.value() + "/";
 


### PR DESCRIPTION
# 概要

## 背景

`GalleryException` は `Exception` を継承したチェック例外のため、`@Transactional` のデフォルト設定ではロールバック対象とならない。そのため、複数の写真登録・削除をループ処理する `PhotoServiceImpl.savePhotos`/`deletePhotos` などで、途中の1件が `GalleryException` を送出しても、それ以前にループ内で処理済みの分がロールバックされずコミットされてしまう不整合が発生し得た（バックエンド全体のコードレビューで検出）。

## 変更内容

`GalleryException` を `throws` しつつ `@Transactional` を付与している全メソッドに `rollbackFor = GalleryException.class` を明示した。

- `PhotoServiceImpl`: `savePhotos`、`deletePhotos`
- `AccountServiceImpl`: `registAccount`、`updateAccount`、`unlockAccount`、`lockAccount`、`handle(AuthenticationSuccessEvent)`、`handle(AuthenticationFailureBadCredentialsEvent)`
- `PhotoFavoriteServiceImpl`: `addFavorite`、`deleteFavorite`

# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `./backend/gradlew -p backend bootRun --args='--spring.profiles.active=local'` で backend の起動が成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認

# 懸念事項

- アノテーションの修正のみでロジック自体に変更はないため、既存の振る舞いへの影響はない想定。
- backendのアノテーション変更のみのため、frontend起動確認・E2Eテストは未実施。