### PR TITLE
refactor: 写真ドメインイベントの発行漏れ・欠落リスクを解消

### DIFF
--- a/backend/src/main/java/com/web/gallery/event/AccountEventListener.java
+++ b/backend/src/main/java/com/web/gallery/event/AccountEventListener.java
@@ -43,4 +43,24 @@ public class AccountEventListener {
 	public void handle(AccountDeletedEvent event) {
 		log.info("Account deleted (accountNo: {}, accountId: {})", event.accountNo().value(), event.accountId().value());
 	}
+
+	/**
+	 * アカウントの強制ロックイベントをハンドリングする
+	 *
+	 * @param	event	{@link AccountLockedEvent}
+	 */
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(AccountLockedEvent event) {
+		log.info("Account locked (accountNo: {})", event.accountNo().value());
+	}
+
+	/**
+	 * アカウントのロック解除イベントをハンドリングする
+	 *
+	 * @param	event	{@link AccountUnlockedEvent}
+	 */
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(AccountUnlockedEvent event) {
+		log.info("Account unlocked (accountNo: {})", event.accountNo().value());
+	}
 }

--- a/backend/src/main/java/com/web/gallery/event/AccountLockedEvent.java
+++ b/backend/src/main/java/com/web/gallery/event/AccountLockedEvent.java
@@ -1,0 +1,11 @@
+package com.web.gallery.event;
+
+import com.web.gallery.domain.account.AccountNo;
+
+/**
+ * アカウントの強制ロック時に発行されるドメインイベント
+ *
+ * @param	accountNo	アカウント番号
+ */
+public record AccountLockedEvent(AccountNo accountNo) {
+}

--- a/backend/src/main/java/com/web/gallery/event/AccountUnlockedEvent.java
+++ b/backend/src/main/java/com/web/gallery/event/AccountUnlockedEvent.java
@@ -1,0 +1,11 @@
+package com.web.gallery.event;
+
+import com.web.gallery.domain.account.AccountNo;
+
+/**
+ * アカウントのロック解除時に発行されるドメインイベント
+ *
+ * @param	accountNo	アカウント番号
+ */
+public record AccountUnlockedEvent(AccountNo accountNo) {
+}

--- a/backend/src/main/java/com/web/gallery/mapper/PhotoMstMapper.java
+++ b/backend/src/main/java/com/web/gallery/mapper/PhotoMstMapper.java
@@ -1,5 +1,7 @@
 package com.web.gallery.mapper;
 
+import java.util.List;
+
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -60,4 +62,12 @@ public interface PhotoMstMapper {
 	 * @return				削除件数
 	 */
 	public Integer delete(PhotoMstCondition condition);
+
+	/**
+	 * アカウント番号に紐づく写真番号の一覧を取得する
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @return				写真番号のリスト
+	 */
+	public List<Long> getPhotoNosByAccountNo(Long accountNo);
 }

--- a/backend/src/main/java/com/web/gallery/model/PhotoNoList.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoNoList.java
@@ -1,0 +1,80 @@
+package com.web.gallery.model;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import com.web.gallery.domain.photo.PhotoNo;
+
+/**
+ * PhotoNoのコレクションを表すクラス
+ *
+ * @param	photoNoList	{@link PhotoNo}のリスト
+ */
+public record PhotoNoList(List<PhotoNo> photoNoList) implements Iterable<PhotoNo> {
+
+	public PhotoNoList {
+		Objects.requireNonNull(photoNoList);
+	}
+
+	/**
+	 * PhotoNoのリストからPhotoNoListを生成する
+	 *
+	 * @param	photoNoList	{@link PhotoNo}のリスト
+	 * @return				{@link PhotoNoList}
+	 */
+	public static PhotoNoList of(List<PhotoNo> photoNoList) {
+		return new PhotoNoList(photoNoList);
+	}
+
+	/**
+	 * 空のPhotoNoListを生成する
+	 *
+	 * @return	{@link PhotoNoList}
+	 */
+	public static PhotoNoList empty() {
+		return PhotoNoList.of(List.of());
+	}
+
+	/**
+	 * 要素数を取得する
+	 *
+	 * @return	要素数
+	 */
+	public Integer size() {
+		return photoNoList.size();
+	}
+
+	/**
+	 * 要素が空かどうかを取得する
+	 *
+	 * @return	要素が空の場合はtrue
+	 */
+	public Boolean isEmpty() {
+		return photoNoList.isEmpty();
+	}
+
+	/**
+	 * Streamに変換する
+	 *
+	 * @return	{@link PhotoNo}のStream
+	 */
+	public Stream<PhotoNo> stream() {
+		return photoNoList.stream();
+	}
+
+	/**
+	 * Listに変換する
+	 *
+	 * @return	{@link PhotoNo}のList
+	 */
+	public List<PhotoNo> toList() {
+		return photoNoList;
+	}
+
+	@Override
+	public Iterator<PhotoNo> iterator() {
+		return photoNoList.iterator();
+	}
+}

--- a/backend/src/main/java/com/web/gallery/repository/PhotoMstRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/PhotoMstRepository.java
@@ -6,6 +6,7 @@ import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.PhotoDeleteModel;
 import com.web.gallery.model.PhotoDetailModel;
+import com.web.gallery.model.PhotoNoList;
 
 /**
  * 写真マスタデータを永続化するRepositoryクラス
@@ -67,4 +68,12 @@ public interface PhotoMstRepository {
 	 * @param	accountNo	アカウント番号
 	 */
 	void deleteByAccountNo(AccountNo accountNo);
+
+	/**
+	 * アカウント番号に紐づく写真番号の一覧を取得する
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @return				{@link PhotoNoList}
+	 */
+	PhotoNoList getPhotoNosByAccountNo(AccountNo accountNo);
 }

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
@@ -14,6 +14,7 @@ import com.web.gallery.exception.GalleryException;
 import com.web.gallery.mapper.PhotoMstMapper;
 import com.web.gallery.model.PhotoDeleteModel;
 import com.web.gallery.model.PhotoDetailModel;
+import com.web.gallery.model.PhotoNoList;
 import com.web.gallery.repository.PhotoMstRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -126,5 +127,18 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	@Override
 	public void deleteByAccountNo(AccountNo accountNo) {
 		photoMstMapper.delete(PhotoMstCondition.byAccountNo(accountNo));
+	}
+
+	/**
+	 * アカウント番号に紐づく写真番号の一覧を取得する
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @return				{@link PhotoNoList}
+	 */
+	@Override
+	public PhotoNoList getPhotoNosByAccountNo(AccountNo accountNo) {
+		return PhotoNoList.of(photoMstMapper.getPhotoNosByAccountNo(accountNo.value()).stream()
+				.map(PhotoNo::new)
+				.toList());
 	}
 }

--- a/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
@@ -20,12 +20,17 @@ import com.web.gallery.constant.MessageConst;
 import com.web.gallery.domain.account.AccountId;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.domain.photo.ImageFilePath;
+import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.event.AccountDeletedEvent;
+import com.web.gallery.event.AccountLockedEvent;
 import com.web.gallery.event.AccountRegisteredEvent;
+import com.web.gallery.event.AccountUnlockedEvent;
 import com.web.gallery.event.AccountUpdatedEvent;
+import com.web.gallery.event.PhotoDeletedEvent;
 import com.web.gallery.exception.GalleryException;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.model.AccountModelList;
+import com.web.gallery.model.PhotoNoList;
 import com.web.gallery.repository.AccountRepository;
 import com.web.gallery.repository.FileRepository;
 import com.web.gallery.repository.PhotoFavoriteRepository;
@@ -146,6 +151,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	@Transactional(rollbackFor = GalleryException.class)
 	public void unlockAccount(AccountNo accountNo) throws GalleryException {
 		accountRepository.updateLoginFailureCount(AccountModel.forUnlock(accountNo.value()));
+		applicationEventPublisher.publishEvent(new AccountUnlockedEvent(accountNo));
 	}
 
 	/**
@@ -157,6 +163,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	@Transactional(rollbackFor = GalleryException.class)
 	public void lockAccount(AccountNo accountNo) throws GalleryException {
 		accountRepository.updateLoginFailureCount(AccountModel.forLock(accountNo.value(), loginConfig.getFailCount()));
+		applicationEventPublisher.publishEvent(new AccountLockedEvent(accountNo));
 	}
 
 	/**
@@ -176,6 +183,9 @@ public class AccountServiceImpl implements UserDetailsService {
 		// 写真タグを削除
 		photoTagMstRepository.deleteByAccountNo(accountNo);
 
+		// 削除対象の写真番号を退避（物理削除後にイベント発行するため）
+		PhotoNoList deletedPhotoNoList = photoMstRepository.getPhotoNosByAccountNo(accountNo);
+
 		// 写真マスタを物理削除
 		photoMstRepository.deleteByAccountNo(accountNo);
 
@@ -185,6 +195,9 @@ public class AccountServiceImpl implements UserDetailsService {
 		// 写真ファイルのディレクトリを削除
 		fileRepository.delete(new ImageFilePath(photoConfig.getOutputPath() + accountId.value() + "/"));
 
+		for(PhotoNo photoNo : deletedPhotoNoList) {
+			applicationEventPublisher.publishEvent(new PhotoDeletedEvent(accountNo, photoNo));
+		}
 		applicationEventPublisher.publishEvent(new AccountDeletedEvent(accountNo, accountId));
 	}
 

--- a/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/PhotoServiceImpl.java
@@ -122,20 +122,44 @@ public class PhotoServiceImpl implements PhotoService {
 
 		for(PhotoDetailModel photoDetailModel : photoDetailModelList){
 			if(Objects.isNull(photoDetailModel.getPhotoNo())) {
-				String filename = photoDetailModel.getImageFile().value().getOriginalFilename();
-				Photo photo = Photo.forRegist(photoDetailModel, new PhotoNo(photoNo), new ImageFilePath(filePath + filename));
-				photoAggregateRepository.regist(photo);
-				fileRepository.save(FileModel.of(photo.getImageFilePath(), photo.getImageFile()));
-				applicationEventPublisher.publishEvent(new PhotoRegisteredEvent(photo.getAccountNo(), photo.getPhotoNo()));
+				registPhoto(photoDetailModel, new PhotoNo(photoNo), filePath);
 				++photoNo;
 			} else {
 				savedPhotoNo = photoDetailModel.getPhotoNo();
-				Photo photo = Photo.forUpdate(photoDetailModel);
-				photoAggregateRepository.update(photo);
-				applicationEventPublisher.publishEvent(new PhotoUpdatedEvent(photo.getAccountNo(), photo.getPhotoNo()));
+				updatePhoto(photoDetailModel);
 			}
 		}
 		return savedPhotoNo;
+	}
+
+	/**
+	 * 写真を1件登録し、登録イベントを発行する
+	 *
+	 * @param	photoDetailModel	{@link PhotoDetailModel}
+	 * @param	newPhotoNo			新規採番した写真番号
+	 * @param	filePath			写真の保存先ディレクトリパス
+	 * @throws	GalleryException	以下のいずれかに該当する場合
+	 *                              	・同じファイル名のファイルが既に保存済みの場合
+	 *                              	・登録に失敗した場合
+	 */
+	private void registPhoto(PhotoDetailModel photoDetailModel, PhotoNo newPhotoNo, String filePath) throws GalleryException {
+		String filename = photoDetailModel.getImageFile().value().getOriginalFilename();
+		Photo photo = Photo.forRegist(photoDetailModel, newPhotoNo, new ImageFilePath(filePath + filename));
+		photoAggregateRepository.regist(photo);
+		fileRepository.save(FileModel.of(photo.getImageFilePath(), photo.getImageFile()));
+		applicationEventPublisher.publishEvent(new PhotoRegisteredEvent(photo.getAccountNo(), photo.getPhotoNo()));
+	}
+
+	/**
+	 * 写真を1件更新し、更新イベントを発行する
+	 *
+	 * @param	photoDetailModel	{@link PhotoDetailModel}
+	 * @throws	GalleryException	更新に失敗した場合
+	 */
+	private void updatePhoto(PhotoDetailModel photoDetailModel) throws GalleryException {
+		Photo photo = Photo.forUpdate(photoDetailModel);
+		photoAggregateRepository.update(photo);
+		applicationEventPublisher.publishEvent(new PhotoUpdatedEvent(photo.getAccountNo(), photo.getPhotoNo()));
 	}
 
 	/**

--- a/backend/src/main/resources/com/web/gallery/mapper/PhotoMstMapper.xml
+++ b/backend/src/main/resources/com/web/gallery/mapper/PhotoMstMapper.xml
@@ -156,4 +156,13 @@
 			<if test="photoNo != null"> AND photo_no = #{photoNo, typeHandler=com.web.gallery.type_handler.PhotoNoTypeHandler}</if>
 		</where>
 	</delete>
+
+	<select id="getPhotoNosByAccountNo" parameterType="Long" resultType="Long">
+		SELECT
+			photo_no AS photoNo
+		FROM
+			photo.photo_mst
+		WHERE
+			account_no = #{accountNo}
+	</select>
 </mapper>

--- a/backend/src/test/java/com/web/gallery/event/AccountEventListenerTest.java
+++ b/backend/src/test/java/com/web/gallery/event/AccountEventListenerTest.java
@@ -38,4 +38,18 @@ public class AccountEventListenerTest {
 		AccountDeletedEvent event = new AccountDeletedEvent(new AccountNo(1L), new AccountId("aaaaaaaa"));
 		assertDoesNotThrow(() -> accountEventListener.handle(event));
 	}
+
+	@Test
+	@DisplayName("正常系：AccountLockedEventを受け取っても例外が発生しないこと")
+	void handle_accountLockedEvent_success() {
+		AccountLockedEvent event = new AccountLockedEvent(new AccountNo(1L));
+		assertDoesNotThrow(() -> accountEventListener.handle(event));
+	}
+
+	@Test
+	@DisplayName("正常系：AccountUnlockedEventを受け取っても例外が発生しないこと")
+	void handle_accountUnlockedEvent_success() {
+		AccountUnlockedEvent event = new AccountUnlockedEvent(new AccountNo(1L));
+		assertDoesNotThrow(() -> accountEventListener.handle(event));
+	}
 }

--- a/backend/src/test/java/com/web/gallery/mapper/PhotoMstMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/PhotoMstMapperTest.java
@@ -979,4 +979,27 @@ public class PhotoMstMapperTest {
 			assertFalse(photoMstMapper.isExistPhoto(photoMst));
 		}
 	}
+
+	@Nested
+	@Order(7)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	@Sql("/sql/common/cleanup.sql")
+	@Sql("/sql/mapper/PhotoMstMapperTest.sql")
+	class getPhotoNosByAccountNo {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウント番号に該当する写真がある場合")
+		void getPhotoNosByAccountNo_found() {
+			List<Long> actual = photoMstMapper.getPhotoNosByAccountNo(1L);
+			assertEquals(List.of(1L, 2L, 3L), actual.stream().sorted().toList());
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("正常系：アカウント番号に該当する写真がない場合")
+		void getPhotoNosByAccountNo_not_found() {
+			List<Long> actual = photoMstMapper.getPhotoNosByAccountNo(100L);
+			assertTrue(actual.isEmpty());
+		}
+	}
 }

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoMstRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoMstRepositoryImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
@@ -51,6 +52,7 @@ import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.mapper.PhotoMstMapper;
 import com.web.gallery.model.PhotoDeleteModel;
 import com.web.gallery.model.PhotoDetailModel;
+import com.web.gallery.model.PhotoNoList;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
@@ -592,6 +594,33 @@ public class PhotoMstRepositoryImplTest {
 			PhotoMstCondition photoMst = photoMstCaptor.getValue();
 			assertEquals(new AccountNo(1L), photoMst.getAccountNo());
 			assertNull(photoMst.getPhotoNo());
+		}
+	}
+
+	@Nested
+	@Order(8)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class getPhotoNosByAccountNo {
+		@Test
+		@Order(1)
+		@DisplayName("正常系：アカウント番号に紐づく写真番号の一覧を取得する")
+		void getPhotoNosByAccountNo_found() {
+			doReturn(List.of(1L, 2L, 3L)).when(photoMstMapper).getPhotoNosByAccountNo(1L);
+
+			PhotoNoList actual = photoMstRepositoryImpl.getPhotoNosByAccountNo(new AccountNo(1L));
+
+			assertEquals(List.of(new PhotoNo(1L), new PhotoNo(2L), new PhotoNo(3L)), actual.toList());
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("正常系：アカウント番号に紐づく写真がない場合")
+		void getPhotoNosByAccountNo_not_found() {
+			doReturn(List.of()).when(photoMstMapper).getPhotoNosByAccountNo(1L);
+
+			PhotoNoList actual = photoMstRepositoryImpl.getPhotoNosByAccountNo(new AccountNo(1L));
+
+			assertTrue(actual.isEmpty());
 		}
 	}
 }

--- a/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
@@ -48,14 +48,19 @@ import com.web.gallery.domain.account.Password;
 import com.web.gallery.domain.account.ResidentPrefectureKbnCode;
 import com.web.gallery.domain.common.IsDeleted;
 import com.web.gallery.domain.photo.ImageFilePath;
+import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.event.AccountDeletedEvent;
+import com.web.gallery.event.AccountLockedEvent;
 import com.web.gallery.event.AccountRegisteredEvent;
+import com.web.gallery.event.AccountUnlockedEvent;
 import com.web.gallery.event.AccountUpdatedEvent;
+import com.web.gallery.event.PhotoDeletedEvent;
 import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.model.AccountModelList;
+import com.web.gallery.model.PhotoNoList;
 import com.web.gallery.repository.FileRepository;
 import com.web.gallery.repository.PhotoFavoriteRepository;
 import com.web.gallery.repository.PhotoMstRepository;
@@ -351,6 +356,10 @@ public class AccountServiceImplTest {
 			assertEquals(new AccountNo(1L), accountModel.getAccountNo());
 			assertEquals(new LoginFailureCount(0), accountModel.getLoginFailureCount());
 			assertNull(accountModel.getLastLoginDatetime());
+
+			ArgumentCaptor<AccountUnlockedEvent> eventCaptor = ArgumentCaptor.forClass(AccountUnlockedEvent.class);
+			verify(applicationEventPublisher, times(1)).publishEvent(eventCaptor.capture());
+			assertEquals(new AccountNo(1L), eventCaptor.getValue().accountNo());
 		}
 
 		@Test
@@ -380,6 +389,10 @@ public class AccountServiceImplTest {
 			AccountModel accountModel = captor.getValue();
 			assertEquals(new AccountNo(1L), accountModel.getAccountNo());
 			assertEquals(new LoginFailureCount(10), accountModel.getLoginFailureCount());
+
+			ArgumentCaptor<AccountLockedEvent> eventCaptor = ArgumentCaptor.forClass(AccountLockedEvent.class);
+			verify(applicationEventPublisher, times(1)).publishEvent(eventCaptor.capture());
+			assertEquals(new AccountNo(1L), eventCaptor.getValue().accountNo());
 		}
 
 		@Test
@@ -406,6 +419,8 @@ public class AccountServiceImplTest {
 			doNothing().when(photoFavoriteRepository).deleteByAccountNo(any(AccountNo.class));
 			doNothing().when(photoFavoriteRepository).deleteByFavoritePhotoAccountNo(any(AccountNo.class));
 			doNothing().when(photoTagMstRepository).deleteByAccountNo(any(AccountNo.class));
+			doReturn(PhotoNoList.of(List.of(new PhotoNo(1L), new PhotoNo(2L))))
+					.when(photoMstRepository).getPhotoNosByAccountNo(any(AccountNo.class));
 			doNothing().when(photoMstRepository).deleteByAccountNo(any(AccountNo.class));
 			doNothing().when(accountRepositoryImpl).delete(new AccountNo(accountNo));
 			doReturn("/output/").when(photoConfig).getOutputPath();
@@ -422,14 +437,30 @@ public class AccountServiceImplTest {
 			assertEquals(new AccountNo(accountNo), favoritePhotoCaptor.getValue());
 
 			verify(photoTagMstRepository, times(1)).deleteByAccountNo(new AccountNo(accountNo));
+			verify(photoMstRepository, times(1)).getPhotoNosByAccountNo(new AccountNo(accountNo));
 			verify(photoMstRepository, times(1)).deleteByAccountNo(new AccountNo(accountNo));
 			verify(accountRepositoryImpl, times(1)).delete(new AccountNo(accountNo));
 			verify(fileRepository, times(1)).delete(new ImageFilePath("/output/" + accountId + "/"));
 
-			ArgumentCaptor<AccountDeletedEvent> accountDeletedEventCaptor = ArgumentCaptor.forClass(AccountDeletedEvent.class);
-			verify(applicationEventPublisher, times(1)).publishEvent(accountDeletedEventCaptor.capture());
-			assertEquals(new AccountNo(accountNo), accountDeletedEventCaptor.getValue().accountNo());
-			assertEquals(new AccountId(accountId), accountDeletedEventCaptor.getValue().accountId());
+			ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+			verify(applicationEventPublisher, times(3)).publishEvent(eventCaptor.capture());
+			List<Object> publishedEvents = eventCaptor.getAllValues();
+
+			List<PhotoDeletedEvent> photoDeletedEvents = publishedEvents.stream()
+					.filter(PhotoDeletedEvent.class::isInstance)
+					.map(PhotoDeletedEvent.class::cast)
+					.toList();
+			assertEquals(2, photoDeletedEvents.size());
+			assertEquals(new PhotoNo(1L), photoDeletedEvents.get(0).photoNo());
+			assertEquals(new PhotoNo(2L), photoDeletedEvents.get(1).photoNo());
+
+			List<AccountDeletedEvent> accountDeletedEvents = publishedEvents.stream()
+					.filter(AccountDeletedEvent.class::isInstance)
+					.map(AccountDeletedEvent.class::cast)
+					.toList();
+			assertEquals(1, accountDeletedEvents.size());
+			assertEquals(new AccountNo(accountNo), accountDeletedEvents.get(0).accountNo());
+			assertEquals(new AccountId(accountId), accountDeletedEvents.get(0).accountId());
 		}
 	}
 


### PR DESCRIPTION
# 概要

## 背景

backend全体のコードレビューにて、以下3件のドメインイベント関連の課題が検出された。

1. アカウント削除時（`AccountServiceImpl.deleteAccount`）の写真一括削除が`Photo`集約を経由せず`photoMstRepository.deleteByAccountNo()`を直接呼び出しているため、削除された写真それぞれに対する`PhotoDeletedEvent`が一切発行されない
2. `registAccount`/`updateAccount`/`deleteAccount`にはドメインイベントが実装されている一方、管理者操作である`lockAccount`/`unlockAccount`には対応するイベントがなく非対称だった
3. `PhotoServiceImpl.savePhotos`内で`publishEvent`呼び出しが集約操作の直後に手動でインライン記述されており、将来的にこの処理がプライベートメソッドへ抽出された際にイベント発行だけが移し忘れられるリスクがあった（過去に類似のリファクタが発生した実績あり）

## 変更内容

- `PhotoNoList`モデルクラスを新規作成し、`PhotoMstMapper`/XML/`PhotoMstRepository`に`getPhotoNosByAccountNo`を追加。`AccountServiceImpl.deleteAccount`で物理削除前に写真番号一覧を取得し、削除後に写真ごとの`PhotoDeletedEvent`を発行するよう修正
- `AccountLockedEvent`/`AccountUnlockedEvent`を新規作成し、`lockAccount`/`unlockAccount`から発行。`AccountEventListener`にハンドラを追加
- `PhotoServiceImpl.savePhotos`の登録・更新分岐を`registPhoto`/`updatePhoto`プライベートメソッドに切り出し、集約操作とイベント発行を1セットにまとめてリファクタ耐性を向上

# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `scripts/check-architecture.sh` でレイヤードアーキテクチャ違反がないことを確認
- [x] `./backend/gradlew -p backend bootRun --args='--spring.profiles.active=local'` で backend の起動が成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認

# 懸念事項

- backendのみの変更（イベント発行・Repository/Mapper追加）で、既存のAPIレスポンス仕様や画面挙動への影響はない想定。frontend起動確認・E2Eテストは未実施。
- `PhotoEventListener`/`AccountEventListener`は現状ログ出力のみのため、動作上のリスクは低い。