### PR TITLE
fix: アカウント削除時に論理削除済みの写真でPhotoDeletedEventが重複発行される不具合を修正

### DIFF
--- a/backend/src/main/java/com/web/gallery/mapper/PhotoMstMapper.java
+++ b/backend/src/main/java/com/web/gallery/mapper/PhotoMstMapper.java
@@ -64,7 +64,7 @@ public interface PhotoMstMapper {
 	public Integer delete(PhotoMstCondition condition);
 
 	/**
-	 * アカウント番号に紐づく写真番号の一覧を取得する
+	 * アカウント番号に紐づく未削除の写真番号の一覧を取得する
 	 *
 	 * @param	accountNo	アカウント番号
 	 * @return				写真番号のリスト

--- a/backend/src/main/java/com/web/gallery/repository/PhotoMstRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/PhotoMstRepository.java
@@ -70,7 +70,7 @@ public interface PhotoMstRepository {
 	void deleteByAccountNo(AccountNo accountNo);
 
 	/**
-	 * アカウント番号に紐づく写真番号の一覧を取得する
+	 * アカウント番号に紐づく未削除の写真番号の一覧を取得する
 	 *
 	 * @param	accountNo	アカウント番号
 	 * @return				{@link PhotoNoList}

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
@@ -130,7 +130,7 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	}
 
 	/**
-	 * アカウント番号に紐づく写真番号の一覧を取得する
+	 * アカウント番号に紐づく未削除の写真番号の一覧を取得する
 	 *
 	 * @param	accountNo	アカウント番号
 	 * @return				{@link PhotoNoList}

--- a/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
@@ -184,6 +184,7 @@ public class AccountServiceImpl implements UserDetailsService {
 		photoTagMstRepository.deleteByAccountNo(accountNo);
 
 		// 削除対象の写真番号を退避（物理削除後にイベント発行するため）
+		// 既に論理削除済みの写真でイベントが重複発行されないよう、未削除の写真のみを対象とする
 		PhotoNoList deletedPhotoNoList = photoMstRepository.getPhotoNosByAccountNo(accountNo);
 
 		// 写真マスタを物理削除

--- a/backend/src/main/resources/com/web/gallery/mapper/PhotoMstMapper.xml
+++ b/backend/src/main/resources/com/web/gallery/mapper/PhotoMstMapper.xml
@@ -164,5 +164,6 @@
 			photo.photo_mst
 		WHERE
 			account_no = #{accountNo}
+			AND is_deleted = false
 	</select>
 </mapper>

--- a/backend/src/test/java/com/web/gallery/mapper/PhotoMstMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/PhotoMstMapperTest.java
@@ -988,14 +988,23 @@ public class PhotoMstMapperTest {
 	class getPhotoNosByAccountNo {
 		@Test
 		@Order(1)
-		@DisplayName("正常系：アカウント番号に該当する写真がある場合")
+		@DisplayName("正常系：アカウント番号に該当する未削除の写真がある場合")
 		void getPhotoNosByAccountNo_found() {
 			List<Long> actual = photoMstMapper.getPhotoNosByAccountNo(1L);
-			assertEquals(List.of(1L, 2L, 3L), actual.stream().sorted().toList());
+			assertEquals(List.of(1L), actual.stream().sorted().toList());
 		}
 
 		@Test
 		@Order(2)
+		@DisplayName("正常系：論理削除済みの写真は取得対象から除外される")
+		void getPhotoNosByAccountNo_excludes_deleted() {
+			List<Long> actual = photoMstMapper.getPhotoNosByAccountNo(1L);
+			assertFalse(actual.contains(2L));
+			assertFalse(actual.contains(3L));
+		}
+
+		@Test
+		@Order(3)
 		@DisplayName("正常系：アカウント番号に該当する写真がない場合")
 		void getPhotoNosByAccountNo_not_found() {
 			List<Long> actual = photoMstMapper.getPhotoNosByAccountNo(100L);


### PR DESCRIPTION
# 概要

## 背景

`getPhotoNosByAccountNo`（`PhotoMstMapper.xml`）が`is_deleted`で絞り込んでおらず、アカウントに紐づく全ての`photo_no`（論理削除済みのものも含む）を返していた。

これにより、以下のシナリオでイベントが重複発行される不具合があった。

1. ユーザーが写真を個別に削除する（論理削除。この時点で`PhotoDeletedEvent`が発行済み）
2. その後、ユーザーがアカウント自体を削除する
3. `AccountServiceImpl.deleteAccount`が`getPhotoNosByAccountNo`で取得した全写真番号（既に論理削除済みのものを含む）に対してループし、`PhotoDeletedEvent`を再発行してしまう

PR #120「写真ドメインイベントの発行漏れ・欠落リスクを解消」が本来解消すべきバグと同種の問題であったため、backend全体のコードレビューで検出し修正した。

## 変更内容

- `PhotoMstMapper.xml`の`getPhotoNosByAccountNo`のSQLに`AND is_deleted = false`を追加し、既に論理削除済みの写真を取得対象から除外
- `PhotoMstMapperTest`に、論理削除済みの写真が取得結果から除外されることを検証するテストケースを追加し、既存テストの期待値を修正


# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `./backend/gradlew -p backend bootRun --args='--spring.profiles.active=local'` で backend の起動が成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認


# 懸念事項

- backend側のみの修正であり、frontendへの影響はない
- `getPhotoNosByAccountNo`の呼び出し元は`AccountServiceImpl.deleteAccount`のみであることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)