### PR TITLE
fix: リフレッシュトークンによるアクセストークン再発行がアカウントロック状態を無視する不具合を修正

### DIFF
--- a/backend/src/main/java/com/web/gallery/controller/AuthRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/AuthRestController.java
@@ -96,6 +96,7 @@ public class AuthRestController {
 	@Operation(summary = "トークンリフレッシュ", description = "リフレッシュトークン（cookie）を使用してアクセストークンを再発行する")
 	@ApiResponse(responseCode = "200", description = "リフレッシュ成功")
 	@ApiResponse(responseCode = "401", description = "リフレッシュトークンが無効", content = @Content)
+	@ApiResponse(responseCode = "423", description = "アカウントロック", content = @Content)
 	@PostMapping(ApiRoutes.API_AUTH_REFRESH)
 	public ResponseEntity<AuthLoginResponse> refresh(
 			@CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken) {

--- a/backend/src/main/java/com/web/gallery/service/impl/AuthServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AuthServiceImpl.java
@@ -16,6 +16,7 @@ import com.web.gallery.domain.common.TokenHash;
 
 import org.springframework.context.annotation.Lazy;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.LockedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -104,6 +105,7 @@ public class AuthServiceImpl implements AuthService {
 	 * @param	refreshToken	リフレッシュトークン
 	 * @return					{@link AuthTokenModel}
 	 * @throws	IllegalArgumentException	トークンが無効な場合
+	 * @throws	LockedException				アカウントがロックされている場合
 	 */
 	@Override
 	@Transactional(readOnly = true)
@@ -123,6 +125,13 @@ public class AuthServiceImpl implements AuthService {
 		AccountModel accountModel = accountRepository.getByAccountNo(storedToken.getAccountNo());
 		UserDetails userDetails = accountServiceImpl.loadUserByUsername(accountModel.getAccountId().value());
 		AccountPrincipal principal = (AccountPrincipal) userDetails;
+
+		if (!principal.isAccountNonLocked()) {
+			throw new LockedException("アカウントがロックされています");
+		}
+		if (!principal.isEnabled()) {
+			throw new IllegalArgumentException("無効なリフレッシュトークンです");
+		}
 
 		String accessToken = jwtTokenProvider.generateAccessToken(principal);
 

--- a/backend/src/test/java/com/web/gallery/service/impl/AuthServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AuthServiceImplTest.java
@@ -159,6 +159,8 @@ class AuthServiceImplTest {
 			when(accountRepository.getByAccountNo(new AccountNo(1L))).thenReturn(account);
 
 			AccountPrincipal principal = mock(AccountPrincipal.class);
+			when(principal.isAccountNonLocked()).thenReturn(true);
+			when(principal.isEnabled()).thenReturn(true);
 			when(accountServiceImpl.loadUserByUsername("testuser1")).thenReturn(principal);
 			when(jwtTokenProvider.generateAccessToken(principal)).thenReturn("new-access-token");
 			when(jwtConfig.getAccessTokenExpirationMinutes()).thenReturn(15);
@@ -168,6 +170,63 @@ class AuthServiceImplTest {
 			assertNotNull(result);
 			assertEquals("new-access-token", result.getAccessToken().value());
 			assertEquals(900L, result.getExpiresIn().value());
+		}
+
+		@Test
+		@DisplayName("異常系: アカウントがロックされている場合は例外がスローされること")
+		void refresh_accountLocked() {
+			String refreshToken = "valid-refresh-token";
+			RefreshTokenModel storedToken = RefreshTokenModel.builder()
+					.accountNo(new AccountNo(1L))
+					.tokenHash(new TokenHash("hashed-token"))
+					.expiresAt(new ExpiresAt(OffsetDateTime.now().plusDays(7)))
+					.isRevoked(new IsRevoked(false))
+					.build();
+
+			when(refreshTokenRepository.findByTokenHash(any(TokenHash.class))).thenReturn(storedToken);
+
+			AccountModel account = AccountModel.builder()
+					.accountNo(new AccountNo(1L))
+					.accountId(new AccountId("testuser1"))
+					.build();
+			when(accountRepository.getByAccountNo(new AccountNo(1L))).thenReturn(account);
+
+			AccountPrincipal principal = mock(AccountPrincipal.class);
+			when(principal.isAccountNonLocked()).thenReturn(false);
+			when(accountServiceImpl.loadUserByUsername("testuser1")).thenReturn(principal);
+
+			assertThrows(LockedException.class, () -> {
+				authServiceImpl.refresh(new RefreshTokenValue(refreshToken));
+			});
+		}
+
+		@Test
+		@DisplayName("異常系: アカウントが無効化（削除済み）されている場合は例外がスローされること")
+		void refresh_accountDisabled() {
+			String refreshToken = "valid-refresh-token";
+			RefreshTokenModel storedToken = RefreshTokenModel.builder()
+					.accountNo(new AccountNo(1L))
+					.tokenHash(new TokenHash("hashed-token"))
+					.expiresAt(new ExpiresAt(OffsetDateTime.now().plusDays(7)))
+					.isRevoked(new IsRevoked(false))
+					.build();
+
+			when(refreshTokenRepository.findByTokenHash(any(TokenHash.class))).thenReturn(storedToken);
+
+			AccountModel account = AccountModel.builder()
+					.accountNo(new AccountNo(1L))
+					.accountId(new AccountId("testuser1"))
+					.build();
+			when(accountRepository.getByAccountNo(new AccountNo(1L))).thenReturn(account);
+
+			AccountPrincipal principal = mock(AccountPrincipal.class);
+			when(principal.isAccountNonLocked()).thenReturn(true);
+			when(principal.isEnabled()).thenReturn(false);
+			when(accountServiceImpl.loadUserByUsername("testuser1")).thenReturn(principal);
+
+			assertThrows(IllegalArgumentException.class, () -> {
+				authServiceImpl.refresh(new RefreshTokenValue(refreshToken));
+			});
 		}
 
 		@Test

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/AuthServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/AuthServiceImplIntegrationTest.java
@@ -244,6 +244,24 @@ public class AuthServiceImplIntegrationTest {
 				() -> authServiceImpl.refresh(new RefreshTokenValue(refreshToken)));
 			assertEquals("リフレッシュトークンの有効期限が切れています", exception.getMessage());
 		}
+
+		@Test
+		@Order(5)
+		@DisplayName("異常系：発行後にアカウントがロックされた場合、LockedExceptionをthrowする")
+		void refresh_account_locked_after_token_issued() {
+			// ログインしてリフレッシュトークンを取得
+			AuthTokenModel loginResult = authServiceImpl.login(new AccountId("testuser01"), new Password(TEST_PASSWORD));
+			String refreshToken = loginResult.getRefreshToken().value();
+
+			// 管理者によるアカウントロックを模擬（ログイン失敗回数を上限に更新）
+			jdbcTemplate.update(
+				"UPDATE common.account SET login_failure_count = 3 WHERE account_no = 1"
+			);
+
+			// ロック後のリフレッシュはLockedExceptionをthrowする
+			assertThrows(LockedException.class,
+				() -> authServiceImpl.refresh(new RefreshTokenValue(refreshToken)));
+		}
 	}
 
 	@Nested


### PR DESCRIPTION
# 概要

## 背景

コードレビューにより、`AuthServiceImpl.refresh()` が `AuthenticationManager` を経由せず `accountRepository.getByAccountNo(...)` → `accountServiceImpl.loadUserByUsername(...)` で直接 `UserDetails` を組み立てているため、`isAccountNonLocked()` / `isEnabled()` の判定が一切行われていないことが判明した。

`login()` は `authenticationManager.authenticate(...)` 経由でロック判定が効くのに対し、`refresh()` のみこれを迂回していた。結果として、管理者が `lockAccount()` でアカウントを強制ロックしても、既にリフレッシュトークンを保持しているユーザーはトークンの有効期限（7日間）中、ロックを回避してアクセストークンを再取得し続けられる状態だった。

## 変更内容

- `AuthServiceImpl.refresh()` にて、`AccountPrincipal` 生成後に `isAccountNonLocked()` / `isEnabled()` を検証し、該当しない場合はそれぞれ `LockedException` / `IllegalArgumentException` をスローするよう修正
  - `LockedException` は `AuthRestController` に既存の `@ExceptionHandler(LockedException.class)`（423 Locked）でそのまま処理される
- `AuthRestController` の `refresh` エンドポイントのOpenAPI仕様に423（アカウントロック）レスポンスを追記
- 上記修正に対するユニットテスト・統合テストを追加
  - 統合テストでは、トークン発行後に管理者がアカウントをロックした状態でリフレッシュを試み、`LockedException` がスローされることを検証

# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `./backend/gradlew -p backend bootRun --args='--spring.profiles.active=local'` で backend の起動が成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認

# 懸念事項

- backendのみの修正であり、frontend側の変更は不要なため、frontendの起動確認・E2Eテストは未実施
- 本PRは既存コードレビュー結果の指摘のうち「アカウントロック状態の未検証」のみに対応するもので、レビューで併せて指摘された他の項目（`FileRepositoryImpl`未実装、`AccountService`インターフェース欠如など）は別PRで対応予定