### PR TITLE
fix: PhotoNoListにModel規約で必須のget(int)とfrom()を追加

### DIFF
--- a/backend/src/main/java/com/web/gallery/model/PhotoNoList.java
+++ b/backend/src/main/java/com/web/gallery/model/PhotoNoList.java
@@ -29,6 +29,18 @@ public record PhotoNoList(List<PhotoNo> photoNoList) implements Iterable<PhotoNo
 	}
 
 	/**
+	 * 写真番号のLongリストからPhotoNoListを生成する
+	 *
+	 * @param	photoNoValueList	写真番号のLongリスト
+	 * @return						{@link PhotoNoList}
+	 */
+	public static PhotoNoList from(List<Long> photoNoValueList) {
+		return PhotoNoList.of(photoNoValueList.stream()
+				.map(PhotoNo::new)
+				.toList());
+	}
+
+	/**
 	 * 空のPhotoNoListを生成する
 	 *
 	 * @return	{@link PhotoNoList}
@@ -53,6 +65,16 @@ public record PhotoNoList(List<PhotoNo> photoNoList) implements Iterable<PhotoNo
 	 */
 	public Boolean isEmpty() {
 		return photoNoList.isEmpty();
+	}
+
+	/**
+	 * 指定インデックスの要素を取得する
+	 *
+	 * @param	index	インデックス
+	 * @return			{@link PhotoNo}
+	 */
+	public PhotoNo get(int index) {
+		return photoNoList.get(index);
 	}
 
 	/**

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
@@ -137,8 +137,6 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	 */
 	@Override
 	public PhotoNoList getPhotoNosByAccountNo(AccountNo accountNo) {
-		return PhotoNoList.of(photoMstMapper.getPhotoNosByAccountNo(accountNo.value()).stream()
-				.map(PhotoNo::new)
-				.toList());
+		return PhotoNoList.from(photoMstMapper.getPhotoNosByAccountNo(accountNo.value()));
 	}
 }


### PR DESCRIPTION
# 概要

## 背景

コードレビュー（`WebGallery_backend_code_review_fable_20260825.md` 項番3）にて、`.claude/rules/model.md` の規約で必須とされているコレクションラッパークラス（`XxxModelList` 系）の `get(int)` アクセサと `from()` ファクトリメソッドが `PhotoNoList` に実装されていない指摘があった。兄弟クラスである `PhotoModelList` は規約通り全メソッドを実装しており、`PhotoNoList` のみが規約から外れていた。

## 変更内容

- `PhotoNoList` に `get(int)` アクセサと、写真番号の`Long`リストから生成する `from()` ファクトリメソッドを追加
- `PhotoMstRepositoryImpl#getPhotoNosByAccountNo` を、追加した `from()` を使う実装に簡潔化


# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `./backend/gradlew -p backend bootRun --args='--spring.profiles.active=local'` で backend の起動が成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認


# 懸念事項

Model層のコレクションラッパークラスの規約準拠のみを目的とした修正であり、機能的な振る舞いの変更はない。
