### PR TITLE
refactor: AccountServiceインターフェースを新設しAccountServiceImplへの直接依存を解消

### DIFF
--- a/backend/src/main/java/com/web/gallery/controller/AccountRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/AccountRestController.java
@@ -32,7 +32,7 @@ import com.web.gallery.exception.GalleryException;
 import com.web.gallery.exception.RegistFailureException;
 import com.web.gallery.helper.SessionHelper;
 import com.web.gallery.model.AccountModel;
-import com.web.gallery.service.impl.AccountServiceImpl;
+import com.web.gallery.service.AccountService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -53,7 +53,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Tag(name = "アカウント", description = "アカウント管理に関するAPI")
 public class AccountRestController {
-	private final AccountServiceImpl accountServiceImpl;
+	private final AccountService accountService;
 	private final SessionHelper sessionHelper;
 	
 	/**
@@ -65,7 +65,7 @@ public class AccountRestController {
 	@ApiResponse(responseCode = "200", description = "取得成功")
 	@GetMapping(ApiRoutes.API_ACCOUNTS)
 	public ResponseEntity<List<AccountListItemResponse>> getAccountList() {
-		List<AccountListItemResponse> responseList = accountServiceImpl.getAccountList().stream()
+		List<AccountListItemResponse> responseList = accountService.getAccountList().stream()
 				.map(AccountListItemResponse::from)
 				.toList();
 
@@ -91,7 +91,7 @@ public class AccountRestController {
 			throw ErrorEnum.NOT_AUTHORIZED_TO_EDIT_ACCOUNT.toException();
 		}
 
-		AccountModel accountModel = accountServiceImpl.getAccountById(new AccountId(accountId));
+		AccountModel accountModel = accountService.getAccountById(new AccountId(accountId));
 
 		AccountDetailResponse response = AccountDetailResponse.from(accountModel);
 
@@ -127,7 +127,7 @@ public class AccountRestController {
 		
 		AccountModel accountModel = AccountModel.from(accountRegistRequest);
 		
-		Boolean isSuccess = accountServiceImpl.registAccount(accountModel);
+		Boolean isSuccess = accountService.registAccount(accountModel);
 		return ResponseEntity.ok(AccountRegistResponse.of(isSuccess, Consts.STRING_EMPTY));
 	}
 	
@@ -174,7 +174,7 @@ public class AccountRestController {
 		
 		AccountModel accountModel = AccountModel.from(accountUpdateRequest, sessionHelper.getAccountNo());
 		
-		Boolean isDuplicateAccountId = accountServiceImpl.updateAccount(accountModel);
+		Boolean isDuplicateAccountId = accountService.updateAccount(accountModel);
 		
 		return ResponseEntity.ok(AccountUpdateResponse.of(
 					isDuplicateAccountId,
@@ -202,7 +202,7 @@ public class AccountRestController {
 			throw ErrorEnum.NOT_AUTHORIZED_TO_EDIT_ACCOUNT.toException();
 		}
 
-		accountServiceImpl.deleteAccount(new AccountNo(sessionHelper.getAccountNo()), new AccountId(accountId));
+		accountService.deleteAccount(new AccountNo(sessionHelper.getAccountNo()), new AccountId(accountId));
 
 		return ResponseEntity.ok().build();
 	}

--- a/backend/src/main/java/com/web/gallery/controller/AdminAccountRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/AdminAccountRestController.java
@@ -15,7 +15,7 @@ import com.web.gallery.controller.response.AdminAccountListItemResponse;
 import com.web.gallery.controller.response.AdminAccountLockResponse;
 import com.web.gallery.domain.account.AccountNo;
 import com.web.gallery.exception.GalleryException;
-import com.web.gallery.service.impl.AccountServiceImpl;
+import com.web.gallery.service.AccountService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -32,7 +32,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "管理者アカウント管理", description = "管理者用アカウント管理に関するAPI")
 @SecurityRequirement(name = "Bearer")
 public class AdminAccountRestController {
-	private final AccountServiceImpl accountServiceImpl;
+	private final AccountService accountService;
 
 	/**
 	 * 管理者用アカウント一覧取得
@@ -48,7 +48,7 @@ public class AdminAccountRestController {
 	public ResponseEntity<List<AdminAccountListItemResponse>> getAdminAccountList()
 			throws GalleryException {
 
-		List<AdminAccountListItemResponse> responseList = accountServiceImpl.getAccountListForAdmin().stream()
+		List<AdminAccountListItemResponse> responseList = accountService.getAccountListForAdmin().stream()
 				.map(AdminAccountListItemResponse::from)
 				.toList();
 
@@ -72,7 +72,7 @@ public class AdminAccountRestController {
 	public ResponseEntity<AdminAccountLockResponse> unlockAccount(
 			@PathVariable Long accountNo) throws GalleryException {
 
-		accountServiceImpl.unlockAccount(new AccountNo(accountNo));
+		accountService.unlockAccount(new AccountNo(accountNo));
 
 		return ResponseEntity.ok(AdminAccountLockResponse.of(MessageConst.UNLOCK_ACCOUNT));
 	}
@@ -94,7 +94,7 @@ public class AdminAccountRestController {
 	public ResponseEntity<AdminAccountLockResponse> lockAccount(
 			@PathVariable Long accountNo) throws GalleryException {
 
-		accountServiceImpl.lockAccount(new AccountNo(accountNo));
+		accountService.lockAccount(new AccountNo(accountNo));
 
 		return ResponseEntity.ok(AdminAccountLockResponse.of(MessageConst.LOCK_ACCOUNT));
 	}

--- a/backend/src/main/java/com/web/gallery/service/AccountService.java
+++ b/backend/src/main/java/com/web/gallery/service/AccountService.java
@@ -1,0 +1,76 @@
+package com.web.gallery.service;
+
+import com.web.gallery.domain.account.AccountId;
+import com.web.gallery.domain.account.AccountNo;
+import com.web.gallery.exception.GalleryException;
+import com.web.gallery.model.AccountModel;
+import com.web.gallery.model.AccountModelList;
+
+/**
+ * アカウントに関するビジネスロジックを行うServiceクラス
+ */
+public interface AccountService {
+	/**
+	 * アカウントを新規登録する
+	 *
+	 * @param	accountModel		{@link AccountModel}
+	 * @return						登録に成功した場合、true
+	 * @throws	GalleryException	登録に失敗した場合
+	 */
+	Boolean registAccount(AccountModel accountModel) throws GalleryException;
+
+	/**
+	 * アカウントを更新する
+	 *
+	 * @param	accountModel		{@link AccountModel}
+	 * @return						更新に成功した場合、true
+	 * @throws	GalleryException	更新に失敗した場合
+	 */
+	Boolean updateAccount(AccountModel accountModel) throws GalleryException;
+
+	/**
+	 * アカウントIDからアカウント情報を取得する
+	 *
+	 * @param	accountId	アカウントID
+	 * @return				{@link AccountModel}
+	 */
+	AccountModel getAccountById(AccountId accountId);
+
+	/**
+	 * アカウントの一覧を取得する
+	 *
+	 * @return	{@link AccountModelList}
+	 */
+	AccountModelList getAccountList();
+
+	/**
+	 * 管理者用：削除済みを含む全アカウントの一覧を取得する
+	 *
+	 * @return	{@link AccountModelList}
+	 */
+	AccountModelList getAccountListForAdmin();
+
+	/**
+	 * 管理者用：アカウントのロックを解除する（ログイン失敗回数を0にリセット）
+	 *
+	 * @param	accountNo			アカウント番号
+	 * @throws	GalleryException	更新に失敗した場合
+	 */
+	void unlockAccount(AccountNo accountNo) throws GalleryException;
+
+	/**
+	 * 管理者用：アカウントを強制ロックする（ログイン失敗回数を上限超過に設定）
+	 *
+	 * @param	accountNo			アカウント番号
+	 * @throws	GalleryException	更新に失敗した場合
+	 */
+	void lockAccount(AccountNo accountNo) throws GalleryException;
+
+	/**
+	 * アカウントを削除する
+	 *
+	 * @param	accountNo	アカウント番号
+	 * @param	accountId	アカウントID
+	 */
+	void deleteAccount(AccountNo accountNo, AccountId accountId);
+}

--- a/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
@@ -37,6 +37,7 @@ import com.web.gallery.repository.PhotoFavoriteRepository;
 import com.web.gallery.repository.PhotoMstRepository;
 import com.web.gallery.repository.PhotoTagMstRepository;
 import com.web.gallery.repository.RefreshTokenRepository;
+import com.web.gallery.service.AccountService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,7 +48,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class AccountServiceImpl implements UserDetailsService {
+public class AccountServiceImpl implements UserDetailsService, AccountService {
 
 	private final AccountRepository accountRepository;
 	private final FileRepository fileRepository;
@@ -86,6 +87,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @return						登録に成功した場合、true
 	 * @throws	GalleryException	登録に失敗した場合
 	 */
+	@Override
 	@Transactional(rollbackFor = GalleryException.class)
 	public Boolean registAccount(AccountModel accountModel) throws GalleryException {
 		Boolean isExist = accountRepository.isExistAccount(accountModel.getAccountId());
@@ -103,6 +105,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @return						更新に成功した場合、true
 	 * @throws GalleryException	更新に失敗した場合
 	 */
+	@Override
 	@Transactional(rollbackFor = GalleryException.class)
 	public Boolean updateAccount(AccountModel accountModel) throws GalleryException {
 		Boolean isExist = accountRepository.isExistAccount(accountModel.getAccountNo(), accountModel.getAccountId());
@@ -119,6 +122,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @param	accountId	アカウントID
 	 * @return				{@link AccountModel}
 	 */
+	@Override
 	@Transactional(readOnly = true)
 	public AccountModel getAccountById(AccountId accountId) {
 		return accountRepository.getByAccountId(accountId);
@@ -129,6 +133,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 *
 	 * @return	{@link AccountModelList}
 	 */
+	@Override
 	@Transactional(readOnly = true)
 	public AccountModelList getAccountList() {
 		return accountRepository.getAccountList().sortByAccountId();
@@ -139,6 +144,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 *
 	 * @return	{@link AccountModelList}
 	 */
+	@Override
 	@Transactional(readOnly = true)
 	public AccountModelList getAccountListForAdmin() {
 		return accountRepository.getAccountListAll().sortByAccountId();
@@ -150,6 +156,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @param	accountNo			アカウント番号
 	 * @throws	GalleryException	更新に失敗した場合
 	 */
+	@Override
 	@Transactional(rollbackFor = GalleryException.class)
 	public void unlockAccount(AccountNo accountNo) throws GalleryException {
 		accountRepository.updateLoginFailureCount(AccountModel.forUnlock(accountNo.value()));
@@ -162,6 +169,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @param	accountNo			アカウント番号
 	 * @throws	GalleryException	更新に失敗した場合
 	 */
+	@Override
 	@Transactional(rollbackFor = GalleryException.class)
 	public void lockAccount(AccountNo accountNo) throws GalleryException {
 		accountRepository.updateLoginFailureCount(AccountModel.forLock(accountNo.value(), loginConfig.getFailCount()));
@@ -174,6 +182,7 @@ public class AccountServiceImpl implements UserDetailsService {
 	 * @param	accountNo	アカウント番号
 	 * @param	accountId	アカウントID
 	 */
+	@Override
 	@Transactional
 	public void deleteAccount(AccountNo accountNo, AccountId accountId) {
 		// 自分が登録したお気に入りを削除

--- a/backend/src/main/java/com/web/gallery/service/impl/AuthServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AuthServiceImpl.java
@@ -20,6 +20,7 @@ import org.springframework.security.authentication.LockedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,7 +48,7 @@ public class AuthServiceImpl implements AuthService {
 	private final JwtConfig jwtConfig;
 	private final RefreshTokenRepository refreshTokenRepository;
 	private final AccountRepository accountRepository;
-	private final AccountServiceImpl accountServiceImpl;
+	private final UserDetailsService userDetailsService;
 	private final Clock clock;
 
 	public AuthServiceImpl(
@@ -56,14 +57,14 @@ public class AuthServiceImpl implements AuthService {
 			JwtConfig jwtConfig,
 			RefreshTokenRepository refreshTokenRepository,
 			AccountRepository accountRepository,
-			@Lazy AccountServiceImpl accountServiceImpl,
+			@Lazy UserDetailsService userDetailsService,
 			Clock clock) {
 		this.authenticationManager = authenticationManager;
 		this.jwtTokenProvider = jwtTokenProvider;
 		this.jwtConfig = jwtConfig;
 		this.refreshTokenRepository = refreshTokenRepository;
 		this.accountRepository = accountRepository;
-		this.accountServiceImpl = accountServiceImpl;
+		this.userDetailsService = userDetailsService;
 		this.clock = clock;
 	}
 
@@ -126,7 +127,7 @@ public class AuthServiceImpl implements AuthService {
 		if (accountModel == null) {
 			throw new IllegalArgumentException("無効なリフレッシュトークンです");
 		}
-		UserDetails userDetails = accountServiceImpl.loadUserByUsername(accountModel.getAccountId().value());
+		UserDetails userDetails = userDetailsService.loadUserByUsername(accountModel.getAccountId().value());
 		AccountPrincipal principal = (AccountPrincipal) userDetails;
 
 		if (!principal.isAccountNonLocked()) {

--- a/backend/src/test/java/com/web/gallery/controller/AccountRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/AccountRestControllerTest.java
@@ -49,7 +49,7 @@ import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.helper.SessionHelper;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.model.AccountModelList;
-import com.web.gallery.service.impl.AccountServiceImpl;
+import com.web.gallery.service.AccountService;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
@@ -58,7 +58,7 @@ public class AccountRestControllerTest {
 	private AccountRestController accountRestController;
 
 	@Mock
-	private AccountServiceImpl accountServiceImpl;
+	private AccountService accountService;
 
 	@Mock
 	private SessionHelper sessionHelper;
@@ -96,7 +96,7 @@ public class AccountRestControllerTest {
 					AccountModel.builder().accountId(new AccountId("bbbbbbbb")).accountName(new AccountName("BBBBBBBB")).build()
 			));
 
-			doReturn(accountModels).when(accountServiceImpl).getAccountList();
+			doReturn(accountModels).when(accountService).getAccountList();
 
 			mockMvc.perform(get("/api/v1/accounts"))
 				.andExpect(status().isOk())
@@ -110,7 +110,7 @@ public class AccountRestControllerTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが0件の場合は空リストを返すこと")
 		void getAccountList_empty() throws Exception {
-			doReturn(AccountModelList.empty()).when(accountServiceImpl).getAccountList();
+			doReturn(AccountModelList.empty()).when(accountService).getAccountList();
 
 			mockMvc.perform(get("/api/v1/accounts"))
 				.andExpect(status().isOk())
@@ -142,7 +142,7 @@ public class AccountRestControllerTest {
 					.freeMemo(new FreeMemo("フリーメモ"))
 					.build();
 
-			doReturn(accountModel).when(accountServiceImpl).getAccountById(new AccountId(accountId));
+			doReturn(accountModel).when(accountService).getAccountById(new AccountId(accountId));
 
 			mockMvc.perform(get("/api/v1/accounts/" + accountId))
 				.andExpect(status().isOk())
@@ -174,7 +174,7 @@ public class AccountRestControllerTest {
 					.freeMemo(new FreeMemo(""))
 					.build();
 
-			doReturn(accountModel).when(accountServiceImpl).getAccountById(new AccountId(accountId));
+			doReturn(accountModel).when(accountService).getAccountById(new AccountId(accountId));
 
 			mockMvc.perform(get("/api/v1/accounts/" + accountId))
 				.andExpect(status().isOk())
@@ -196,7 +196,7 @@ public class AccountRestControllerTest {
 			mockMvc.perform(get("/api/v1/accounts/aaaaaaaa"))
 				.andExpect(status().isForbidden());
 
-			verify(accountServiceImpl, times(0)).getAccountById(any(AccountId.class));
+			verify(accountService, times(0)).getAccountById(any(AccountId.class));
 		}
 	}
 
@@ -209,7 +209,7 @@ public class AccountRestControllerTest {
 		@DisplayName("正常系")
 		void register_regist_success() throws Exception {
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
-			doReturn(true).when(accountServiceImpl).registAccount(accountModelCaptor.capture());
+			doReturn(true).when(accountService).registAccount(accountModelCaptor.capture());
 
 			mockMvc.perform(post("/api/v1/accounts")
 					.contentType(MediaType.APPLICATION_JSON)
@@ -239,7 +239,7 @@ public class AccountRestControllerTest {
 		@DisplayName("正常系：既に使われているアカウントIDの場合")
 		void register_exist_accountId() throws Exception {
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
-			doReturn(false).when(accountServiceImpl).registAccount(accountModelCaptor.capture());
+			doReturn(false).when(accountService).registAccount(accountModelCaptor.capture());
 
 			mockMvc.perform(post("/api/v1/accounts")
 					.contentType(MediaType.APPLICATION_JSON)
@@ -273,7 +273,7 @@ public class AccountRestControllerTest {
 					.content(readJsonFile("regist_badrequest_blank_accountid.json")))
 				.andExpect(status().isBadRequest());
 
-			verify(accountServiceImpl, times(0)).registAccount(any(AccountModel.class));
+			verify(accountService, times(0)).registAccount(any(AccountModel.class));
 		}
 
 		@Test
@@ -281,7 +281,7 @@ public class AccountRestControllerTest {
 		@DisplayName("異常系：RegistFailureExceptionをthrowする")
 		void account_setting_RegistFailureException() throws Exception {
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
-			doThrow(new RegistFailureException(ErrorEnum.FAIL_TO_REGIST_ACCOUNT)).when(accountServiceImpl).registAccount(accountModelCaptor.capture());
+			doThrow(new RegistFailureException(ErrorEnum.FAIL_TO_REGIST_ACCOUNT)).when(accountService).registAccount(accountModelCaptor.capture());
 
 			mockMvc.perform(post("/api/v1/accounts")
 					.contentType(MediaType.APPLICATION_JSON)
@@ -318,7 +318,7 @@ public class AccountRestControllerTest {
 			doReturn(accountId).when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
-			doReturn(false).when(accountServiceImpl).updateAccount(accountModelCaptor.capture());
+			doReturn(false).when(accountService).updateAccount(accountModelCaptor.capture());
 
 			mockMvc.perform(put("/api/v1/accounts/" + accountId)
 					.contentType(MediaType.APPLICATION_JSON)
@@ -355,7 +355,7 @@ public class AccountRestControllerTest {
 			doReturn("bbbbbbbb").when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
-			doReturn(false).when(accountServiceImpl).updateAccount(accountModelCaptor.capture());
+			doReturn(false).when(accountService).updateAccount(accountModelCaptor.capture());
 
 			mockMvc.perform(put("/api/v1/accounts/" + accountId)
 					.contentType(MediaType.APPLICATION_JSON)
@@ -384,7 +384,7 @@ public class AccountRestControllerTest {
 			doReturn(accountId).when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
-			doReturn(false).when(accountServiceImpl).updateAccount(accountModelCaptor.capture());
+			doReturn(false).when(accountService).updateAccount(accountModelCaptor.capture());
 
 			mockMvc.perform(put("/api/v1/accounts/" + accountId)
 					.contentType(MediaType.APPLICATION_JSON)
@@ -413,7 +413,7 @@ public class AccountRestControllerTest {
 			doReturn("bbbbbbbb").when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
-			doReturn(false).when(accountServiceImpl).updateAccount(accountModelCaptor.capture());
+			doReturn(false).when(accountService).updateAccount(accountModelCaptor.capture());
 
 			mockMvc.perform(put("/api/v1/accounts/" + accountId)
 					.contentType(MediaType.APPLICATION_JSON)
@@ -441,7 +441,7 @@ public class AccountRestControllerTest {
 			doReturn("bbbbbbbb").when(sessionHelper).getAccountId();
 
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
-			doReturn(true).when(accountServiceImpl).updateAccount(accountModelCaptor.capture());
+			doReturn(true).when(accountService).updateAccount(accountModelCaptor.capture());
 
 			mockMvc.perform(put("/api/v1/accounts/" + accountId)
 					.contentType(MediaType.APPLICATION_JSON)
@@ -469,7 +469,7 @@ public class AccountRestControllerTest {
 				.andExpect(status().isBadRequest());
 
 			verify(sessionHelper, times(0)).getAccountNo();
-			verify(accountServiceImpl, times(0)).updateAccount(any(AccountModel.class));
+			verify(accountService, times(0)).updateAccount(any(AccountModel.class));
 		}
 
 		@Test
@@ -482,7 +482,7 @@ public class AccountRestControllerTest {
 				.andExpect(status().isBadRequest());
 
 			verify(sessionHelper, times(0)).getAccountNo();
-			verify(accountServiceImpl, times(0)).updateAccount(any(AccountModel.class));
+			verify(accountService, times(0)).updateAccount(any(AccountModel.class));
 		}
 
 		@Test
@@ -495,7 +495,7 @@ public class AccountRestControllerTest {
 				.andExpect(status().isBadRequest());
 
 			verify(sessionHelper, times(0)).getAccountNo();
-			verify(accountServiceImpl, times(0)).updateAccount(any(AccountModel.class));
+			verify(accountService, times(0)).updateAccount(any(AccountModel.class));
 		}
 
 		@Test
@@ -507,7 +507,7 @@ public class AccountRestControllerTest {
 			doReturn(1L).when(sessionHelper).getAccountNo();
 
 			ArgumentCaptor<AccountModel> accountModelCaptor = ArgumentCaptor.forClass(AccountModel.class);
-			doThrow(UpdateFailureException.class).when(accountServiceImpl).updateAccount(accountModelCaptor.capture());
+			doThrow(UpdateFailureException.class).when(accountService).updateAccount(accountModelCaptor.capture());
 
 			mockMvc.perform(put("/api/v1/accounts/" + accountId)
 					.contentType(MediaType.APPLICATION_JSON)
@@ -534,12 +534,12 @@ public class AccountRestControllerTest {
 
 			doReturn(accountId).when(sessionHelper).getAccountId();
 			doReturn(1L).when(sessionHelper).getAccountNo();
-			doNothing().when(accountServiceImpl).deleteAccount(new AccountNo(1L), new AccountId(accountId));
+			doNothing().when(accountService).deleteAccount(new AccountNo(1L), new AccountId(accountId));
 
 			mockMvc.perform(delete("/api/v1/accounts/" + accountId))
 				.andExpect(status().isOk());
 
-			verify(accountServiceImpl, times(1)).deleteAccount(new AccountNo(1L), new AccountId(accountId));
+			verify(accountService, times(1)).deleteAccount(new AccountNo(1L), new AccountId(accountId));
 		}
 
 		@Test
@@ -551,7 +551,7 @@ public class AccountRestControllerTest {
 			mockMvc.perform(delete("/api/v1/accounts/aaaaaaaa"))
 				.andExpect(status().isForbidden());
 
-			verify(accountServiceImpl, times(0)).deleteAccount(any(AccountNo.class), any(AccountId.class));
+			verify(accountService, times(0)).deleteAccount(any(AccountNo.class), any(AccountId.class));
 		}
 	}
 

--- a/backend/src/test/java/com/web/gallery/controller/AdminAccountRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/AdminAccountRestControllerTest.java
@@ -36,7 +36,7 @@ import com.web.gallery.enumeration.AuthorityEnum;
 import com.web.gallery.exception.UpdateFailureException;
 import com.web.gallery.model.AccountModel;
 import com.web.gallery.model.AccountModelList;
-import com.web.gallery.service.impl.AccountServiceImpl;
+import com.web.gallery.service.AccountService;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
@@ -45,7 +45,7 @@ public class AdminAccountRestControllerTest {
 	private AdminAccountRestController adminAccountRestController;
 
 	@Mock
-	private AccountServiceImpl accountServiceImpl;
+	private AccountService accountService;
 
 	private MockMvc mockMvc;
 
@@ -90,7 +90,7 @@ public class AdminAccountRestControllerTest {
 							.build()
 			));
 
-			doReturn(accountModels).when(accountServiceImpl).getAccountListForAdmin();
+			doReturn(accountModels).when(accountService).getAccountListForAdmin();
 
 			mockMvc.perform(get("/api/v1/admin/accounts"))
 				.andExpect(status().isOk())
@@ -110,7 +110,7 @@ public class AdminAccountRestControllerTest {
 		@Order(2)
 		@DisplayName("正常系：アカウントが0件の場合は空リストを返すこと")
 		void getAdminAccountList_empty() throws Exception {
-			doReturn(AccountModelList.empty()).when(accountServiceImpl).getAccountListForAdmin();
+			doReturn(AccountModelList.empty()).when(accountService).getAccountListForAdmin();
 
 			mockMvc.perform(get("/api/v1/admin/accounts"))
 				.andExpect(status().isOk())
@@ -127,7 +127,7 @@ public class AdminAccountRestControllerTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントのロックを解除できること")
 		void unlockAccount_success() throws Exception {
-			doNothing().when(accountServiceImpl).unlockAccount(new AccountNo(1L));
+			doNothing().when(accountService).unlockAccount(new AccountNo(1L));
 
 			mockMvc.perform(put("/api/v1/admin/accounts/1/unlock"))
 				.andExpect(status().isOk())
@@ -135,14 +135,14 @@ public class AdminAccountRestControllerTest {
 				.andExpect(jsonPath("$.isSuccess").value(true))
 				.andExpect(jsonPath("$.message").value(MessageConst.UNLOCK_ACCOUNT));
 
-			verify(accountServiceImpl, times(1)).unlockAccount(new AccountNo(1L));
+			verify(accountService, times(1)).unlockAccount(new AccountNo(1L));
 		}
 
 		@Test
 		@Order(2)
 		@DisplayName("異常系：UpdateFailureExceptionが発生した場合は409を返すこと")
 		void unlockAccount_updateFailure() throws Exception {
-			doThrow(UpdateFailureException.class).when(accountServiceImpl).unlockAccount(new AccountNo(999L));
+			doThrow(UpdateFailureException.class).when(accountService).unlockAccount(new AccountNo(999L));
 
 			mockMvc.perform(put("/api/v1/admin/accounts/999/unlock"))
 				.andExpect(status().isConflict());
@@ -157,7 +157,7 @@ public class AdminAccountRestControllerTest {
 		@Order(1)
 		@DisplayName("正常系：アカウントを強制ロックできること")
 		void lockAccount_success() throws Exception {
-			doNothing().when(accountServiceImpl).lockAccount(new AccountNo(1L));
+			doNothing().when(accountService).lockAccount(new AccountNo(1L));
 
 			mockMvc.perform(put("/api/v1/admin/accounts/1/lock"))
 				.andExpect(status().isOk())
@@ -165,14 +165,14 @@ public class AdminAccountRestControllerTest {
 				.andExpect(jsonPath("$.isSuccess").value(true))
 				.andExpect(jsonPath("$.message").value(MessageConst.LOCK_ACCOUNT));
 
-			verify(accountServiceImpl, times(1)).lockAccount(new AccountNo(1L));
+			verify(accountService, times(1)).lockAccount(new AccountNo(1L));
 		}
 
 		@Test
 		@Order(2)
 		@DisplayName("異常系：UpdateFailureExceptionが発生した場合は409を返すこと")
 		void lockAccount_updateFailure() throws Exception {
-			doThrow(UpdateFailureException.class).when(accountServiceImpl).lockAccount(new AccountNo(999L));
+			doThrow(UpdateFailureException.class).when(accountService).lockAccount(new AccountNo(999L));
 
 			mockMvc.perform(put("/api/v1/admin/accounts/999/lock"))
 				.andExpect(status().isConflict());

--- a/backend/src/test/java/com/web/gallery/service/impl/AuthServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AuthServiceImplTest.java
@@ -25,6 +25,7 @@ import org.springframework.security.authentication.LockedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetailsService;
 
 import com.web.gallery.AccountPrincipal;
 import com.web.gallery.config.JwtConfig;
@@ -65,7 +66,7 @@ class AuthServiceImplTest {
 	private AccountRepository accountRepository;
 
 	@Mock
-	private AccountServiceImpl accountServiceImpl;
+	private UserDetailsService userDetailsService;
 
 	@Mock
 	private Clock clock;
@@ -161,7 +162,7 @@ class AuthServiceImplTest {
 			AccountPrincipal principal = mock(AccountPrincipal.class);
 			when(principal.isAccountNonLocked()).thenReturn(true);
 			when(principal.isEnabled()).thenReturn(true);
-			when(accountServiceImpl.loadUserByUsername("testuser1")).thenReturn(principal);
+			when(userDetailsService.loadUserByUsername("testuser1")).thenReturn(principal);
 			when(jwtTokenProvider.generateAccessToken(principal)).thenReturn("new-access-token");
 			when(jwtConfig.getAccessTokenExpirationMinutes()).thenReturn(15);
 
@@ -193,7 +194,7 @@ class AuthServiceImplTest {
 
 			AccountPrincipal principal = mock(AccountPrincipal.class);
 			when(principal.isAccountNonLocked()).thenReturn(false);
-			when(accountServiceImpl.loadUserByUsername("testuser1")).thenReturn(principal);
+			when(userDetailsService.loadUserByUsername("testuser1")).thenReturn(principal);
 
 			assertThrows(LockedException.class, () -> {
 				authServiceImpl.refresh(new RefreshTokenValue(refreshToken));
@@ -222,7 +223,7 @@ class AuthServiceImplTest {
 			AccountPrincipal principal = mock(AccountPrincipal.class);
 			when(principal.isAccountNonLocked()).thenReturn(true);
 			when(principal.isEnabled()).thenReturn(false);
-			when(accountServiceImpl.loadUserByUsername("testuser1")).thenReturn(principal);
+			when(userDetailsService.loadUserByUsername("testuser1")).thenReturn(principal);
 
 			assertThrows(IllegalArgumentException.class, () -> {
 				authServiceImpl.refresh(new RefreshTokenValue(refreshToken));

--- a/backend/src/test/java/com/web/gallery/service/impl/integration/AuthServiceImplIntegrationTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/integration/AuthServiceImplIntegrationTest.java
@@ -32,7 +32,7 @@ import com.web.gallery.domain.common.TokenHash;
 import com.web.gallery.model.AuthTokenModel;
 import com.web.gallery.model.RefreshTokenModel;
 import com.web.gallery.repository.RefreshTokenRepository;
-import com.web.gallery.service.impl.AccountServiceImpl;
+import com.web.gallery.service.AccountService;
 import com.web.gallery.service.impl.AuthServiceImpl;
 
 @ActiveProfiles("test")
@@ -43,7 +43,7 @@ public class AuthServiceImplIntegrationTest {
 	private AuthServiceImpl authServiceImpl;
 
 	@Autowired
-	private AccountServiceImpl accountServiceImpl;
+	private AccountService accountServiceImpl;
 
 	@Autowired
 	private RefreshTokenRepository refreshTokenRepository;


### PR DESCRIPTION
# 概要

## 背景

コードレビューにて、`service/`配下には`KbnMstService`・`AuthService`・`PhotoFavoriteService`・`PhotoService`のインターフェースが存在する一方、`AccountServiceImpl`のみ対応するインターフェースがなく、`Controller`層・`Service`層が具象クラスに直接依存している状態が指摘された。

- `AccountRestController` / `AdminAccountRestController` が `AccountServiceImpl` に直接依存
- `AuthServiceImpl`（Service実装）も `@Lazy AccountServiceImpl` を直接注入しており、Service実装同士が密結合になっていた

これは `.claude/rules/service.md` の「インターフェースベース設計」、`.claude/rules/controller.md` の「レイヤー間依存関係」に反する。

## 変更内容

- `service/AccountService.java` を新設し、`AccountServiceImpl` の全publicビジネスメソッド（`registAccount` / `updateAccount` / `getAccountById` / `getAccountList` / `getAccountListForAdmin` / `unlockAccount` / `lockAccount` / `deleteAccount`）を定義
- `AccountServiceImpl` が `UserDetailsService` に加えて `AccountService` を実装するよう変更し、各メソッドに `@Override` を付与
- `AccountRestController` / `AdminAccountRestController` のフィールド型を `AccountServiceImpl` → `AccountService`（インターフェース）に変更
- `AuthServiceImpl` は `loadUserByUsername` のみを利用していたため、`AccountServiceImpl` への直接依存をやめ、Spring Security標準の `UserDetailsService` インターフェースに依存するよう変更（Service実装同士の密結合を解消）
- 上記変更に追随して、対応するユニットテスト・統合テストのモック/フィールド型も変更

## 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `./backend/gradlew -p backend bootRun --args='--spring.profiles.active=local'` で backend の起動が成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認

上記に加え、`backend-architecture-checker`エージェントにより `.claude/rules/service.md`・`.claude/rules/controller.md`・`.claude/rules/unit-test.md`・`.claude/rules/integration-test.md` への準拠を確認済み（違反なし）。

# 懸念事項

- APIの外部仕様・振る舞いに変更はない（純粋なリファクタリング）
- `config/JwtAuthenticationFilter.java` も現状 `AccountServiceImpl`（具象クラス）に直接依存し `loadUserByUsername` のみを利用しているが、レビュー指摘の対象外のため本PRでは変更していない。同様の理由で `UserDetailsService` 型に変更する余地があるため、別途対応を検討したい。