### PR TITLE
fix: アカウント削除時の写真物理削除にTOCTOUギャップがある不具合を修正

### DIFF
--- a/backend/src/main/java/com/web/gallery/dto/PhotoDeletionDto.java
+++ b/backend/src/main/java/com/web/gallery/dto/PhotoDeletionDto.java
@@ -1,0 +1,15 @@
+package com.web.gallery.dto;
+
+import lombok.Data;
+
+/**
+ * 写真マスタ物理削除結果を保持するDtoクラス
+ */
+@Data
+public class PhotoDeletionDto {
+	/** 写真番号 */
+	private Long photoNo;
+
+	/** 物理削除前の論理削除フラグ */
+	private Boolean isDeleted;
+}

--- a/backend/src/main/java/com/web/gallery/entity/PhotoMstCondition.java
+++ b/backend/src/main/java/com/web/gallery/entity/PhotoMstCondition.java
@@ -110,16 +110,4 @@ public class PhotoMstCondition {
 				.isDeleted(new IsDeleted(false))
 				.build();
 	}
-
-	/**
-	 * アカウント番号による抽出条件を生成する
-	 *
-	 * @param	accountNo	アカウント番号
-	 * @return				{@link PhotoMstCondition}
-	 */
-	public static PhotoMstCondition byAccountNo(AccountNo accountNo) {
-		return PhotoMstCondition.builder()
-				.accountNo(accountNo)
-				.build();
-	}
 }

--- a/backend/src/main/java/com/web/gallery/mapper/PhotoMstMapper.java
+++ b/backend/src/main/java/com/web/gallery/mapper/PhotoMstMapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import com.web.gallery.dto.PhotoDeletionDto;
 import com.web.gallery.entity.PhotoMst;
 import com.web.gallery.entity.PhotoMstCondition;
 import com.web.gallery.entity.PhotoMstUpdateTarget;
@@ -56,18 +57,10 @@ public interface PhotoMstMapper {
 	public Boolean isExistPhoto(PhotoMstCondition condition);
 
 	/**
-	 * 写真マスタを物理削除する
-	 *
-	 * @param	condition	削除対象の抽出条件
-	 * @return				削除件数
-	 */
-	public Integer delete(PhotoMstCondition condition);
-
-	/**
-	 * アカウント番号に紐づく未削除の写真番号の一覧を取得する
+	 * アカウント番号に紐づく写真マスタを物理削除し、削除した行を返す
 	 *
 	 * @param	accountNo	アカウント番号
-	 * @return				写真番号のリスト
+	 * @return				削除した{@link PhotoDeletionDto}のリスト
 	 */
-	public List<Long> getPhotoNosByAccountNo(Long accountNo);
+	public List<PhotoDeletionDto> deletePhotosByAccountNo(Long accountNo);
 }

--- a/backend/src/main/java/com/web/gallery/repository/PhotoMstRepository.java
+++ b/backend/src/main/java/com/web/gallery/repository/PhotoMstRepository.java
@@ -63,17 +63,10 @@ public interface PhotoMstRepository {
 	Integer count(AccountNo accountNo);
 
 	/**
-	 * アカウント番号で写真マスタを物理削除する
-	 *
-	 * @param	accountNo	アカウント番号
-	 */
-	void deleteByAccountNo(AccountNo accountNo);
-
-	/**
-	 * アカウント番号に紐づく未削除の写真番号の一覧を取得する
+	 * アカウント番号に紐づく写真マスタを物理削除し、削除時点で未削除だった写真番号一覧を返す
 	 *
 	 * @param	accountNo	アカウント番号
 	 * @return				{@link PhotoNoList}
 	 */
-	PhotoNoList getPhotoNosByAccountNo(AccountNo accountNo);
+	PhotoNoList deleteAndGetUndeletedPhotoNosByAccountNo(AccountNo accountNo);
 }

--- a/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
+++ b/backend/src/main/java/com/web/gallery/repository/impl/PhotoMstRepositoryImpl.java
@@ -120,25 +120,16 @@ public class PhotoMstRepositoryImpl implements PhotoMstRepository {
 	}
 
 	/**
-	 * アカウント番号で写真マスタを物理削除する
-	 *
-	 * @param	accountNo	アカウント番号
-	 */
-	@Override
-	public void deleteByAccountNo(AccountNo accountNo) {
-		photoMstMapper.delete(PhotoMstCondition.byAccountNo(accountNo));
-	}
-
-	/**
-	 * アカウント番号に紐づく未削除の写真番号の一覧を取得する
+	 * アカウント番号に紐づく写真マスタを物理削除し、削除時点で未削除だった写真番号一覧を返す
 	 *
 	 * @param	accountNo	アカウント番号
 	 * @return				{@link PhotoNoList}
 	 */
 	@Override
-	public PhotoNoList getPhotoNosByAccountNo(AccountNo accountNo) {
-		return PhotoNoList.of(photoMstMapper.getPhotoNosByAccountNo(accountNo.value()).stream()
-				.map(PhotoNo::new)
+	public PhotoNoList deleteAndGetUndeletedPhotoNosByAccountNo(AccountNo accountNo) {
+		return PhotoNoList.of(photoMstMapper.deletePhotosByAccountNo(accountNo.value()).stream()
+				.filter(dto -> !dto.getIsDeleted())
+				.map(dto -> new PhotoNo(dto.getPhotoNo()))
 				.toList());
 	}
 }

--- a/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
+++ b/backend/src/main/java/com/web/gallery/service/impl/AccountServiceImpl.java
@@ -185,12 +185,10 @@ public class AccountServiceImpl implements UserDetailsService {
 		// 写真タグを削除
 		photoTagMstRepository.deleteByAccountNo(accountNo);
 
-		// 削除対象の写真番号を退避（物理削除後にイベント発行するため）
-		// 既に論理削除済みの写真でイベントが重複発行されないよう、未削除の写真のみを対象とする
-		PhotoNoList deletedPhotoNoList = photoMstRepository.getPhotoNosByAccountNo(accountNo);
-
-		// 写真マスタを物理削除
-		photoMstRepository.deleteByAccountNo(accountNo);
+		// 写真マスタを物理削除し、削除時点で未削除だった写真番号を取得
+		// SELECTとDELETEの間のTOCTOUギャップを無くすため単一SQLでアトミックに実施し、
+		// 既に論理削除済みだった写真はイベントの重複発行を避けるため対象から除外する
+		PhotoNoList deletedPhotoNoList = photoMstRepository.deleteAndGetUndeletedPhotoNosByAccountNo(accountNo);
 
 		// リフレッシュトークンを失効
 		refreshTokenRepository.revokeAllByAccountNo(accountNo);

--- a/backend/src/main/resources/com/web/gallery/mapper/PhotoMstMapper.xml
+++ b/backend/src/main/resources/com/web/gallery/mapper/PhotoMstMapper.xml
@@ -148,22 +148,18 @@
 		AND is_deleted = false
 	</select>
 
-	<delete id="delete" parameterType="com.web.gallery.entity.PhotoMstCondition">
-		DELETE FROM
-			photo.photo_mst
-		<where>
-			<if test="accountNo != null"> AND account_no = #{accountNo, typeHandler=com.web.gallery.type_handler.AccountNoTypeHandler}</if>
-			<if test="photoNo != null"> AND photo_no = #{photoNo, typeHandler=com.web.gallery.type_handler.PhotoNoTypeHandler}</if>
-		</where>
-	</delete>
+	<resultMap id="PhotoDeletionDtoResultMap" type="com.web.gallery.dto.PhotoDeletionDto">
+		<result column="photoNo" property="photoNo"/>
+		<result column="isDeleted" property="isDeleted"/>
+	</resultMap>
 
-	<select id="getPhotoNosByAccountNo" parameterType="Long" resultType="Long">
-		SELECT
-			photo_no AS photoNo
-		FROM
+	<select id="deletePhotosByAccountNo" parameterType="Long" resultMap="PhotoDeletionDtoResultMap">
+		DELETE FROM
 			photo.photo_mst
 		WHERE
 			account_no = #{accountNo}
-			AND is_deleted = false
+		RETURNING
+			photo_no AS photoNo,
+			is_deleted AS isDeleted
 	</select>
 </mapper>

--- a/backend/src/test/java/com/web/gallery/mapper/PhotoMstMapperTest.java
+++ b/backend/src/test/java/com/web/gallery/mapper/PhotoMstMapperTest.java
@@ -38,6 +38,7 @@ import com.web.gallery.domain.photo.PhotoEnglishTitle;
 import com.web.gallery.domain.photo.PhotoJapaneseTitle;
 import com.web.gallery.domain.photo.PhotoNo;
 import com.web.gallery.domain.photo.ShutterSpeed;
+import com.web.gallery.dto.PhotoDeletionDto;
 import com.web.gallery.entity.PhotoMst;
 import com.web.gallery.entity.PhotoMstCondition;
 import com.web.gallery.entity.PhotoMstUpdateTarget;
@@ -847,66 +848,6 @@ public class PhotoMstMapperTest {
 	}
 	
 	@Nested
-	@Order(4)
-	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-	@Sql("/sql/common/cleanup.sql")
-	@Sql("/sql/mapper/PhotoMstMapperTest.sql")
-	class delete {
-		@Test
-		@Order(1)
-		@DisplayName("正常系：アカウント番号でのdeleteで複数件削除される場合")
-		void delete_by_accountNo() {
-			PhotoMstCondition photoMst = PhotoMstCondition.builder().accountNo(new AccountNo(1L)).build();
-			Integer actual = photoMstMapper.delete(photoMst);
-			assertEquals(3, actual);
-
-			Integer remainCount = jdbcTemplate.queryForObject(
-					"SELECT COUNT(*) FROM photo.photo_mst WHERE account_no=1", Integer.class);
-			assertEquals(0, remainCount);
-
-			// 他のアカウントの写真は残っていること
-			Integer otherCount = jdbcTemplate.queryForObject(
-					"SELECT COUNT(*) FROM photo.photo_mst WHERE account_no=2", Integer.class);
-			assertEquals(3, otherCount);
-		}
-
-		@Test
-		@Order(2)
-		@DisplayName("正常系：写真番号でのdeleteで複数件削除される場合")
-		void delete_by_photoNo() {
-			PhotoMstCondition photoMst = PhotoMstCondition.builder().photoNo(new PhotoNo(1L)).build();
-			Integer actual = photoMstMapper.delete(photoMst);
-			assertEquals(2, actual);
-
-			Integer remainCount = jdbcTemplate.queryForObject(
-					"SELECT COUNT(*) FROM photo.photo_mst WHERE photo_no=1", Integer.class);
-			assertEquals(0, remainCount);
-		}
-
-		@Test
-		@Order(3)
-		@DisplayName("正常系：アカウント番号と写真番号でのdeleteで1件削除される場合")
-		void delete_by_accountNo_and_photoNo() {
-			PhotoMstCondition photoMst = PhotoMstCondition.builder().accountNo(new AccountNo(1L)).photoNo(new PhotoNo(1L)).build();
-			Integer actual = photoMstMapper.delete(photoMst);
-			assertEquals(1, actual);
-
-			Integer remainCount = jdbcTemplate.queryForObject(
-					"SELECT COUNT(*) FROM photo.photo_mst WHERE account_no=1", Integer.class);
-			assertEquals(2, remainCount);
-		}
-
-		@Test
-		@Order(4)
-		@DisplayName("正常系：該当するレコードがない場合は0件")
-		void delete_not_found() {
-			PhotoMstCondition photoMst = PhotoMstCondition.builder().accountNo(new AccountNo(100L)).build();
-			Integer actual = photoMstMapper.delete(photoMst);
-			assertEquals(0, actual);
-		}
-	}
-
-	@Nested
 	@Order(5)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	@Sql("/sql/common/cleanup.sql")
@@ -985,29 +926,37 @@ public class PhotoMstMapperTest {
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	@Sql("/sql/common/cleanup.sql")
 	@Sql("/sql/mapper/PhotoMstMapperTest.sql")
-	class getPhotoNosByAccountNo {
+	class deletePhotosByAccountNo {
 		@Test
 		@Order(1)
-		@DisplayName("正常系：アカウント番号に該当する未削除の写真がある場合")
-		void getPhotoNosByAccountNo_found() {
-			List<Long> actual = photoMstMapper.getPhotoNosByAccountNo(1L);
-			assertEquals(List.of(1L), actual.stream().sorted().toList());
+		@DisplayName("正常系：アカウント番号に該当する写真を物理削除し、削除した行を返す")
+		void deletePhotosByAccountNo_found() {
+			List<PhotoDeletionDto> actual = photoMstMapper.deletePhotosByAccountNo(1L);
+
+			assertEquals(3, actual.size());
+			List<PhotoDeletionDto> sorted = actual.stream().sorted((a, b) -> Long.compare(a.getPhotoNo(), b.getPhotoNo())).toList();
+			assertEquals(1L, sorted.get(0).getPhotoNo());
+			assertFalse(sorted.get(0).getIsDeleted());
+			assertEquals(2L, sorted.get(1).getPhotoNo());
+			assertTrue(sorted.get(1).getIsDeleted());
+			assertEquals(3L, sorted.get(2).getPhotoNo());
+			assertTrue(sorted.get(2).getIsDeleted());
+
+			Integer remainCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM photo.photo_mst WHERE account_no=1", Integer.class);
+			assertEquals(0, remainCount);
+
+			// 他のアカウントの写真は残っていること
+			Integer otherCount = jdbcTemplate.queryForObject(
+					"SELECT COUNT(*) FROM photo.photo_mst WHERE account_no=2", Integer.class);
+			assertEquals(3, otherCount);
 		}
 
 		@Test
 		@Order(2)
-		@DisplayName("正常系：論理削除済みの写真は取得対象から除外される")
-		void getPhotoNosByAccountNo_excludes_deleted() {
-			List<Long> actual = photoMstMapper.getPhotoNosByAccountNo(1L);
-			assertFalse(actual.contains(2L));
-			assertFalse(actual.contains(3L));
-		}
-
-		@Test
-		@Order(3)
 		@DisplayName("正常系：アカウント番号に該当する写真がない場合")
-		void getPhotoNosByAccountNo_not_found() {
-			List<Long> actual = photoMstMapper.getPhotoNosByAccountNo(100L);
+		void deletePhotosByAccountNo_not_found() {
+			List<PhotoDeletionDto> actual = photoMstMapper.deletePhotosByAccountNo(100L);
 			assertTrue(actual.isEmpty());
 		}
 	}

--- a/backend/src/test/java/com/web/gallery/repository/impl/PhotoMstRepositoryImplTest.java
+++ b/backend/src/test/java/com/web/gallery/repository/impl/PhotoMstRepositoryImplTest.java
@@ -42,6 +42,7 @@ import com.web.gallery.domain.photo.FocalLength;
 import com.web.gallery.domain.photo.FValue;
 import com.web.gallery.domain.photo.ShutterSpeed;
 import com.web.gallery.domain.photo.Iso;
+import com.web.gallery.dto.PhotoDeletionDto;
 import com.web.gallery.entity.PhotoMst;
 import com.web.gallery.entity.PhotoMstCondition;
 import com.web.gallery.entity.PhotoMstUpdateTarget;
@@ -580,45 +581,33 @@ public class PhotoMstRepositoryImplTest {
 	@Nested
 	@Order(7)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-	class deleteByAccountNo {
+	class deleteAndGetUndeletedPhotoNosByAccountNo {
 		@Test
 		@Order(1)
-		@DisplayName("正常系：アカウント番号で写真マスタを物理削除する")
-		void deleteByAccountNo_success() {
-			ArgumentCaptor<PhotoMstCondition> photoMstCaptor = ArgumentCaptor.forClass(PhotoMstCondition.class);
-			doReturn(1).when(photoMstMapper).delete(photoMstCaptor.capture());
+		@DisplayName("正常系：物理削除した写真のうち、未削除だった写真番号の一覧を取得する")
+		void deleteAndGetUndeletedPhotoNosByAccountNo_found() {
+			PhotoDeletionDto undeleted = new PhotoDeletionDto();
+			undeleted.setPhotoNo(1L);
+			undeleted.setIsDeleted(false);
 
-			photoMstRepositoryImpl.deleteByAccountNo(new AccountNo(1L));
+			PhotoDeletionDto alreadyDeleted = new PhotoDeletionDto();
+			alreadyDeleted.setPhotoNo(2L);
+			alreadyDeleted.setIsDeleted(true);
 
-			verify(photoMstMapper).delete(any(PhotoMstCondition.class));
-			PhotoMstCondition photoMst = photoMstCaptor.getValue();
-			assertEquals(new AccountNo(1L), photoMst.getAccountNo());
-			assertNull(photoMst.getPhotoNo());
-		}
-	}
+			doReturn(List.of(undeleted, alreadyDeleted)).when(photoMstMapper).deletePhotosByAccountNo(1L);
 
-	@Nested
-	@Order(8)
-	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-	class getPhotoNosByAccountNo {
-		@Test
-		@Order(1)
-		@DisplayName("正常系：アカウント番号に紐づく写真番号の一覧を取得する")
-		void getPhotoNosByAccountNo_found() {
-			doReturn(List.of(1L, 2L, 3L)).when(photoMstMapper).getPhotoNosByAccountNo(1L);
+			PhotoNoList actual = photoMstRepositoryImpl.deleteAndGetUndeletedPhotoNosByAccountNo(new AccountNo(1L));
 
-			PhotoNoList actual = photoMstRepositoryImpl.getPhotoNosByAccountNo(new AccountNo(1L));
-
-			assertEquals(List.of(new PhotoNo(1L), new PhotoNo(2L), new PhotoNo(3L)), actual.toList());
+			assertEquals(List.of(new PhotoNo(1L)), actual.toList());
 		}
 
 		@Test
 		@Order(2)
 		@DisplayName("正常系：アカウント番号に紐づく写真がない場合")
-		void getPhotoNosByAccountNo_not_found() {
-			doReturn(List.of()).when(photoMstMapper).getPhotoNosByAccountNo(1L);
+		void deleteAndGetUndeletedPhotoNosByAccountNo_not_found() {
+			doReturn(List.of()).when(photoMstMapper).deletePhotosByAccountNo(1L);
 
-			PhotoNoList actual = photoMstRepositoryImpl.getPhotoNosByAccountNo(new AccountNo(1L));
+			PhotoNoList actual = photoMstRepositoryImpl.deleteAndGetUndeletedPhotoNosByAccountNo(new AccountNo(1L));
 
 			assertTrue(actual.isEmpty());
 		}

--- a/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
+++ b/backend/src/test/java/com/web/gallery/service/impl/AccountServiceImplTest.java
@@ -424,8 +424,7 @@ public class AccountServiceImplTest {
 			doNothing().when(photoFavoriteRepository).deleteByFavoritePhotoAccountNo(any(AccountNo.class));
 			doNothing().when(photoTagMstRepository).deleteByAccountNo(any(AccountNo.class));
 			doReturn(PhotoNoList.of(List.of(new PhotoNo(1L), new PhotoNo(2L))))
-					.when(photoMstRepository).getPhotoNosByAccountNo(any(AccountNo.class));
-			doNothing().when(photoMstRepository).deleteByAccountNo(any(AccountNo.class));
+					.when(photoMstRepository).deleteAndGetUndeletedPhotoNosByAccountNo(any(AccountNo.class));
 			doNothing().when(refreshTokenRepository).revokeAllByAccountNo(any(AccountNo.class));
 			doNothing().when(accountRepositoryImpl).delete(new AccountNo(accountNo));
 			doReturn("/output/").when(photoConfig).getOutputPath();
@@ -442,8 +441,7 @@ public class AccountServiceImplTest {
 			assertEquals(new AccountNo(accountNo), favoritePhotoCaptor.getValue());
 
 			verify(photoTagMstRepository, times(1)).deleteByAccountNo(new AccountNo(accountNo));
-			verify(photoMstRepository, times(1)).getPhotoNosByAccountNo(new AccountNo(accountNo));
-			verify(photoMstRepository, times(1)).deleteByAccountNo(new AccountNo(accountNo));
+			verify(photoMstRepository, times(1)).deleteAndGetUndeletedPhotoNosByAccountNo(new AccountNo(accountNo));
 			verify(refreshTokenRepository, times(1)).revokeAllByAccountNo(new AccountNo(accountNo));
 			verify(accountRepositoryImpl, times(1)).delete(new AccountNo(accountNo));
 			verify(fileRepository, times(1)).delete(new ImageFilePath("/output/" + accountId + "/"));


### PR DESCRIPTION
# 概要

## 背景

コードレビュー（`/code-review` high）で以下の問題が指摘された。

`AccountServiceImpl.deleteAccount` は単一の `@Transactional` メソッド内で実行されるが、PostgreSQLの READ COMMITTED 分離レベルでは各SQL文ごとに独立したスナップショットが取得される。そのため、削除対象の写真番号一覧をSELECTで退避してから物理削除のDELETEを実行するまでの間に、別リクエスト（進行中のアップロード処理など）が同一アカウントに `savePhotos` を呼び出すと、新規INSERTされた写真が退避済みリストには含まれないまま物理削除され、`PhotoDeletedEvent` がサイレントに発行されなくなる（TOCTOUギャップ）。これは直近マージされたPR #124（写真ドメインイベントの発行漏れ・欠落リスクを解消）が対象としていたバグと同種の問題。

## 変更内容

- `PhotoMstMapper` / `PhotoMstMapper.xml` に `deletePhotosByAccountNo` を追加し、`DELETE ... RETURNING` で「削除対象の特定」と「物理削除」を1つのSQL文にまとめてアトミック化。削除された行の元の `is_deleted` フラグも同時に取得できるようにした
- 上記に伴い、`PhotoMstRepository` の `getPhotoNosByAccountNo` と `deleteByAccountNo` を `deleteAndGetUndeletedPhotoNosByAccountNo` に統合。削除された写真のうち、削除前に既に論理削除済みだったものはイベント発行対象から除外する
- `AccountServiceImpl.deleteAccount` を新メソッド呼び出しに変更
- 統合により不要になった `PhotoMstMapper.delete(PhotoMstCondition)`（汎用の条件付き物理削除、本PR時点で呼び出し元がなくなったもの）と `PhotoMstCondition.byAccountNo()` を削除
- 対応するユニットテスト・統合テストを更新

# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `./backend/gradlew -p backend bootRun --args='--spring.profiles.active=local'` で backend の起動が成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認

# 懸念事項

- backend側のみの修正でfrontendへの影響はない
- `PhotoMstMapper.delete(PhotoMstCondition)` は本PRの統合により呼び出し元がなくなったため削除した。汎用的な条件付き物理削除メソッドのため、将来的に別用途で必要になった場合は改めて実装してほしい