### PR TITLE
fix: PhotoListRequestにバリデーションアノテーションを追加

### DIFF
--- a/backend/src/main/java/com/web/gallery/controller/PhotoRestController.java
+++ b/backend/src/main/java/com/web/gallery/controller/PhotoRestController.java
@@ -74,14 +74,27 @@ public class PhotoRestController {
 	 * 
 	 * @param	photoAccountId		ページ所有者のアカウントID
 	 * @param	photoListRequest	{@link PhotoListRequest}
+	 * @param	result				バリデーション結果
 	 * @return						{@link PhotoListGetResponse}
+	 * @throws	GalleryException	リクエストパラメータが不正な場合
 	 */
 	@Operation(summary = "写真一覧取得", description = "抽出条件に該当する写真を、指定の並び順で取得する")
 	@ApiResponse(responseCode = "200", description = "取得成功")
+	@ApiResponse(responseCode = "400", description = "リクエストパラメータ不正", content = @Content)
 	@GetMapping(ApiRoutes.API_PHOTOS)
 	public ResponseEntity<PhotoListGetResponse> getPhotoList(
 			@PathVariable String photoAccountId,
-			@ModelAttribute @Validated PhotoListRequest photoListRequest) {
+			@ModelAttribute @Validated PhotoListRequest photoListRequest,
+			BindingResult result) throws GalleryException {
+
+		if(result.hasErrors()) {
+			for(FieldError error : result.getFieldErrors()) {
+				log.info("Invalid input. (Field: {}, Value: {}, Message: {})",
+						error.getField(), error.getRejectedValue(), error.getDefaultMessage());
+			}
+			throw ErrorEnum.INVALID_INPUT.toException();
+		}
+
 		// 抽出条件に該当する写真の一覧を、指定の並び順で取得する
 		PhotoModelList photoList = photoService.getPhotoList(
 				PhotoListGetModel.from(photoListRequest, sessionHelper.getAccountNo(), photoAccountId));

--- a/backend/src/main/java/com/web/gallery/controller/request/PhotoListRequest.java
+++ b/backend/src/main/java/com/web/gallery/controller/request/PhotoListRequest.java
@@ -6,6 +6,8 @@ import com.web.gallery.enumeration.DirectionEnum;
 import com.web.gallery.enumeration.SortPhotoEnum;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Data;
 
 /**
@@ -21,11 +23,13 @@ public class PhotoListRequest {
 	 */
 	@Schema(description = "向き区分（未選択/縦/横/正方形）")
 	@JsonSetter(nulls = Nulls.SKIP)
+	@NotNull(message = "{validation.common.notBlank}")
 	private DirectionEnum directionKbn = DirectionEnum.NONE;
 
 	/** お気に入り写真のみ */
 	@Schema(description = "お気に入り写真のみ表示するか", example = "false")
 	@JsonSetter(nulls = Nulls.SKIP)
+	@NotNull(message = "{validation.common.notBlank}")
 	private Boolean isFavorite = Boolean.FALSE;
 
 	/** タグリスト */
@@ -39,10 +43,13 @@ public class PhotoListRequest {
 	 */
 	@Schema(description = "並び順（photoAt: 撮影日順, favorite: お気に入り数順, season: 季節順）")
 	@JsonSetter(nulls = Nulls.SKIP)
+	@NotNull(message = "{validation.common.notBlank}")
 	private SortPhotoEnum sortBy = SortPhotoEnum.PHOTO_AT;
 
 	/** ページ番号 */
 	@Schema(description = "ページ番号", example = "1")
 	@JsonSetter(nulls = Nulls.SKIP)
+	@NotNull(message = "{validation.common.notBlank}")
+	@Positive(message = "{validation.common.positive}")
 	private Integer pageNo = 1;
 }

--- a/backend/src/test/java/com/web/gallery/controller/PhotoRestControllerTest.java
+++ b/backend/src/test/java/com/web/gallery/controller/PhotoRestControllerTest.java
@@ -324,6 +324,17 @@ public class PhotoRestControllerTest {
 			assertEquals(new ArrayList<String>(), photoListGetModel.getTagList());
 			assertEquals(SortPhotoEnum.PHOTO_AT, photoListGetModel.getSortBy());
 		}
+
+		@Test
+		@Order(5)
+		@DisplayName("異常系：ページ番号が0以下。BadRequestExceptionをthrowする")
+		void getPhotoList_BadRequestException_pageNo_not_positive() throws Exception {
+			mockMvc.perform(get("/api/v1/accounts/aaaaaaaa/photos")
+					.param("pageNo", "0"))
+				.andExpect(status().isBadRequest());
+
+			verify(photoServiceImpl, times(0)).getPhotoList(any(PhotoListGetModel.class));
+		}
 	}
 
 	@Nested


### PR DESCRIPTION
# 概要

## 背景

コードレビュー（`WebGallery_backend_code_review_20260825.md` No.8）にて、実際に使用されている`PhotoListRequest`にバリデーションアノテーションが一つも付与されていないことが指摘された。加えて`PhotoRestController.getPhotoList()`は`@Validated`を付けているが`BindingResult`を受け取っておらず、将来バリデーションを追加すると`BindException`が未捕捉になり標準エラー形式が崩れる懸念があった。

## 変更内容

- `PhotoListRequest`の`directionKbn`/`isFavorite`/`sortBy`/`pageNo`に`@NotNull`（`pageNo`は`@Positive`も追加）のバリデーションアノテーションを付与
- `PhotoRestController.getPhotoList()`に`BindingResult`引数を追加し、`savePhoto()`等の既存メソッドと同様にバリデーションエラー時は`ErrorEnum.INVALID_INPUT`をthrowするよう修正
- `pageNo`に0以下の値を指定した場合に400エラーとなることを確認する単体テストを追加

# 検証事項

- [x] `./backend/gradlew -p backend build` でbackendのビルドが成功することを確認
- [x] `./backend/gradlew -p backend test` で単体テストが成功することを確認
- [x] `./backend/gradlew -p backend integrationTest` で結合テストが成功することを確認
- [x] `./backend/gradlew -p backend bootRun --args='--spring.profiles.active=local'` で backend の起動が成功することを確認
- [x] `just dev` で frontend の起動が成功することを確認
- [x] `just e2e` でE2Eテストが成功することを確認

# 懸念事項

`@ModelAttribute`によるクエリパラメータバインディングのため、型変換自体が失敗するケース（例: `pageNo=abc`）はバリデーションアノテーションではなく`BindingResult`内のTypeMismatchエラーとして捕捉される。今回`BindingResult`チェックを追加したことでこのケースも`INVALID_INPUT`として扱われるようになる。